### PR TITLE
Added image URLs to the package metadata schema.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ _Sample package directory layout._
   "maintainer": "help@bar.io",
   "description": "Does baz.",
   "website": "http://bar.io/foo",
+  "images": {
+    "icon-small": "http://some.org/foo/small.png",
+    "icon-medium": "http://some.org/foo/medium.png",
+    "icon-large": "http://some.org/foo/large.png",
+    "screenshots": [
+      "http://some.org/foo/screen-1.png",
+      "http://some.org/foo/screen-2.png"
+    ]
+  },
   "dependencies": [
     { "name": "biz", "version": "1.2.+" }
   ],
@@ -45,6 +54,13 @@ _Sample package directory layout._
 }
 ```
 _Sample `package.json`._
+
+The required fields are:
+
+- name
+- version
+- maintainer
+- description
 
 #### `config.json`
 

--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -20,11 +20,33 @@
     "description": {
       "type": "string"
     },
+    "images": {
+      "type": "object",
+      "properties": {
+        "icon-small": {
+          "type": "string",
+          "description": "PNG icon URL, preferably 48 by 48 pixels."
+        },
+        "icon-small": {
+          "type": "string",
+          "description": "PNG icon URL, preferably 128 by 128 pixels."
+        },
+        "icon-small": {
+          "type": "string",
+          "description": "PNG icon URL, preferably 256 by 256 pixels."
+        },
+        "screenshots": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "PNG screen URL, preferably 1024 by 1024 pixels."
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "postInstallNotes": {
       "type": "string"
-    },
-    "dataSchema": {
-      "type": "object"
     },
     "dependencies": {
       "type": "array",
@@ -48,7 +70,6 @@
   "required": [
     "name",
     "version",
-    "scm",
     "maintainer",
     "description"
   ]


### PR DESCRIPTION
- Updated sample package.json in the README.
- scm is no longer required in package metadata.
- Added required package.json fields to README.
- Fixes #16.

cc @ashenden 