### PR TITLE
Fix the Marathon schema for labels

### DIFF
--- a/repo/meta/schema/marathon-schema.json
+++ b/repo/meta/schema/marathon-schema.json
@@ -203,7 +203,7 @@
     },
     "labels": {
       "type": "object",
-      "properties": {
+      "additionalProperties": {
         "type": "string"
       }
     }


### PR DESCRIPTION
To alloy any property that maps to a string we need to use
`additionalProperties`. See
http://spacetelescope.github.io/understanding-json-schema/reference/object.html#properties