### PR TITLE
Check for unstaged changes in pre-commit.

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -9,3 +9,5 @@ SCRIPTS_DIR=$UNIVERSE_DIR/scripts
 
 $SCRIPTS_DIR/build.sh
 
+# Fail if there are unstaged changes
+git diff --exit-code


### PR DESCRIPTION
Fixes #41 

This will cause CI to fail for PRs that don't update the index properly.