### PR TITLE
Fix schema to allow icon-medium and icon-large

### DIFF
--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -27,11 +27,11 @@
           "type": "string",
           "description": "PNG icon URL, preferably 48 by 48 pixels."
         },
-        "icon-small": {
+        "icon-medium": {
           "type": "string",
           "description": "PNG icon URL, preferably 128 by 128 pixels."
         },
-        "icon-small": {
+        "icon-large": {
           "type": "string",
           "description": "PNG icon URL, preferably 256 by 256 pixels."
         },


### PR DESCRIPTION
There was a bug in the package schema preventing the declaration of `icon-medium` and `icon-large`.