### PR TITLE
Fix python image name/tag for helloworld.

### DIFF
--- a/repo/packages/H/helloworld/0/marathon.json
+++ b/repo/packages/H/helloworld/0/marathon.json
@@ -7,7 +7,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "python/3.4.3",
+      "image": "python:3",
       "network": "HOST"
     }
   }


### PR DESCRIPTION
Needed to change the '/' to a ':' to use the tag properly.
Also switched to just `:3` so we automatically get the latest 3.x.y
@jsancio PTAL