### PR TITLE
Cassandra cleanup

### DIFF
--- a/repo/packages/C/cassandra/0/config.json
+++ b/repo/packages/C/cassandra/0/config.json
@@ -54,9 +54,17 @@
                   "description": "The path to the Mesos secret file containing the authentication secret.",
                   "type": "string"
                 }
-              }
+              },
+              "required": [
+                "enabled"
+              ]
             }
-          }
+          },
+          "required": [
+            "failover-timeout-seconds",
+            "role",
+            "authentication"
+          ]
         },
         "cluster-name": {
           "description": "The name of the framework to register with mesos. Will also be used as the cluster name in Cassandra",
@@ -130,9 +138,30 @@
               "type": "integer",
               "minimum": 0
             }
-          }
+          },
+          "required": [
+            "cpus",
+            "mem",
+            "disk"
+          ]
         }
-      }
+      },
+      "required": [
+        "framework",
+        "cluster-name",
+        "zk-timeout-ms",
+        "node-count",
+        "seed-count",
+        "health-check-interval-seconds",
+        "bootstrap-grace-time-seconds",
+        "data-directory",
+        "resources"
+      ]
     }
-  }
+  },
+  "required": [
+    "mesos",
+    "cassandra"
+  ]
+
 }

--- a/repo/packages/C/cassandra/0/marathon.json
+++ b/repo/packages/C/cassandra/0/marathon.json
@@ -31,6 +31,9 @@
       "timeoutSeconds": 5
     }
   ],
+  "labels": {
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "cassandra.{{cassandra.cluster-name}}"
+  },
   "env": {
     "MESOS_ZK": "{{mesos.master}}"
     ,"JAVA_OPTS": "-Xms256m -Xmx256m"


### PR DESCRIPTION
1. Update config.json to define all required fields.
1. Update marathon.json to manually define `DCOS_PACKAGE_FRAMEWORK_NAME` following framework naming convention in cassandra.

Tested install on DCOS Cluster.