### PR TITLE
kafka_dcos_compat_changes

### DIFF
--- a/repo/packages/K/kafka/0/config.json
+++ b/repo/packages/K/kafka/0/config.json
@@ -68,6 +68,12 @@
                     "default": "*"
                 },
 
+                "user": {
+                    "type": "string",
+                    "description": "Mesos user to run tasks",
+                    "default": ""
+                },
+
                 "other-options": {
                     "type": "string",
                     "description": "Other Scheduler options if required",

--- a/repo/packages/K/kafka/0/config.json
+++ b/repo/packages/K/kafka/0/config.json
@@ -73,6 +73,16 @@
                     "description": "Mesos user to run tasks",
                     "default": ""
                 },
+                "principal": {
+                    "type": "string",
+                    "description": "Mesos principal (username)",
+                    "default": ""
+                },
+                "secret": {
+                    "type": "string",
+                    "description": "Mesos secret (password)",
+                    "default": ""
+                },
 
                 "other-options": {
                     "type": "string",

--- a/repo/packages/K/kafka/0/config.json
+++ b/repo/packages/K/kafka/0/config.json
@@ -56,6 +56,13 @@
                     "description": "See --jre option",
                     "default": "jre-7-openjdk.zip"
                 },
+
+                "framework-name": {
+                    "type": "string",
+                    "description": "Mesos Framework Name",
+                    "default": "kafka"
+                },
+
                 "other-options": {
                     "type": "string",
                     "description": "Other Scheduler options if required",

--- a/repo/packages/K/kafka/0/config.json
+++ b/repo/packages/K/kafka/0/config.json
@@ -23,17 +23,17 @@
                 "jre": {
                     "type": "string",
                     "description": "JRE zip URL",
-                    "default": "https://s3-us-west-2.amazonaws.com/kafka-mesos/jre-7-openjdk.zip"
+                    "default": "https://d1vubr0evspla.cloudfront.net/jre-7-openjdk.zip"
                 },
                 "kafka": {
                     "type": "string",
                     "description": "Kafka distro URL",
-                    "default": "https://s3-us-west-2.amazonaws.com/kafka-mesos/kafka_2.10-0.8.2.1.tgz"
+                    "default": "https://d1vubr0evspla.cloudfront.net/kafka_2.10-0.8.2.1.tgz"
                 },
                 "jar": {
                     "type": "string",
                     "description": "kafka-mesos*.jar URL",
-                    "default": "https://s3-us-west-2.amazonaws.com/kafka-mesos/kafka-mesos-0.9.0-beta.jar"
+                    "default": "https://d1vubr0evspla.cloudfront.net/kafka-mesos-0.9.0-beta.jar"
                 },
 
                 "zk": {

--- a/repo/packages/K/kafka/0/config.json
+++ b/repo/packages/K/kafka/0/config.json
@@ -13,27 +13,49 @@
             },
             "required": ["master"]
         },
-
         "kafka": {
-            "description": "Kafka Framework Configuration Properties",
+            "description": "Kafka framework configuration properties",
             "type": "object",
             "additionalProperties": false,
 
             "properties": {
-                "jre": {
-                    "type": "string",
-                    "description": "JRE zip URL",
-                    "default": "https://d1vubr0evspla.cloudfront.net/jre-7-openjdk.zip"
-                },
-                "kafka": {
-                    "type": "string",
-                    "description": "Kafka distro URL",
-                    "default": "https://d1vubr0evspla.cloudfront.net/kafka_2.10-0.8.2.1.tgz"
-                },
-                "jar": {
-                    "type": "string",
-                    "description": "kafka-mesos*.jar URL",
-                    "default": "https://d1vubr0evspla.cloudfront.net/kafka-mesos-0.9.0-beta.jar"
+                "app": {
+                    "description": "Marathon app configuration properties",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "id": {
+                            "description": "app id",
+                            "type": "string",
+                            "default": "kafka"
+                        },
+                        "cpus": {
+                            "description": "cpu requirements",
+                            "type": "number",
+                            "default": 0.5
+                        },
+                        "mem": {
+                            "description": "mem requirements",
+                            "type": "integer",
+                            "default": 256
+                        },
+                        "jre": {
+                            "type": "string",
+                            "description": "JRE distro URL",
+                            "default": "https://d1vubr0evspla.cloudfront.net/jre-7-openjdk.zip"
+                        },
+                        "kafka": {
+                            "type": "string",
+                            "description": "Kafka distro URL",
+                            "default": "https://d1vubr0evspla.cloudfront.net/kafka_2.10-0.8.2.1.tgz"
+                        },
+                        "jar": {
+                            "type": "string",
+                            "description": "kafka-mesos*.jar URL",
+                            "default": "https://d1vubr0evspla.cloudfront.net/kafka-mesos-0.9.0-beta.jar"
+                        }
+                    },
+                    "required": ["id", "cpus", "mem", "jre", "kafka", "jar"]
                 },
 
                 "zk": {
@@ -51,7 +73,7 @@
                     "description": "State storage path. See --storage option",
                     "default": "zk:/kafka-mesos"
                 },
-                "jre-file": {
+                "jre": {
                     "type": "string",
                     "description": "See --jre option",
                     "default": "jre-7-openjdk.zip"
@@ -91,8 +113,8 @@
                 }
             },
             "required": [
-                "jre", "kafka", "jar",
-                "zk", "api", "storage", "jre-file",
+                "app",
+                "zk", "api", "storage", "jre",
                 "framework-name", "framework-role",
                 "user", "principal", "secret",
                 "other-options"

--- a/repo/packages/K/kafka/0/config.json
+++ b/repo/packages/K/kafka/0/config.json
@@ -62,6 +62,11 @@
                     "description": "Mesos Framework Name",
                     "default": "kafka"
                 },
+                "framework-role": {
+                    "type": "string",
+                    "description": "Mesos Framework Role",
+                    "default": "*"
+                },
 
                 "other-options": {
                     "type": "string",

--- a/repo/packages/K/kafka/0/config.json
+++ b/repo/packages/K/kafka/0/config.json
@@ -92,7 +92,10 @@
             },
             "required": [
                 "jre", "kafka", "jar",
-                "zk", "api", "storage", "jre-file", "other-options"
+                "zk", "api", "storage", "jre-file",
+                "framework-name", "framework-role",
+                "user", "principal", "secret",
+                "other-options"
             ]
         }
     }

--- a/repo/packages/K/kafka/0/config.json
+++ b/repo/packages/K/kafka/0/config.json
@@ -1,50 +1,71 @@
 {
     "type": "object",
     "properties": {
-        "kafka/jre": {
-            "type": "string",
-            "description": "JRE zip",
-            "default": "https://s3-us-west-2.amazonaws.com/kafka-mesos/jre-7-openjdk.zip"
+        "mesos": {
+            "description": "Mesos specific configuration properties",
+            "type": "object",
+            "properties": {
+                "master": {
+                    "default": "zk://master.mesos:2181/mesos",
+                    "description": "The URL of the Mesos master. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard host:port patterns, like localhost:5050 or 10.0.0.5:5050,10.0.0.6:5050, are also acceptable.",
+                    "type": "string"
+                }
+            },
+            "required": ["master"]
         },
-        "kafka/kafka": {
-            "type": "string",
-            "description": "Kafka distro",
-            "default": "https://s3-us-west-2.amazonaws.com/kafka-mesos/kafka_2.10-0.8.2.1.tgz"
-        },
-        "kafka/jar": {
-            "type": "string",
-            "description": "Kafka-Mesos jar",
-            "default": "https://s3-us-west-2.amazonaws.com/kafka-mesos/kafka-mesos-0.9.0-beta.jar"
-        },
-        "kafka/master": {
-            "type": "string",
-            "description": "--master option",
-            "default": "zk://master.mesos:2181/mesos"
-        },
-        "kafka/zk": {
-            "type": "string",
-            "description": "--zk option",
-            "default": "master.mesos:2181"
-        },
-        "kafka/api": {
-            "type": "string",
-            "description": "--api option",
-            "default": "http://$HOST:$PORT0"
-        },
-        "kafka/storage": {
-            "type": "string",
-            "description": "--storage option",
-            "default": "zk:/kafka-mesos"
-        },
-        "kafka/jre-file": {
-            "type": "string",
-            "description": "--jre option",
-            "default": "jre-7-openjdk.zip"
-        },
-        "kafka/otherOptions": {
-            "type": "string",
-            "description": "other options if required",
-            "default": ""
+
+        "kafka": {
+            "description": "Kafka Framework Configuration Properties",
+            "type": "object",
+            "additionalProperties": false,
+
+            "properties": {
+                "jre": {
+                    "type": "string",
+                    "description": "JRE zip URL",
+                    "default": "https://s3-us-west-2.amazonaws.com/kafka-mesos/jre-7-openjdk.zip"
+                },
+                "kafka": {
+                    "type": "string",
+                    "description": "Kafka distro URL",
+                    "default": "https://s3-us-west-2.amazonaws.com/kafka-mesos/kafka_2.10-0.8.2.1.tgz"
+                },
+                "jar": {
+                    "type": "string",
+                    "description": "kafka-mesos*.jar URL",
+                    "default": "https://s3-us-west-2.amazonaws.com/kafka-mesos/kafka-mesos-0.9.0-beta.jar"
+                },
+
+                "zk": {
+                    "type": "string",
+                    "description": "ZK URL for Kafka",
+                    "default": "master.mesos:2181"
+                },
+                "api": {
+                    "type": "string",
+                    "description": "Scheduler API URL to bind to",
+                    "default": "http://$HOST:$PORT0"
+                },
+                "storage": {
+                    "type": "string",
+                    "description": "State storage path. See --storage option",
+                    "default": "zk:/kafka-mesos"
+                },
+                "jre-file": {
+                    "type": "string",
+                    "description": "See --jre option",
+                    "default": "jre-7-openjdk.zip"
+                },
+                "other-options": {
+                    "type": "string",
+                    "description": "Other Scheduler options if required",
+                    "default": ""
+                }
+            },
+            "required": [
+                "jre", "kafka", "jar",
+                "zk", "api", "storage", "jre-file", "other-options"
+            ]
         }
     }
 }

--- a/repo/packages/K/kafka/0/marathon.json
+++ b/repo/packages/K/kafka/0/marathon.json
@@ -14,6 +14,15 @@
       "intervalSeconds": 60,
       "portIndex": 0,
       "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 3
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/api/status",
+      "gracePeriodSeconds": 120,
+      "intervalSeconds": 60,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
       "maxConsecutiveFailures": 0
     }
   ]

--- a/repo/packages/K/kafka/0/marathon.json
+++ b/repo/packages/K/kafka/0/marathon.json
@@ -3,7 +3,7 @@
   "cpus": 0.5,
   "mem": 256,
   "instances": 1,
-  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage={{kafka.storage}} --jre={{kafka.jre-file}} --framework-name={{kafka.framework-name}} {{kafka.other-options}}",
+  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage={{kafka.storage}} --jre={{kafka.jre-file}} --framework-name={{kafka.framework-name}} --framework-role={{kafka.framework-role}} {{kafka.other-options}}",
   "uris": ["{{kafka.jre}}", "{{kafka.kafka}}", "{{kafka.jar}}"],
   "ports": [0],
   "healthChecks": [

--- a/repo/packages/K/kafka/0/marathon.json
+++ b/repo/packages/K/kafka/0/marathon.json
@@ -3,7 +3,7 @@
   "cpus": 0.5,
   "mem": 256,
   "instances": 1,
-  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage={{kafka.storage}} --jre={{kafka.jre-file}} --user \"{{kafka.user}}\" --framework-name={{kafka.framework-name}} --framework-role={{kafka.framework-role}} {{kafka.other-options}}",
+  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage=\"{{kafka.storage}}\" --jre={{kafka.jre-file}} {{#kafka.user}}--user=\"{{kafka.user}}\"{{/kafka.user}} --framework-name=\"{{kafka.framework-name}}\" --framework-role=\"{{kafka.framework-role}}\" {{#kafka.principal}}--principal=\"{{kafka.principal}}\"{{/kafka.principal}} {{#kafka.secret}}--secret=\"{{kafka.secret}}\"{{/kafka.secret}} {{kafka.other-options}}",
   "uris": ["{{kafka.jre}}", "{{kafka.kafka}}", "{{kafka.jar}}"],
   "ports": [0],
   "healthChecks": [

--- a/repo/packages/K/kafka/0/marathon.json
+++ b/repo/packages/K/kafka/0/marathon.json
@@ -3,8 +3,8 @@
   "cpus": 0.5,
   "mem": 256,
   "instances": 1,
-  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{kafka/master}} --zk={{kafka/zk}} --api={{kafka/api}} --storage={{kafka/storage}} --jre={{kafka/jre-file}} {{kafka/otherOptions}}",
-  "uris": ["{{kafka/jre}}", "{{kafka/kafka}}", "{{kafka/jar}}"],
+  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage={{kafka.storage}} --jre={{kafka.jre-file}} {{kafka.other-options}}",
+  "uris": ["{{kafka.jre}}", "{{kafka.kafka}}", "{{kafka.jar}}"],
   "ports": [0],
   "healthChecks": [
     {

--- a/repo/packages/K/kafka/0/marathon.json
+++ b/repo/packages/K/kafka/0/marathon.json
@@ -3,7 +3,7 @@
   "cpus": 0.5,
   "mem": 256,
   "instances": 1,
-  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage={{kafka.storage}} --jre={{kafka.jre-file}} {{kafka.other-options}}",
+  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage={{kafka.storage}} --jre={{kafka.jre-file}} --framework-name={{kafka.framework-name}} {{kafka.other-options}}",
   "uris": ["{{kafka.jre}}", "{{kafka.kafka}}", "{{kafka.jar}}"],
   "ports": [0],
   "healthChecks": [

--- a/repo/packages/K/kafka/0/marathon.json
+++ b/repo/packages/K/kafka/0/marathon.json
@@ -3,7 +3,7 @@
   "cpus": 0.5,
   "mem": 256,
   "instances": 1,
-  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage={{kafka.storage}} --jre={{kafka.jre-file}} --framework-name={{kafka.framework-name}} --framework-role={{kafka.framework-role}} {{kafka.other-options}}",
+  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage={{kafka.storage}} --jre={{kafka.jre-file}} --user \"{{kafka.user}}\" --framework-name={{kafka.framework-name}} --framework-role={{kafka.framework-role}} {{kafka.other-options}}",
   "uris": ["{{kafka.jre}}", "{{kafka.kafka}}", "{{kafka.jar}}"],
   "ports": [0],
   "healthChecks": [

--- a/repo/packages/K/kafka/0/marathon.json
+++ b/repo/packages/K/kafka/0/marathon.json
@@ -9,12 +9,12 @@
   "healthChecks": [
     {
       "protocol": "HTTP",
-      "path": "/api/brokers/status",
+      "path": "/health",
       "gracePeriodSeconds": 120,
       "intervalSeconds": 60,
       "portIndex": 0,
       "timeoutSeconds": 30,
-      "maxConsecutiveFailures": 3
+      "maxConsecutiveFailures": 0
     }
   ]
 }

--- a/repo/packages/K/kafka/0/marathon.json
+++ b/repo/packages/K/kafka/0/marathon.json
@@ -1,10 +1,10 @@
 {
-  "id": "kafka",
-  "cpus": 0.5,
-  "mem": 256,
+  "id": "{{kafka.app.id}}",
+  "cpus": {{kafka.app.cpus}},
+  "mem": {{kafka.app.mem}},
   "instances": 1,
-  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage=\"{{kafka.storage}}\" --jre={{kafka.jre-file}} {{#kafka.user}}--user=\"{{kafka.user}}\"{{/kafka.user}} --framework-name=\"{{kafka.framework-name}}\" --framework-role=\"{{kafka.framework-role}}\" {{#kafka.principal}}--principal=\"{{kafka.principal}}\"{{/kafka.principal}} {{#kafka.secret}}--secret=\"{{kafka.secret}}\"{{/kafka.secret}} {{kafka.other-options}}",
-  "uris": ["{{kafka.jre}}", "{{kafka.kafka}}", "{{kafka.jar}}"],
+  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage=\"{{kafka.storage}}\" --jre={{kafka.jre}} {{#kafka.user}}--user=\"{{kafka.user}}\"{{/kafka.user}} --framework-name=\"{{kafka.framework-name}}\" --framework-role=\"{{kafka.framework-role}}\" {{#kafka.principal}}--principal=\"{{kafka.principal}}\"{{/kafka.principal}} {{#kafka.secret}}--secret=\"{{kafka.secret}}\"{{/kafka.secret}} {{kafka.other-options}}",
+  "uris": ["{{kafka.app.jre}}", "{{kafka.app.kafka}}", "{{kafka.app.jar}}"],
   "ports": [0],
   "healthChecks": [
     {

--- a/repo/packages/K/kafka/0/marathon.json
+++ b/repo/packages/K/kafka/0/marathon.json
@@ -3,7 +3,7 @@
   "cpus": {{kafka.app.cpus}},
   "mem": {{kafka.app.mem}},
   "instances": 1,
-  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage=\"{{kafka.storage}}\" --jre={{kafka.jre}} {{#kafka.user}}--user=\"{{kafka.user}}\"{{/kafka.user}} --framework-name=\"{{kafka.framework-name}}\" --framework-role=\"{{kafka.framework-role}}\" {{#kafka.principal}}--principal=\"{{kafka.principal}}\"{{/kafka.principal}} {{#kafka.secret}}--secret=\"{{kafka.secret}}\"{{/kafka.secret}} {{kafka.other-options}}",
+  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage=\"{{kafka.storage}}\" --jre={{kafka.jre}} {{#kafka.user}}--user=\"{{kafka.user}}\"{{/kafka.user}} --framework-name=\"{{kafka.framework-name}}\" --framework-role=\"{{kafka.framework-role}}\" {{#kafka.principal}}--principal=\"{{kafka.principal}}\"{{/kafka.principal}} {{#kafka.secret}}--secret=\"{{kafka.secret}}\"{{/kafka.secret}} --log=scheduler.log {{kafka.other-options}}",
   "uris": ["{{kafka.app.jre}}", "{{kafka.app.kafka}}", "{{kafka.app.jar}}"],
   "ports": [0],
   "healthChecks": [

--- a/repo/packages/K/kafka/0/package.json
+++ b/repo/packages/K/kafka/0/package.json
@@ -7,12 +7,12 @@
   "framework": true,
   "tags": ["mesosphere", "framework", "bigdata"],
   "images": {
-    "icon-small": "https://s3-us-west-2.amazonaws.com/kafka-mesos/icon-small.png",
-    "icon-medium": "https://s3-us-west-2.amazonaws.com/kafka-mesos/icon-medium.png",
-    "icon-large": "https://s3-us-west-2.amazonaws.com/kafka-mesos/icon-large.png",
+    "icon-small": "https://s3-us-west-2.amazonaws.com/kafka-mesos/img/icon-small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/kafka-mesos/img/icon-medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/kafka-mesos/img/icon-large.png",
     "screenshots": [
-        "https://s3-us-west-2.amazonaws.com/kafka-mesos/screen-0-kafka-cluster-overview.png",
-        "https://s3-us-west-2.amazonaws.com/kafka-mesos/screen-1-kafka-communication-scheme.png"
+        "https://s3-us-west-2.amazonaws.com/kafka-mesos/img/screen-0-kafka-cluster-overview.png",
+        "https://s3-us-west-2.amazonaws.com/kafka-mesos/img/screen-1-kafka-communication-scheme.png"
     ]
   },
   "postInstallNotes": "Kafka DCOS Service is installed"

--- a/repo/packages/K/kafka/0/package.json
+++ b/repo/packages/K/kafka/0/package.json
@@ -15,5 +15,5 @@
         "https://s3-us-west-2.amazonaws.com/kafka-mesos/img/screen-1-kafka-communication-scheme.png"
     ]
   },
-  "postInstallNotes": "Kafka DCOS Service is installed"
+  "postInstallNotes": "Kafka DCOS Service is installed:\n  docs   - https://github.com/mesos/kafka\n  issues - https://github.com/mesos/kafka/issues"
 }

--- a/repo/packages/K/kafka/0/package.json
+++ b/repo/packages/K/kafka/0/package.json
@@ -7,13 +7,10 @@
   "framework": true,
   "tags": ["mesosphere", "framework", "bigdata"],
   "images": {
-    "icon-small": "https://s3-us-west-2.amazonaws.com/kafka-mesos/img/icon-small.png",
-    "icon-medium": "https://s3-us-west-2.amazonaws.com/kafka-mesos/img/icon-medium.png",
-    "icon-large": "https://s3-us-west-2.amazonaws.com/kafka-mesos/img/icon-large.png",
-    "screenshots": [
-        "https://s3-us-west-2.amazonaws.com/kafka-mesos/img/screen-0-kafka-cluster-overview.png",
-        "https://s3-us-west-2.amazonaws.com/kafka-mesos/img/screen-1-kafka-communication-scheme.png"
-    ]
+    "icon-small": "https://d1vubr0evspla.cloudfront.net/img/icon-small.png",
+    "icon-medium": "https://d1vubr0evspla.cloudfront.net/img/icon-medium.png",
+    "icon-large": "https://d1vubr0evspla.cloudfront.net/img/icon-large.png",
+    "screenshots": ["https://d1vubr0evspla.cloudfront.net/img/screen-0-kafka.png"]
   },
   "postInstallNotes": "Kafka DCOS Service is installed:\n  docs   - https://github.com/mesos/kafka\n  issues - https://github.com/mesos/kafka/issues"
 }


### PR DESCRIPTION
Hi,
I've just implemented following changes. Please merge.

The Items that are critical to get done are:
1. Health Checks
  1. Add health check for scheduler process that is independent from cluster health
  2. Set maxConsecutiveFailures to 0 for cluster healthcheck

2. Framework name
  1. Add config parameter to config.json in universe
  2. Reference config parameter from config.json in marathon.json

3. Universe config.json
  1. Switch to using the hierarchical definition format used for namespacing
  2. Define all properties listed as required regardless of a default value being provided
    1. Replace kafka/master with mesos.master

  3. Set `additionalProperties` to false for kafka properties object

4. Support setting the role on FrameworkInfo at registration

5. Support setting the user on FrameworkInfo at registration

6. Support framework authentication

7. Update `postInstallNotes` in package.json to include a link to framework documentation/cli documentation

8. Update `postInstallNotes` in package.json to include a link to where issues can be reported