### PR TITLE
kafka-mesos / fixed health check url

### DIFF
--- a/repo/packages/K/kafka/0/marathon.json
+++ b/repo/packages/K/kafka/0/marathon.json
@@ -18,7 +18,7 @@
     },
     {
       "protocol": "HTTP",
-      "path": "/api/status",
+      "path": "/api/brokers/status",
       "gracePeriodSeconds": 120,
       "intervalSeconds": 60,
       "portIndex": 0,


### PR DESCRIPTION
Hey,

I've fixed cluster status health check url. Now both healthchecks for kafka-mesos should pass. 
Please merge.