### PR TITLE
fix memsql config schema

### DIFF
--- a/repo/packages/M/memsql/0/config.json
+++ b/repo/packages/M/memsql/0/config.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "memsql": {
-      "additionalProperties": [],
+      "additionalProperties": false,
       "properties": {
         "cpus": {
           "default": 1.0,


### PR DESCRIPTION
Don't allow additionalProperties. Must be boolean or object to be a
valid jsonschema.