### PR TITLE
fix helloworld config schema

### DIFF
--- a/repo/packages/H/helloworld/0/config.json
+++ b/repo/packages/H/helloworld/0/config.json
@@ -7,6 +7,5 @@
       "default": 8080
     }
   },
-  "additionalProperties": false,
-  "required": []
+  "additionalProperties": false
 }


### PR DESCRIPTION
'required' keyword must have at least one element:
http://json-schema.org/latest/json-schema-validation.html#anchor61