### PR TITLE
Jd: update to use version 0.9.1 kafka-mesos jar

### DIFF
--- a/repo/packages/K/kafka/0/config.json
+++ b/repo/packages/K/kafka/0/config.json
@@ -52,7 +52,7 @@
                         "jar": {
                             "type": "string",
                             "description": "kafka-mesos*.jar URL",
-                            "default": "https://d1vubr0evspla.cloudfront.net/kafka-mesos-0.9.0-beta.jar"
+                            "default": "https://d1vubr0evspla.cloudfront.net/kafka-mesos-0.9.1.1.jar"
                         }
                     },
                     "required": ["id", "cpus", "mem", "jre", "kafka", "jar"]


### PR DESCRIPTION
Update to use new kafka-mesos jar version 0.9.1 that includes bug fixes necessary for running kafka-mesos on instances other than m3.xlarge