### PR TITLE
Package hadoop and java with the HDFS framework

### DIFF
--- a/repo/packages/H/hdfs/0/config.json
+++ b/repo/packages/H/hdfs/0/config.json
@@ -11,7 +11,8 @@
           "type": "string"
         },
         "default": [
-          "https://s3.amazonaws.com/downloads.mesosphere.io/hdfs/artifacts/dcos/0.1.1/hdfs-mesos-0.1.1.tgz"
+          "https://s3.amazonaws.com/downloads.mesosphere.io/hdfs/artifacts/dcos/0.1.1/hdfs-mesos-0.1.1.tgz",
+          "https://downloads.mesosphere.io/java/jre-7u76-linux-x64.tar.gz"
         ]
       },
       "custom-config": {
@@ -22,11 +23,29 @@
         "description": "The name of the framework. Until this is configurable, please do not change this from it's default value.",
         "type": "string",
         "default": "hdfs"
+      },
+      "framework-version": {
+        "description": "Framework version",
+        "type": "string",
+        "default": "hdfs-mesos-0.1.1"
+      },
+      "jre-version": {
+        "description": "JRE version",
+        "type": "string",
+        "default": "jre1.7.0_76"
+      },
+      "ld-library-path": {
+        "desription": "Library path",
+        "type": "string",
+        "default": "/opt/mesosphere/lib"
       }
      },
      "required": [
       "scheduler-uris",
-      "framework-name"
+      "framework-name",
+      "ld-library-path",
+      "jre-version",
+      "framework-version"
      ]
     } 
   }

--- a/repo/packages/H/hdfs/0/marathon.json
+++ b/repo/packages/H/hdfs/0/marathon.json
@@ -4,12 +4,15 @@
   "mem": 512,
   "disk": 100,
   "instances": 1,
-  "cmd": "{{#hdfs.custom-config}}echo {{hdfs.custom-config}} | base64 --decode > mesos-site.xml && {{/hdfs.custom-config}}cd hdfs-mesos* && if [ -e '../mesos-site.xml' ]; then cp -f ../mesos-site.xml ./etc/hadoop/; fi && ./bin/hdfs-mesos",
+  "env": {
+    "LD_LIBRARY_PATH": "{{hdfs.ld-library-path}}" 
+  },
+  "cmd": "export JAVA_HOME=$MESOS_DIRECTORY/{{hdfs.jre-version}} && {{#hdfs.custom-config}}echo {{hdfs.custom-config}} | base64 --decode > mesos-site.xml && {{/hdfs.custom-config}}cd {{hdfs.framework-version}} && if [ -e '../mesos-site.xml' ]; then cp -f ../mesos-site.xml ./etc/hadoop/; fi && ./bin/hdfs-mesos",
   "uris": {{{hdfs.scheduler-uris}}},
   "healthChecks": [
     {
       "protocol": "COMMAND",
-      "command": { "value": "hadoop fs -ls hdfs://hdfs/ && rm -rf hdfs-framework-healthcheck && hadoop fs -rm -r -f hdfs://hdfs/hdfs-framework-healthcheck && hadoop fs -mkdir hdfs://hdfs/hdfs-framework-healthcheck && mkdir hdfs-framework-healthcheck && echo \"this is a test\" > hdfs-framework-healthcheck/test1.txt && hadoop fs -put hdfs-framework-healthcheck/test1.txt hdfs://hdfs/hdfs-framework-healthcheck && hadoop fs -get hdfs://hdfs/hdfs-framework-healthcheck/test1.txt hdfs-framework-healthcheck/test2.txt && rm -rf hdfs-framework-healthcheck && hadoop fs -rm -r -f hdfs://hdfs/hdfs-framework-healthcheck" },
+      "command": { "value": "export PATH=$MESOS_DIRECTORY/{{hdfs.framework-version}}/bin:$PATH && export JAVA_HOME=$MESOS_DIRECTORY/{{hdfs.jre-version}} && hadoop fs -ls hdfs://hdfs/ && rm -rf hdfs-framework-healthcheck && hadoop fs -rm -r -f hdfs://hdfs/hdfs-framework-healthcheck && hadoop fs -mkdir hdfs://hdfs/hdfs-framework-healthcheck && mkdir hdfs-framework-healthcheck && echo \"this is a test\" > hdfs-framework-healthcheck/test1.txt && hadoop fs -put hdfs-framework-healthcheck/test1.txt hdfs://hdfs/hdfs-framework-healthcheck && hadoop fs -get hdfs://hdfs/hdfs-framework-healthcheck/test1.txt hdfs-framework-healthcheck/test2.txt && rm -rf hdfs-framework-healthcheck && hadoop fs -rm -r -f hdfs://hdfs/hdfs-framework-healthcheck" },
       "gracePeriodSeconds": 300,
       "intervalSeconds": 60,
       "timeoutSeconds": 20,


### PR DESCRIPTION
Frameworks in the continuous/testing branch no longer have access to the
host's java and hadoop.  It must be packaged with the framework.