### PR TITLE
Add LD_LIBRARY_PATH to environment

### DIFF
--- a/repo/packages/C/cassandra/0/config.json
+++ b/repo/packages/C/cassandra/0/config.json
@@ -71,6 +71,11 @@
           "type": "string",
           "default": "dcos"
         },
+        "ld-library-path": {
+          "desription": "Library path",
+          "type": "string",
+          "default": "/opt/mesosphere/lib"
+        },
         "zk": {
           "description": "ZooKeeper URL for storing state. Format: zk://host1:port1,host2:port2,.../path (can have nested directories)",
           "type": "string"
@@ -163,5 +168,4 @@
     "mesos",
     "cassandra"
   ]
-
 }

--- a/repo/packages/C/cassandra/0/marathon.json
+++ b/repo/packages/C/cassandra/0/marathon.json
@@ -36,6 +36,7 @@
   },
   "env": {
     "MESOS_ZK": "{{mesos.master}}"
+    ,"LD_LIBRARY_PATH": "{{cassandra.ld-library-path}}"
     ,"JAVA_OPTS": "-Xms256m -Xmx256m"
     ,"CASSANDRA_CLUSTER_NAME": "{{cassandra.cluster-name}}"
     ,"CASSANDRA_NODE_COUNT": "{{cassandra.node-count}}"


### PR DESCRIPTION
This change allows Cassandra can be deployed on DCOS Test/Continuous AWS clusters.  It still deploys  fine on Stable clusters too.  When a new release of Cassandra comes out the URI will have to be updated here, but so far this is a non-breaking change.