### PR TITLE
fix #197 - fix variable names

### DIFF
--- a/repo/packages/S/spark/1/config.json
+++ b/repo/packages/S/spark/1/config.json
@@ -75,7 +75,7 @@
         "framework-name",
         "instances",
         "mem",
-        "zk"
+        "zookeeper"
       ]
     }
   },


### PR DESCRIPTION
fix variable names mismatching "zookeeper" and "zk"

it's fix failing spark deployment with message below:
```
$ dcos package install spark
Note that the Apache Spark DCOS Service is beta and there may be bugs, incomplete features, incorrect documentation or other discrepancies.
We recommend a minimum of two nodes with at least 2 CPU and 2GB of RAM available for the Spark Service and running a Spark job.
Note: The Spark CLI may take up to 5min to download depending on your connection.
Continue installing? [yes/no] yes
\Error: missing required property 'zk'.

Please create a JSON file with the appropriate options, and pass the /path/to/file as an --options argument.

```