### PR TITLE
Added ability to use default chroot

### DIFF
--- a/repo/packages/R/riak/0/config.json
+++ b/repo/packages/R/riak/0/config.json
@@ -77,6 +77,11 @@
                 "description": "Memory requirements",
                 "default": 2048
             },
+            "super-chroot":{
+                "type": "string",
+                "description": "When this is false, use the default chroot.",
+                "default": "true"
+            },
             "healthcheck-grace-period-seconds": {
                 "type": "number",
                 "description": "Memory requirements",

--- a/repo/packages/R/riak/0/marathon.json
+++ b/repo/packages/R/riak/0/marathon.json
@@ -5,7 +5,7 @@
   "mem": {{riak.mem}},
   "ports": [0, 0],
   "uris": ["{{riak.url}}"],
-  "env": {},
+  "env": {"USE_SUPER_CHROOT": "{{riak.super-chroot}}"},
   "cmd": "riak_mesos_framework/framework_linux_amd64 -master={{riak.master}} -zk={{riak.zk}} -name={{riak.framework-name}} -user={{riak.user}}{{#riak.ip}} -ip={{riak.ip}}{{/riak.ip}}{{#riak.hostname}} -hostname={{riak.hostname}}{{/riak.hostname}}{{#riak.log}} -log={{riak.log}}{{/riak.log}}{{#riak.role}} -role={{riak.role}}{{/riak.role}}{{#riak.auth-provider}} -mesos_authentication_provider={{riak.auth-provider}}{{/riak.auth-provider}}{{#riak.auth-principal}} -mesos_authentication_principal={{riak.auth-principal}}{{/riak.auth-principal}}{{#riak.auth-secret-file}} -mesos_authentication_secret_file={{riak.auth-secret-file}}{{/riak.auth-secret-file}}",
   "healthChecks": [
     {

--- a/repo/packages/R/riak/0/package.json
+++ b/repo/packages/R/riak/0/package.json
@@ -16,7 +16,7 @@
     ]
   },
   "postInstallNotes": "Thank you for installing Riak on Mesos. Visit https://github.com/basho-labs/riak-mesos for usage information.",
-  "preInstallNotes": "The Mesos Riak Framework implementation is alpha and there may be bugs, incomplete features, incorrect documentation or other discrepancies. The Riak framework should have at least 2GB of RAM and 0.5 CPUs to perform successfully.",
+  "preInstallNotes": "The Mesos Riak Framework implementation is an experimental beta and there may be bugs, incomplete features, incorrect documentation or other discrepancies. The Riak framework should have at least 2GB of RAM and 0.5 CPUs to perform successfully.",
   "postUninstallNotes": "The Mesos Riak Framework has been uninstalled and will no longer run. In order to fully remove Riak from the DCOS cluster, delete the /riak/frameworks/<framework-id> or /riak nodes from Zookeeper.",
   "licenses": [
     {


### PR DESCRIPTION
Due to compatibility issues with our framework on certain versions of CentOS, we needed to add the ability to use standard chroot. This change adds a configuration value to config.json