### PR TITLE
Force a timeout of the healthcheck in 45s

### DIFF
--- a/repo/packages/H/hdfs/1/marathon.json
+++ b/repo/packages/H/hdfs/1/marathon.json
@@ -12,7 +12,7 @@
   "healthChecks": [
     {
       "protocol": "COMMAND",
-      "command": { "value": "export PATH=$MESOS_DIRECTORY/{{hdfs.framework-version}}/bin:$PATH && export JAVA_HOME=$MESOS_DIRECTORY/{{hdfs.jre-version}} && hadoop fs -ls hdfs://hdfs/ && rm -rf hdfs-framework-healthcheck && hadoop fs -rm -r -f hdfs://hdfs/hdfs-framework-healthcheck && hadoop fs -mkdir hdfs://hdfs/hdfs-framework-healthcheck && mkdir hdfs-framework-healthcheck && echo \"this is a test\" > hdfs-framework-healthcheck/test1.txt && hadoop fs -put hdfs-framework-healthcheck/test1.txt hdfs://hdfs/hdfs-framework-healthcheck && hadoop fs -get hdfs://hdfs/hdfs-framework-healthcheck/test1.txt hdfs-framework-healthcheck/test2.txt && rm -rf hdfs-framework-healthcheck && hadoop fs -rm -r -f hdfs://hdfs/hdfs-framework-healthcheck" },
+      "command": { "value": "export PATH=$MESOS_DIRECTORY/{{hdfs.framework-version}}/bin:$PATH && export JAVA_HOME=$MESOS_DIRECTORY/{{hdfs.jre-version}} && timeout 45s hadoop fs -ls hdfs://hdfs/ && rm -rf hdfs-framework-healthcheck && hadoop fs -rm -r -f hdfs://hdfs/hdfs-framework-healthcheck && hadoop fs -mkdir hdfs://hdfs/hdfs-framework-healthcheck && mkdir hdfs-framework-healthcheck && echo \"this is a test\" > hdfs-framework-healthcheck/test1.txt && hadoop fs -put hdfs-framework-healthcheck/test1.txt hdfs://hdfs/hdfs-framework-healthcheck && hadoop fs -get hdfs://hdfs/hdfs-framework-healthcheck/test1.txt hdfs-framework-healthcheck/test2.txt && rm -rf hdfs-framework-healthcheck && hadoop fs -rm -r -f hdfs://hdfs/hdfs-framework-healthcheck" },
       "gracePeriodSeconds": 300,
       "intervalSeconds": 60,
       "timeoutSeconds": 60,


### PR DESCRIPTION
Until https://issues.apache.org/jira/browse/MESOS-3479 is resolved we
must never timeout.  There are cases where we still exceed the 60s
timeout

I got lucky testing this.  I ran into the scenario which usually has a health check exceed it's 60s timeout, but the timeout enforced here (Ctrl+f timeout 45s) caused the health-check to fail on time.  The next health-check succeeded as usual, but this time we converged to a healthy state.  Defect mitigated!