### PR TITLE
Add checks for duplicated keys to validation

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -4,7 +4,7 @@ set -o errexit -o nounset -o pipefail
 echo "RUNNING PRE-COMMIT";
 
 GIT_HOOKS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
-UNIVERSE_DIR=$GIT_HOOKS_DIR/..
+UNIVERSE_DIR=$GIT_HOOKS_DIR/../..
 SCRIPTS_DIR=$UNIVERSE_DIR/scripts
 
 $SCRIPTS_DIR/build.sh

--- a/scripts/1-validate-packages.sh
+++ b/scripts/1-validate-packages.sh
@@ -10,7 +10,10 @@ validate () {
   query=$1;
   schema=$2;
   for file in $(find $PKG_DIR -name $query); do
+    package=${file/$PKG_DIR/}
+    echo "- $package"
     jsonschema -i $file $schema
+    $SCRIPTS_DIR/json_dup_key_check.py $file
   done
 }
 

--- a/scripts/json_dup_key_check.py
+++ b/scripts/json_dup_key_check.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import json
+
+class DuplicatedKeysException(Exception):
+  pass
+
+def json_checker(pair):
+  ret = {} 
+  for key, value in pair:
+    if key in ret:
+      raise DuplicatedKeysException("Duplicate key %r in json document" % key)
+    else:
+      ret[key]=value
+  return ret
+
+if len(sys.argv) != 2:
+  sys.stderr.write("Syntax: %s path/to/file.json\n" % os.path.basename(__file__))
+  sys.exit(1)
+
+try:
+  json.load(open(sys.argv[1]), object_pairs_hook=json_checker)
+except DuplicatedKeysException as e:
+  sys.stderr.write("Error validating %s: %s\n" % (sys.argv[1], e.args[0]))
+  sys.exit(1)


### PR DESCRIPTION
I wanted to do the same for marathon.json but that turned out to be more complicated given that the template first needs to be rendered. 