### PR TITLE
Improving PreInstallNotes for HDFS

### DIFF
--- a/repo/packages/H/hdfs/2/package.json
+++ b/repo/packages/H/hdfs/2/package.json
@@ -17,7 +17,7 @@
       "url": "https://github.com/mesosphere/hdfs/blob/master/LICENSE"
     }
   ],
-  "preInstallNotes": "In order for HDFS to start successfully, we recommend a minimum of five nodes, each with at least 2 CPU shares and 8GB of RAM available for use by the HDFS Service.\nNote that the service is alpha and there may be bugs, including possible data loss, incomplete features, incorrect documentation or other discrepancies.",
+  "preInstallNotes": "In order for HDFS to start successfully, it requires a minimum of five nodes; each with at least 2 CPU shares and 8GB of RAM available for use by the HDFS Service.\nNote that the service is alpha and there may be bugs, including possible data loss, incomplete features, incorrect documentation or other discrepancies.",
   "postInstallNotes": "HDFS DCOS Service has been successfully installed!\n\n\tDocumentation: https://github.com/mesosphere/hdfs\n\tIssues: https://github.com/mesosphere/hdfs/issues",
   "postUninstallNotes": "The HDFS DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/hdfs/#uninstall to clean up any persisted state"
 }


### PR DESCRIPTION
Changing the preinstall note language from "recommend" to "require" to emphasize to users that this is a hard requirement.