### PR TITLE
spark fine grained mode

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -97,7 +97,7 @@
       }
     },
     {
-      "currentVersion":"1.5.0-db83ac7",
+      "currentVersion":"1.5.0-multi-roles-v2",
       "description":"Spark is a fast and general cluster computing system for Big Data",
       "framework":true,
       "name":"spark",
@@ -111,7 +111,8 @@
         "1.4.0-SNAPSHOT":"0",
         "1.4.1":"1",
         "1.5.0":"2",
-        "1.5.0-db83ac7":"3"
+        "1.5.0-db83ac7":"3",
+        "1.5.0-multi-roles-v2":"4"
       }
     }
   ],

--- a/repo/packages/S/spark/4/command.json
+++ b/repo/packages/S/spark/4/command.json
@@ -1,0 +1,5 @@
+{
+  "pip": [
+    "https://s3.amazonaws.com/downloads.mesosphere.io/dcos/spark/dcos_spark-0.4.0_spark_1.5.0_multi_roles_v2_bin_2.4.0-py2.py3-none-any.whl"
+  ]
+}

--- a/repo/packages/S/spark/4/config.json
+++ b/repo/packages/S/spark/4/config.json
@@ -1,0 +1,74 @@
+{
+  "type": "object",
+  "properties": {
+    "mesos": {
+      "description": "Mesos specific configuration properties",
+      "type": "object",
+      "properties": {
+        "master": {
+          "default": "mesos://zk://master.mesos:2181/mesos",
+          "description": "The URL of the Mesos master. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard host:port patterns, like localhost:5050 or 10.0.0.5:5050,10.0.0.6:5050, are also acceptable.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "master"
+      ]
+    },
+    "spark": {
+      "description": "Spark Framework Configuration Properties",
+      "type": "object",
+      "properties": {
+        "framework-name": {
+            "description": "The name of the framework. Until this is configurable, please do not change this from it's default value.",
+            "type": "string",
+            "default": "spark"
+        },
+        "host": {
+          "type": "string",
+          "description": "The host that the Spark cluster dispatcher will register under.",
+          "default": "$HOST"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each Marathon instance.",
+          "minimum": 0.0,
+          "type": "number"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of Marathon instances to run.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "mem": {
+          "default": 1024.0,
+          "description": "Memory (MB) to allocate to each Marathon task.",
+          "minimum": 1024.0,
+          "type": "number"
+        },
+        "mesos-user": {
+          "description": "Mesos user to run the executor under",
+          "type": "string",
+          "default": "root"
+        },
+        "zookeeper": {
+          "type": "string",
+          "description": "URL to the Zookeeper that Spark cluster framework connects to persist state to. (l.e: zk://0.0.0.0:2181)",
+          "default": "master.mesos:2181"
+        }
+      },
+      "required": [
+        "cpus",
+        "framework-name",
+        "instances",
+        "mem",
+        "zookeeper"
+      ]
+    }
+  },
+  "required": [
+  	"mesos",
+    "spark"
+  ]
+}

--- a/repo/packages/S/spark/4/marathon.json
+++ b/repo/packages/S/spark/4/marathon.json
@@ -1,0 +1,37 @@
+{
+  "id": "{{spark.framework-name}}",
+  "cpus": {{spark.cpus}},
+  "mem": {{spark.mem}},
+  "instances": {{spark.instances}},
+  "cmd": "mv /mnt/mesos/sandbox/log4j.properties conf/log4j.properties && ./bin/spark-class org.apache.spark.deploy.mesos.MesosClusterDispatcher --port $PORT0 --webui-port $PORT1 --master {{mesos.master}} --zk {{spark.zookeeper}} --host {{spark.host}} --name {{spark.framework-name}}",
+  "uris": [
+    "http://downloads.mesosphere.com.s3.amazonaws.com/assets/spark/log4j.properties"
+  ],
+  "env": {
+    "APPLICATION_WEB_PROXY_BASE": "/service/spark",
+    "SPARK_USER": "{{spark.mesos-user}}"
+  },
+  "ports": [
+    0,
+    0
+  ],
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "mesosphere/spark:1.5.0-multi-roles-v2-bin-2.4.0",
+      "network": "HOST"
+    }
+  },
+  "healthChecks": [
+    {
+      "path": "/",
+      "portIndex": 1,
+      "protocol": "HTTP",
+      "gracePeriodSeconds": 5,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 10,
+      "maxConsecutiveFailures": 3
+    }
+  ]
+}
+

--- a/repo/packages/S/spark/4/package.json
+++ b/repo/packages/S/spark/4/package.json
@@ -1,0 +1,28 @@
+{
+  "scm": "https://github.com/apache/spark.git", 
+  "postInstallNotes": "The Apache Spark DCOS Service has been successfully installed!\n\n\tDocumentation: https://spark.apache.org/docs/latest/running-on-mesos.html\n\tIssues: https://issues.apache.org/jira/browse/SPARK", 
+  "maintainer": "support@mesosphere.io", 
+  "name": "spark", 
+  "tags": [
+    "bigdata", 
+    "mapreduce", 
+    "batch", 
+    "analytics"
+  ], 
+  "framework": true, 
+  "version": "1.5.0-multi-roles-v2", 
+  "postUninstallNotes": "The Apache Spark DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at http://docs.mesosphere.com/services/spark/#uninstall to clean up any persisted state.", 
+  "images": {
+    "icon-medium": "https://downloads.mesosphere.io/spark/assets/icon-service-spark-medium.png", 
+    "icon-small": "https://downloads.mesosphere.io/spark/assets/icon-service-spark-small.png", 
+    "icon-large": "https://downloads.mesosphere.io/spark/assets/icon-service-spark-large.png"
+  }, 
+  "preInstallNotes": "Note that the Apache Spark DCOS Service is beta and there may be bugs, incomplete features, incorrect documentation or other discrepancies.\nWe recommend a minimum of two nodes with at least 2 CPU and 2GB of RAM available for the Spark Service and running a Spark job.\nNote: The Spark CLI may take up to 5min to download depending on your connection.", 
+  "licenses": [
+    {
+      "url": "https://raw.githubusercontent.com/apache/spark/master/LICENSE", 
+      "name": "Apache License Version 2.0"
+    }
+  ], 
+  "description": "Spark is a fast and general cluster computing system for Big Data"
+}


### PR DESCRIPTION
Added a couple hacks to make spark work in fine-grained mode given the outstanding mesos bugs.

I added symlinks in the docker image to overcome the PATH bug
I added a conf/spark-env.sh entry to overcome the MESOS_NATIVE_JAVA_LIBRARY bug