### PR TITLE
[kafka] Specify heap size, fix memory overhead.

### DIFF
--- a/repo/packages/K/kafka/1/config.json
+++ b/repo/packages/K/kafka/1/config.json
@@ -30,7 +30,12 @@
                             "default": 0.5
                         },
                         "mem": {
-                            "description": "mem requirements",
+                            "description": "mem requirements (this should be approximately 120% of the heap size).",
+                            "type": "integer",
+                            "default": 307
+                        },
+                        "heap-mb": {
+                            "description": "Heap size for scheduler JVM, in MiB",
                             "type": "integer",
                             "default": 256
                         },
@@ -55,7 +60,7 @@
                             "default": "https://d1vubr0evspla.cloudfront.net/kafka-mesos-0.9.2.0.jar"
                         }
                     },
-                    "required": ["cpus", "mem", "instances", "jre", "kafka", "jar"]
+                    "required": ["cpus", "mem", "instances", "jre", "kafka", "jar", "heap-mb"]
                 },
 
                 "zk": {

--- a/repo/packages/K/kafka/1/marathon.json
+++ b/repo/packages/K/kafka/1/marathon.json
@@ -3,7 +3,7 @@
   "cpus": {{kafka.app.cpus}},
   "mem": {{kafka.app.mem}},
   "instances": {{kafka.app.instances}},
-  "cmd": "jre/bin/java -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage=\"{{kafka.storage}}\" --jre={{kafka.jre}} {{#kafka.user}}--user=\"{{kafka.user}}\"{{/kafka.user}} --framework-name=\"{{kafka.framework-name}}\" --framework-role=\"{{kafka.framework-role}}\" {{#kafka.principal}}--principal=\"{{kafka.principal}}\"{{/kafka.principal}} {{#kafka.secret}}--secret=\"{{kafka.secret}}\"{{/kafka.secret}} --log=scheduler.log {{kafka.other-options}}",
+  "cmd": "jre/bin/java -Xmx{{kafka.app.heap-mb}}m -jar kafka-mesos*.jar scheduler --master={{mesos.master}} --zk={{kafka.zk}} --api={{kafka.api}} --storage=\"{{kafka.storage}}\" --jre={{kafka.jre}} {{#kafka.user}}--user=\"{{kafka.user}}\"{{/kafka.user}} --framework-name=\"{{kafka.framework-name}}\" --framework-role=\"{{kafka.framework-role}}\" {{#kafka.principal}}--principal=\"{{kafka.principal}}\"{{/kafka.principal}} {{#kafka.secret}}--secret=\"{{kafka.secret}}\"{{/kafka.secret}} --log=scheduler.log {{kafka.other-options}}",
   "uris": ["{{kafka.app.jre}}", "{{kafka.app.kafka}}", "{{kafka.app.jar}}"],
   "ports": [0],
   "healthChecks": [


### PR DESCRIPTION
With the current default memory settings, the Kafka scheduler will get OOM killed when you try to do too much with it. This PR adds a) an option to specify the heap size and b) increases the memory requirement such that our scheduler doesn't get OOM killed.

cc @joestein