### PR TITLE
Remove the trailing / from marathon.zk 

### DIFF
--- a/repo/packages/M/marathon/8/config.json
+++ b/repo/packages/M/marathon/8/config.json
@@ -255,7 +255,7 @@
           "type": "array"
         },
         "zk": {
-          "default": "zk://master.mesos:2181/",
+          "default": "zk://master.mesos:2181",
           "description": "Parent ZooKeeper URL for storing state. The framework name is joined to the path of this value. Format: zk://host1:port1,host2:port2,.../path",
           "type": "string"
         },


### PR DESCRIPTION
marathon.json has`--zk` as `{{marathon.zk}}/{{marathon.framework-name}}`  Since `marathon.z`k is defined as `zk://master.mesos:2181/` in config.json it turns into `zk://master.mesos:2181//marathon-user`

I have removed the trailing /, otherwise deploying MoM was failing 