### PR TITLE
Implements scripts for downloading all assets

### DIFF
--- a/repo/packages/A/arangodb/0/resource.json
+++ b/repo/packages/A/arangodb/0/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "17881b9777fe": "agangodb/arangodb-mesos:latest"
+        "17881b9777fe": "docker.io/arangodb/arangodb-mesos:latest"
       }
     }
   },

--- a/repo/packages/C/chronos/0/resource.json
+++ b/repo/packages/C/chronos/0/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "99852a4a1a6e": "mesosphere/chronos:chronos-2.4.0-0.1.20150828104228.ubuntu1404-mesos-0.23.0-1.0.ubuntu1404"
+        "99852a4a1a6e": "docker.io/mesosphere/chronos:chronos-2.4.0-0.1.20150828104228.ubuntu1404-mesos-0.23.0-1.0.ubuntu1404"
       }
     }
   },

--- a/repo/packages/M/marathon/0/resource.json
+++ b/repo/packages/M/marathon/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "5e187be16235": "mesosphere/marathon:v0.11.1"
+        "5e187be16235": "docker.io/mesosphere/marathon:v0.11.1"
       }
     }
   }

--- a/repo/packages/S/spark/0/resource.json
+++ b/repo/packages/S/spark/0/resource.json
@@ -5,7 +5,7 @@
     },
     "container": {
       "docker": {
-        "23b1cfe8e04a": "mesosphere/spark:1.5.0-multi-roles-v2-bin-2.4.0"
+        "23b1cfe8e04a": "docker.io/mesosphere/spark:1.5.0-multi-roles-v2-bin-2.4.0"
       }
     }
   },

--- a/scripts/json_dup_key_check.py
+++ b/scripts/json_dup_key_check.py
@@ -4,24 +4,28 @@ import os
 import sys
 import json
 
+
 class DuplicatedKeysException(Exception):
-  pass
+    pass
+
 
 def json_checker(pair):
-  ret = {} 
-  for key, value in pair:
-    if key in ret:
-      raise DuplicatedKeysException("Duplicate key %r in json document" % key)
-    else:
-      ret[key]=value
-  return ret
+    ret = {}
+    for key, value in pair:
+        if key in ret:
+            raise DuplicatedKeysException(
+                "Duplicate key {!r} in json document".format(key))
+        else:
+            ret[key] = value
+    return ret
 
 if len(sys.argv) != 2:
-  sys.stderr.write("Syntax: %s path/to/file.json\n" % os.path.basename(__file__))
-  sys.exit(1)
+    sys.stderr.write(
+        "Syntax: {} path/to/file.json\n".format(os.path.basename(__file__)))
+    sys.exit(1)
 
 try:
-  json.load(open(sys.argv[1]), object_pairs_hook=json_checker)
+    json.load(open(sys.argv[1]), object_pairs_hook=json_checker)
 except DuplicatedKeysException as e:
-  sys.stderr.write("Error validating %s: %s\n" % (sys.argv[1], e.args[0]))
-  sys.exit(1)
+    sys.stderr.write("Error validating %s: %s\n" % (sys.argv[1], e.args[0]))
+    sys.exit(1)

--- a/scripts/local-universe.py
+++ b/scripts/local-universe.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.parse
+import urllib.request
+import zipfile
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--repository')
+    parser.add_argument('--sudo', action='store_true', default=False)
+    parser.add_argument('--out-file', dest='outfile')
+    args = parser.parse_args()
+
+    with zipfile.ZipFile(args.outfile, mode='w') as zip_file:
+        for url, archive_path in ((url, archive_path)
+                                  for package, path in
+                                  enumerate_dcos_packages(
+                                      pathlib.Path(args.repository))
+                                  for url, archive_path in
+                                  enumerate_http_resources(package, path)):
+            add_http_resource(zip_file, url, archive_path)
+
+        docker_images = [name
+                         for _, path in
+                         enumerate_dcos_packages(
+                             pathlib.Path(args.repository))
+                         for name in
+                         enumerate_docker_images(path)]
+
+        for name in docker_images:
+            download_docker_image(name, args.sudo)
+
+        add_docker_images(zip_file, docker_images, args.sudo)
+
+
+def enumerate_dcos_packages(packages_path):
+    for letter_path in packages_path.iterdir():
+        assert len(letter_path.name) == 1 and letter_path.name.isupper()
+        for package_path in letter_path.iterdir():
+
+            largest_revision = max(
+                package_path.iterdir(),
+                key=lambda revision: int(revision.name))
+
+            yield (package_path.name, largest_revision)
+
+
+def enumerate_http_resources(package, package_path):
+    with (package_path / 'resource.json').open() as json_file:
+        resource = json.load(json_file)
+
+    for name, url in resource['images'].items():
+        if name != 'screenshots':
+            yield url, pathlib.PurePosixPath(package, 'images')
+
+    for name, url in resource.get('assets', {}).get('uris', {}).items():
+        yield url, pathlib.PurePosixPath(package, 'uris')
+
+
+def enumerate_docker_images(package_path):
+    with (package_path / 'resource.json').open() as json_file:
+        resource = json.load(json_file)
+
+    dockers = resource.get('assets', {}).get('container', {}).get('docker', {})
+
+    return (name for _, name in dockers.items())
+
+
+def download_docker_image(name, use_sudo):
+    print('Pull docker images: {}'.format(name))
+    command = ['docker', 'pull', name]
+
+    command = ['sudo'] + command if use_sudo else command
+    subprocess.call(command)
+
+
+def add_http_resource(zip_file, url, dir_path):
+    archive_path = (dir_path /
+                    pathlib.PurePosixPath(urllib.parse.urlparse(url).path).name)
+    print('Adding {} at {} to file zip.'.format(url, archive_path))
+    with urllib.request.urlopen(url) as response:
+        with tempfile.NamedTemporaryFile() as tempFile:
+            shutil.copyfileobj(response, tempFile)
+            tempFile.flush()
+            zip_file.write(tempFile.name, str(archive_path))
+
+
+def add_docker_images(zip_file, images, use_sudo):
+    print('Saving docker images: {!r}'.format(images))
+    with tempfile.NamedTemporaryFile() as tempFile:
+        command = (
+            ['docker', 'save', '--output={}'.format(tempFile.name)] +
+            images
+        )
+
+        command = ['sudo'] + command if use_sudo else command
+
+        subprocess.call(command)
+
+        zip_file.write(tempFile.name, 'docker-images.tar')
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This script is able to download all of the HTTP resources and Docker
images. The temp directory used can be overwritten by using the TMPDIR
environment variable.

This script only works with version-2.x of Universe.

To create a local universe zip file, using the current directory as the
temporary directory, run the following command:

```
> TMPDIR=. python3 scripts/local-universe.py --repository repo/packages/ --out-file
local_universe.zip --sudo
```

This creates a file called `local_universe.zip` which contains the
following information:

```
> unzip -l local_universe.zip
Archive:  local_universe.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
     4148  01-15-2016 10:36   arangodb/images/arangodb_small.png
    10128  01-15-2016 10:36   arangodb/images/arangodb_medium.png
    47394  01-15-2016 10:36   arangodb/images/arangodb_large.png
     1920  01-15-2016 10:36   cassandra/images/cassandra-small.png
     5070  01-15-2016 10:36   cassandra/images/cassandra-medium.png
    17969  01-15-2016 10:36   cassandra/images/cassandra-large.png
 47058747  01-15-2016 10:36   cassandra/uris/jre-7u76-linux-x64.tar.gz
 70886405  01-15-2016 10:36   cassandra/uris/cassandra-mesos-0.2.0-1.tar.gz
     3038  01-15-2016 10:36   chronos/images/icon-service-chronos-small.png
    10074  01-15-2016 10:36   chronos/images/icon-service-chronos-medium.png
    23663  01-15-2016 10:36   chronos/images/icon-service-chronos-large.png
     2323  01-15-2016 10:36   hdfs/images/icon-service-hdfs-small.png
     6396  01-15-2016 10:36   hdfs/images/icon-service-hdfs-medium.png
    15829  01-15-2016 10:36   hdfs/images/icon-service-hdfs-large.png
 47058747  01-15-2016 10:36   hdfs/uris/jre-7u76-linux-x64.tar.gz
117885110  01-15-2016 10:36   hdfs/uris/hdfs-mesos-0.1.5.tgz
     4306  01-15-2016 10:36   kafka/images/icon-small.png
     2748  01-15-2016 10:36   kafka/images/icon-medium.png
     7847  01-15-2016 10:36   kafka/images/icon-large.png
 15998492  01-15-2016 10:37   kafka/uris/kafka-mesos-0.9.2.0.jar
 16162559  01-15-2016 10:37   kafka/uris/kafka_2.10-0.8.2.1.tgz
 48993499  01-15-2016 10:37   kafka/uris/jre-7u79-openjdk.tgz
     1839  01-15-2016 10:37   marathon/images/icon-service-marathon-small.png
     3759  01-15-2016 10:37   marathon/images/icon-service-marathon-medium.png
    10927  01-15-2016 10:37   marathon/images/icon-service-marathon-large.png
     1501  01-15-2016 10:37   spark/images/icon-service-spark-small.png
     3040  01-15-2016 10:37   spark/images/icon-service-spark-medium.png
     9028  01-15-2016 10:37   spark/images/icon-service-spark-large.png
      621  01-15-2016 10:37   spark/uris/log4j.properties
2745697792  01-15-2016 10:38   docker-images.tar
---------                     -------
3109934919                     30 files
```