### PR TITLE
fix typo in chronos config

### DIFF
--- a/repo/packages/C/chronos/0/config.json
+++ b/repo/packages/C/chronos/0/config.json
@@ -130,7 +130,7 @@
         "default": "/chronos"
       },
       "leader-max-idle-time": {
-        "integer": "The look-ahead time for scheduling tasks in milliseconds (default = 5000)",
+        "description": "The look-ahead time for scheduling tasks in milliseconds (default = 5000)",
         "type": "string"
       },
       "mail-from": {


### PR DESCRIPTION
Found by @cruhland's validation code. 