### PR TITLE
Upgrade Kafka CLI to 0.2.1

### DIFF
--- a/repo/packages/K/kafka/1/command.json
+++ b/repo/packages/K/kafka/1/command.json
@@ -1,5 +1,5 @@
 {
   "pip": [
-    "https://d1vubr0evspla.cloudfront.net/dcos-kafka-0.2.0.tar.gz"
+    "https://d1vubr0evspla.cloudfront.net/dcos-kafka-0.2.1.tar.gz"
   ]
 }


### PR DESCRIPTION
Kafka CLI does not work with Windows due to https://github.com/mesosphere/dcos-kafka/pull/13 . The PR was merged and there was a new release https://github.com/mesosphere/dcos-kafka/releases/tag/0.2.1. Seems like the new release is available too : https://d1vubr0evspla.cloudfront.net/dcos-kafka-0.2.1.tar.gz

Without this kafka cli would not work on Windows 