### PR TITLE
Increase failover timeout

### DIFF
--- a/repo/packages/A/arangodb/2/config.json
+++ b/repo/packages/A/arangodb/2/config.json
@@ -145,7 +145,7 @@
         "failover-timeout": {
           "description": "Timeout after which an automatic failover is done.",
           "type": "number",
-          "default": 30
+          "default": 604800
         },
 
         "mesos-authenticate": {


### PR DESCRIPTION
Current setting will easily kill the whole arangodb cluster (slave going down etc.).