### PR TITLE
remove mac index file .DS_Store from package_dirs

### DIFF
--- a/scripts/build-index.py
+++ b/scripts/build-index.py
@@ -36,7 +36,7 @@ def build_index(repo_dir):
     package_dirs = [p for d in os.listdir(packages_dir)
                     for p in os.listdir(os.path.join(packages_dir, d))]
 
-    index_entries = [make_index_entry(
+    index_entries = [ make_index_entry(
         os.path.join(
             repo_dir,
             'repo',
@@ -44,7 +44,7 @@ def build_index(repo_dir):
             dir[0].title(),
             dir
         )
-    ) for dir in package_dirs]
+    ) for dir in package_dirs if not dir.startswith('.')]
 
     index_entries.sort(key=lambda p: p.get('name', ''))
 


### PR DESCRIPTION
I had an error went building my third party repo because of the mac index file .DS_Store.

berndzuther@MacBook-Pro ~/development/3rdparty.dcos (master●●)$ ./build.sh
Building the universe!
Validating version...
OK
Validating package definitions...
OK
Building index...

Traceback (most recent call last):
  File "/Users/berndzuther/development/audi/3rdparty.dcos/scripts/build-index.py", line 111, in <module>
    main()
  File "/Users/berndzuther/development/audi/3rdparty.dcos/scripts/build-index.py", line 16, in main
    index = build_index(repo_dir)
  File "/Users/berndzuther/development/audi/3rdparty.dcos/scripts/build-index.py", line 49, in build_index
    ) for dir in package_dirs ]
  File "/Users/berndzuther/development/audi/3rdparty.dcos/scripts/build-index.py", line 68, in make_index_entry
    package_versions = sorted(filter(is_version_dir, os.listdir(package_dir)))
OSError: [Errno 2] No such file or directory: '/Users/berndzuther/development/audi/3rdparty.dcos/scripts/../repo/packages/./.DS_Store'
