### PR TITLE
Fixup Marathon-LB package text.

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -226,7 +226,7 @@
     },
     {
       "currentVersion":"0.0.4-0.1",
-      "description":"HAProxy configured from marathon state",
+      "description":"HAProxy configured using Marathon state",
       "framework":false,
       "name":"marathon-lb",
       "selected":false,
@@ -239,7 +239,7 @@
       ],
       "versions":{
         "0.0.3-0.1":"0",
-        "0.0.4-0.1":"1"
+        "0.0.4-0.1":"2"
       }
     },
     {

--- a/repo/packages/M/marathon-lb/2/config.json
+++ b/repo/packages/M/marathon-lb/2/config.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "marathon-lb": {
+      "properties": {
+        "bind-http-https": {
+          "default": true,
+          "description": "Reserve ports 80 and 443 for the LB. Use this if you intend to use virtual hosts.",
+          "type": "boolean"
+        },
+        "cpus": {
+          "default": 2,
+          "description": "CPU shares to allocate to each marathon-lb instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "haproxy-group": {
+          "default": "external",
+          "description": "HAProxy group parameter. Matches with HAPROXY_GROUP in the app labels.",
+          "type": "string"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "mem": {
+          "default": 1024.0,
+          "description": "Memory (MB) to allocate to each marathon-lb task.",
+          "minimum": 256.0,
+          "type": "number"
+        },
+        "minimumHealthCapacity": {
+          "default": 0.5,
+          "description": "Minimum health capacity.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "maximumOverCapacity": {
+          "default": 0.2,
+          "description": "Maximum over capacity.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "name": {
+          "default": "marathon-lb",
+          "description": "Name for this LB instance",
+          "type": "string"
+        },
+        "role": {
+          "default": "slave_public",
+          "description": "Deploy marathon-lb only on nodes with this role.",
+          "type": "string"
+        },
+        "ssl-cert": {
+          "description": "TLS Cert and private key for HTTPS.",
+          "type": "string"
+        },
+        "sysctl-params": {
+          "default": "net.ipv4.tcp_tw_reuse=1 net.ipv4.tcp_fin_timeout=30 net.ipv4.tcp_max_syn_backlog=10240 net.ipv4.tcp_max_tw_buckets=400000 net.ipv4.tcp_max_orphans=60000 net.core.somaxconn=10000",
+          "description": "sysctl params to set at startup for HAProxy.",
+          "type": "string"
+        },
+        "template-url": {
+          "default": "",
+          "description": "URL to tarball containing a directory templates/ to customize haproxy config.",
+          "type": "string"
+        },
+        "marathon-uri": {
+          "default": "http://master.mesos:8080",
+          "description": "URI of Marathon instance",
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "haproxy-group", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/M/marathon-lb/2/marathon.json.mustache
+++ b/repo/packages/M/marathon-lb/2/marathon.json.mustache
@@ -1,0 +1,171 @@
+{
+  "id": "{{marathon-lb.name}}",
+  "instances": {{marathon-lb.instances}},
+  "cpus": {{marathon-lb.cpus}},
+  "mem": {{marathon-lb.mem}},
+  "maintainer": "support@mesosphere.io",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.marathon-lb-docker}}",
+      "network": "HOST",
+      "privileged": true
+    }
+  },
+  {{#marathon-lb.role}}
+  "acceptedResourceRoles": [
+    "{{marathon-lb.role}}"
+  ],
+  {{/marathon-lb.role}}
+  "constraints": [
+    ["hostname", "UNIQUE"]
+  ],
+  "healthChecks": [
+    {
+      "path": "/_haproxy_health_check",
+  {{#marathon-lb.bind-http-https}}
+      "portIndex": 2,
+  {{/marathon-lb.bind-http-https}}
+  {{^marathon-lb.bind-http-https}}
+      "portIndex": 0,
+  {{/marathon-lb.bind-http-https}}
+      "protocol": "HTTP",
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": {{marathon-lb.minimumHealthCapacity}},
+    "maximumOverCapacity": {{marathon-lb.maximumOverCapacity}}
+  },
+  "args":[
+    "sse",
+    "-m", "{{marathon-lb.marathon-uri}}",
+    "--health-check",
+  {{^marathon-lb.bind-http-https}}
+    "--dont-bind-http-https",
+  {{/marathon-lb.bind-http-https}}
+    "--group", "{{marathon-lb.haproxy-group}}"
+  ],
+  "requirePorts":true,
+  {{#marathon-lb.template-url}}
+  "uris": [ "{{marathon-lb.template-url}}" ],
+  {{/marathon-lb.template-url}}
+  "env": {
+    "FRAMEWORK_NAME": "{{marathon-lb.framework-name}}",
+    "HAPROXY_SSL_CERT": "{{marathon-lb.ssl-cert}}",
+    "HAPROXY_SYSCTL_PARAMS": "{{marathon-lb.sysctl-params}}"
+  },
+  "ports": [
+  {{#marathon-lb.bind-http-https}}
+    80,
+    443,
+  {{/marathon-lb.bind-http-https}}
+    9090,
+    9091,
+    10000,
+    10001,
+    10002,
+    10003,
+    10004,
+    10005,
+    10006,
+    10007,
+    10008,
+    10009,
+    10010,
+    10011,
+    10012,
+    10013,
+    10014,
+    10015,
+    10016,
+    10017,
+    10018,
+    10019,
+    10020,
+    10021,
+    10022,
+    10023,
+    10024,
+    10025,
+    10026,
+    10027,
+    10028,
+    10029,
+    10030,
+    10031,
+    10032,
+    10033,
+    10034,
+    10035,
+    10036,
+    10037,
+    10038,
+    10039,
+    10040,
+    10041,
+    10042,
+    10043,
+    10044,
+    10045,
+    10046,
+    10047,
+    10048,
+    10049,
+    10050,
+    10051,
+    10052,
+    10053,
+    10054,
+    10055,
+    10056,
+    10057,
+    10058,
+    10059,
+    10060,
+    10061,
+    10062,
+    10063,
+    10064,
+    10065,
+    10066,
+    10067,
+    10068,
+    10069,
+    10070,
+    10071,
+    10072,
+    10073,
+    10074,
+    10075,
+    10076,
+    10077,
+    10078,
+    10079,
+    10080,
+    10081,
+    10082,
+    10083,
+    10084,
+    10085,
+    10086,
+    10087,
+    10088,
+    10089,
+    10090,
+    10091,
+    10092,
+    10093,
+    10094,
+    10095,
+    10096,
+    10097,
+    10098,
+    10099,
+    10100
+  ]
+}

--- a/repo/packages/M/marathon-lb/2/package.json
+++ b/repo/packages/M/marathon-lb/2/package.json
@@ -1,0 +1,22 @@
+{
+  "packagingVersion": "2.0",
+  "name": "marathon-lb",
+  "version": "0.0.4-0.1",
+  "scm": "https://github.com/mesosphere/marathon-lb",
+  "description": "HAProxy configured using Marathon state",
+  "maintainer": "support@mesosphere.io",
+  "tags": ["loadbalancer", "service-discovery", "reverse-proxy", "proxy", "haproxy"],
+  "preInstallNotes": "We recommend a minimum of 0.5 CPUs and 256 MB of RAM available for the Marathon-LB DCOS Service.",
+  "postInstallNotes": "Mesosphere-LB DCOS Service has been successfully installed!\nSee https://github.com/mesosphere/marathon-lb for documentation.",
+  "postUninstallNotes": "Mesosphere-LB DCOS Service has been uninstalled and will no longer run.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/mesosphere/marathon/blob/master/LICENSE"
+    },
+    {
+      "name": "GNU General Public License version 2",
+      "url": "http://www.haproxy.org/download/1.6/doc/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/M/marathon-lb/2/resource.json
+++ b/repo/packages/M/marathon-lb/2/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/marathon/assets/icon-service-marathon-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "marathon-lb-docker": "mesosphere/marathon-lb:v1.1.3"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The previous package preInstallNotes were confusing:
```
➜  universe-private git:(velocity-jenkins-url-sunil) ✗ dcos package install --options=marathon-lb.json marathon-lb
We recommend a minimum of 0.5 CPUs and 256 MB of RAM available for the Marathon Service.
Continue installing? [yes/no] yes
Installing Marathon app for package [marathon-lb] version [0.0.4-0.1]
Mesosphere-LB DCOS Service has been successfully installed!
See https://github.com/mesosphere/marathon-lb for documentation.
```

This PR changes `Marathon Service` to `Marathon-LB DCOS Service` for consistency!