### PR TITLE
bump docker image to mesosphere/etcd-mesos:0.1.3

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -95,7 +95,7 @@
       }
     },
     {
-      "currentVersion":"0.0.2",
+      "currentVersion":"0.0.3",
       "description":"A distributed consistent key-value store for shared configuration and service discovery.",
       "framework":true,
       "name":"etcd",
@@ -106,7 +106,8 @@
         "consensus"
       ],
       "versions":{
-        "0.0.2":"0"
+        "0.0.2":"0",
+        "0.0.3":"1"
       }
     },
     {

--- a/repo/packages/E/etcd/1/config.json
+++ b/repo/packages/E/etcd/1/config.json
@@ -1,0 +1,117 @@
+{
+  "properties": {
+    "etcd": {
+      "description": "etcd specific configuration properties",
+      "properties": {
+        "dns-suffix": {
+          "default": ".marathon.mesos",
+          "description": "This value is appended to the framework-name value to form the canonical DNS name for the etcd components.",
+          "type": "string",
+          "pattern": "^(?:\\.[a-z][a-z0-9]*?(?:-[a-z0-9]+)*)+$"
+        },
+        "framework-name": {
+          "default": "etcd",
+          "description": "The framework name to register with Mesos.",
+          "type": "string",
+          "pattern": "^/?(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$"
+        },
+        "admin-port": {
+          "default": "$PORT0",
+          "description": "Admin port that the etcd framework listens on.",
+          "type": "string"
+        },
+        "cpus": {
+          "default": 0.2,
+          "description": "CPU shares to allocate to the etcd framework.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem": {
+          "default": 128.0,
+          "description": "Memory (MB) to allocate to the etcd framework.",
+          "minimum": 32.0,
+          "type": "number"
+        },
+        "reseed-timeout": {
+          "default": 240,
+          "description": "The reseed-timeout in seconds.",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "auto-reseed": {
+          "default": true,
+          "description": "Enable auto reseeding of the etcd cluster.",
+          "type": "boolean"
+        },
+        "cpu-limit": {
+          "default": 1,
+          "description": "The CPU shares for each etcd instance.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem-limit": {
+          "default": 2048,
+          "description": "Memory limit (MB) for each etcd instance.",
+          "minimum": 32,
+          "type": "integer"
+        },
+        "disk-limit": {
+          "default": 4096,
+          "description": "Disk limit (MB) for each etcd instance.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cluster-size": {
+          "default": 3,
+          "description": "The number of nodes in the etcd cluster.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "logging-verbosity": {
+          "default": 1,
+          "description": "Increase this value to obtain more detailed log messages.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "zk": {
+          "default": "zk://master.mesos:2181/etcd",
+          "description": "The URL of Zookeeper to be used to persist etcd framework data. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/zk, including the trailing path.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "dns-suffix",
+        "framework-name",
+        "admin-port",
+        "cpus",
+        "mem",
+        "reseed-timeout",
+        "auto-reseed",
+        "cpu-limit",
+        "mem-limit",
+        "disk-limit",
+        "cluster-size",
+        "logging-verbosity",
+        "zk"
+      ],
+      "type": "object"
+    },
+    "mesos": {
+      "description": "Mesos specific configuration properties",
+      "properties": {
+        "master": {
+          "default": "zk://master.mesos:2181/mesos",
+          "description": "The URL of the Mesos master. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard host:port patterns, like localhost:5050 or 10.0.0.5:5050,10.0.0.6:5050, are also acceptable.",
+          "type": "string"
+        }
+      },
+      "required": ["master"],
+      "type": "object"
+    }
+  },
+  "required": [
+    "etcd",
+    "mesos"
+  ],
+  "type": "object"
+}

--- a/repo/packages/E/etcd/1/marathon.json.mustache
+++ b/repo/packages/E/etcd/1/marathon.json.mustache
@@ -1,0 +1,41 @@
+{
+    "id": "{{etcd.framework-name}}",
+    "container": {
+        "docker": {
+            "image": "{{resource.assets.container.docker.etcd-docker}}",
+            "network": "HOST",
+            "forcePullImage": true
+        },
+        "type": "DOCKER",
+        "volumes": []
+    },
+    "args": [],
+    "cpus": {{etcd.cpus}},
+    "mem": {{etcd.mem}},
+    "instances": 1,
+    "ports": [0, 0, 0],
+    "env": {
+      "FRAMEWORK_NAME":"{{etcd.framework-name}}",
+      "CLUSTER_SIZE":"{{etcd.cluster-size}}",
+      "MESOS_MASTER":"{{mesos.master}}",
+      "ZK_PERSIST":"{{etcd.zk}}",
+      "VERBOSITY":"{{etcd.logging-verbosity}}",
+      "AUTO_RESEED":"{{etcd.auto-reseed}}",
+      "RESEED_TIMEOUT":"{{etcd.reseed-timeout}}",
+      "DISK_LIMIT":"{{etcd.disk-limit}}",
+      "CPU_LIMIT":"{{etcd.cpu-limit}}",
+      "MEM_LIMIT":"{{etcd.mem-limit}}",
+      "WEBURI": "http://{{etcd.framework-name}}{{etcd.dns-suffix}}:{{etcd.admin-port}}/stats"
+    },
+    "healthChecks": [{
+      "protocol": "HTTP",
+      "path": "/healthz",
+      "portIndex": 0,
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }],
+  "labels": {
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{etcd.framework-name}}"
+  }
+}

--- a/repo/packages/E/etcd/1/package.json
+++ b/repo/packages/E/etcd/1/package.json
@@ -1,0 +1,12 @@
+{
+  "packagingVersion": "2.0",
+  "name": "etcd",
+  "version": "0.0.3",
+  "scm": "https://github.com/mesosphere/etcd-mesos",
+  "maintainer": "support@mesosphere.io",
+  "description": "A distributed consistent key-value store for shared configuration and service discovery.",
+  "framework": true,
+  "tags": ["mesosphere", "framework", "consensus"],
+  "preInstallNotes": "In order for etcd to start successfully all resources must be available in the cluster including ports, CPU shares and RAM.\nWe recommend a minimum of 3 nodes with 1 CPU share and 128 MB of RAM available for use by the etcd service.\nNote that the service is alpha and there may be bugs, including possible data loss, incomplete features, incorrect documentation or other discrepancies.",
+  "postInstallNotes": "Once the cluster initializes (<1 minute if offers are available), etcd proxies may connect by passing the argument -discovery-srv=etcd.mesos (or -discovery-srv=<framework-name>.mesos if you're not using the default), and you may discover live members by querying SRV records for _etcd-server._tcp.<framework-name>.mesos"
+}

--- a/repo/packages/E/etcd/1/resource.json
+++ b/repo/packages/E/etcd/1/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-etcd-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-etcd-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-etcd-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "etcd-docker": "mesosphere/etcd-mesos:0.1.3"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Changes in this release:
* support for mesos-0.26+ (including updated mesos-go bindings)
* scheduler driver listener address defaults to `$LIBPROCESS_IP`
* increased default offer refusal interval tom 5s to 15s