### PR TITLE
Minor Calico Updates

### DIFF
--- a/repo/packages/C/calico/0/package.json
+++ b/repo/packages/C/calico/0/package.json
@@ -6,7 +6,8 @@
   "description": "Calico networking for DCOS.  Calico provides IP-per-task functionality with rich policy.  This framework optionally installs Docker multi-host networking (required for Calico with the Docker containerizer) and Agent network hooks with netmodules (required for Calico with Unified tasks).  Both installations will cause temporary restarts of an Agent causing transient task loss.  The number of agents restarted at the same time is configurable and defaults to a single concurrent restart.  At the moment, only a limited set of DCOS versions and OSes are supported - check the documentation for details.  The framework will still run on unsupported versions, in which case the Agent network hooks will not be installed and Calico networking will only be available with the Docker containerizer.",
   "scm": "https://github.com/projectcalico/calico-containers.git",
   "website": "https://projectcalico.org",
-  "postInstallNotes": "Run through the Calico with DCOS guide available at https://github.com/projectcalico/calico-containers.git",
+  "preInstallNotes": "Before installing Calico, ensure the DCOS etcd package is installed. Note: this scheduler makes permament changes to all Agents in the cluster. Calico Networking for DCOS is currently in alpha.",
+  "postInstallNotes": "Calico services are now running on your cluster. Follow the Calico DCOS guide available at https://github.com/projectcalico/calico-containers/blob/master/docs/mesos/DCOS.md",
   "maintainer": "rob@projectcalico.org",
   "licenses": [
     {

--- a/repo/packages/C/calico/0/resource.json
+++ b/repo/packages/C/calico/0/resource.json
@@ -8,13 +8,13 @@
     "container": {
       "docker": {
         "calico-dcos": "calico/calico-dcos:v0.1.0",
-        "calico-node": "calico/node:v0.18.0",
+        "calico-node": "calico/node:v0.19.0",
         "calico-libnetwork": "calico/node-libnetwork:v0.8.0"
       }
     },
     "uris": {
       "etcd": "https://github.com/coreos/etcd/releases/download/v2.3.1/etcd-v2.3.1-linux-amd64.tar.gz",
-      "calicoctl": "https://github.com/projectcalico/calico-containers/releases/download/v0.18.0/calicoctl",
+      "calicoctl": "https://github.com/projectcalico/calico-containers/releases/download/v0.19.0/calicoctl",
       "calico-installer": "https://github.com/projectcalico/calico-mesos/releases/download/v0.1.5/installer",
       "calico-mesos-plugin": "https://github.com/projectcalico/calico-mesos/releases/download/v0.1.5/calico_mesos",
       "netmodules-libraries": "https://github.com/projectcalico/calico-mesos/releases/download/v0.1.5/netmodules.tar.gz"


### PR DESCRIPTION
This package includes a calico node version bump which includes better support for past docker versions.