### PR TITLE
Fixing docker image reference.

### DIFF
--- a/repo/packages/H/hue/0/marathon.json.mustache
+++ b/repo/packages/H/hue/0/marathon.json.mustache
@@ -3,7 +3,7 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "resource.assets.container.docker.hue-docker",
+            "image": "{{resource.assets.container.docker.hue-docker}}",
             "network": "BRIDGE",
             "portMappings": [
                 {


### PR DESCRIPTION
Fixes this error caused by using resource path instead of actual docker image. 

```
State
TASK_FAILED
Message
Failed to launch container: Failed to 'docker -H unix:///var/run/docker.sock pull resource.assets.container.docker.hue-docker:latest': exit status = exited with status 1 stderr = Error: image library/resource.assets.container.docker.hue-docker:latest not found
```
