### PR TITLE
bump linkerd and namerd packages for 0.4.0 release

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -240,7 +240,7 @@
       }
     },
     {
-      "currentVersion":"0.3.1-0.1",
+      "currentVersion":"0.4.0-0.1",
       "description":"A dynamic linker for microservices.",
       "framework":false,
       "name":"linkerd",
@@ -256,7 +256,8 @@
         "rpc"
       ],
       "versions":{
-        "0.3.1-0.1":"0"
+        "0.3.1-0.1":"0",
+        "0.4.0-0.1":"1"
       }
     },
     {
@@ -341,7 +342,7 @@
       }
     },
     {
-      "currentVersion":"0.3.1-0.1",
+      "currentVersion":"0.4.0-0.1",
       "description":"A service for managing name delegation for microservices.",
       "framework":false,
       "name":"namerd",
@@ -357,7 +358,8 @@
         "rpc"
       ],
       "versions":{
-        "0.3.1-0.1":"0"
+        "0.3.1-0.1":"0",
+        "0.4.0-0.1":"1"
       }
     },
     {

--- a/repo/packages/L/linkerd/1/config.json
+++ b/repo/packages/L/linkerd/1/config.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "required": ["linkerd"],
+  "properties": {
+    "linkerd": {
+      "type": "object",
+      "required": ["admin-port", "config-filename", "config-uri", "cpus", "instances", "mem", "name", "routing-port"],
+      "properties": {
+        "admin-port": {
+          "default": 9990,
+          "description": "Admin port. Provides an administrative UI for this instance.",
+          "type": "integer"
+        },
+        "config-filename": {
+          "default": "linkerd-dcos.yaml",
+          "description": "URI of linkerd config file, appends to config-uri. See https://linkerd.io for config docs.",
+          "type": "string"
+        },
+        "config-uri": {
+          "default": "https://s3.amazonaws.com/buoyant-dcos",
+          "description": "URI of linkerd config file, prepends to config-filename.",
+          "type": "string"
+        },
+        "cpus": {
+          "default": 0.25,
+          "description": "CPU shares to allocate to each linkerd instance.",
+          "minimum": 0.25,
+          "type": "number"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "mem": {
+          "default": 256.0,
+          "description": "Memory (MB) to allocate to each linkerd task.",
+          "minimum": 256.0,
+          "type": "number"
+        },
+        "name": {
+          "default": "linkerd",
+          "description": "Name for linkerd instance(s).",
+          "type": "string"
+        },
+        "routing-port": {
+          "default": 4140,
+          "description": "Routing port.",
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/L/linkerd/1/marathon.json.mustache
+++ b/repo/packages/L/linkerd/1/marathon.json.mustache
@@ -1,0 +1,54 @@
+{
+  "id": "{{linkerd.name}}",
+  "instances": {{linkerd.instances}},
+  "cpus": {{linkerd.cpus}},
+  "mem": {{linkerd.mem}},
+  "acceptedResourceRoles": ["*", "slave_public"],
+  "constraints": [["hostname", "UNIQUE"]],
+  "maintainer": "hello@buoyant.io",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.linkerd-docker}}",
+      "network": "BRIDGE",
+      "privileged": true,
+      "portMappings": [
+        {
+          "containerPort": {{linkerd.admin-port}},
+          "hostPort": {{linkerd.admin-port}},
+          "servicePort": 0,
+          "protocol": "tcp"
+        },
+        {
+          "containerPort": {{linkerd.routing-port}},
+          "hostPort": {{linkerd.routing-port}},
+          "servicePort": 0,
+          "protocol": "tcp"
+        }
+      ]
+    }
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/admin/ping"
+    }
+  ],
+  "args": [
+    "/mnt/mesos/sandbox/{{linkerd.config-filename}}"
+  ],
+  "requirePorts":true,
+  "ports": [
+    {{linkerd.admin-port}},
+    {{linkerd.routing-port}}
+  ],
+  "uris": [
+    "{{linkerd.config-uri}}/{{linkerd.config-filename}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{linkerd.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/L/linkerd/1/package.json
+++ b/repo/packages/L/linkerd/1/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "2.0",
+  "name": "linkerd",
+  "version": "0.4.0-0.1",
+  "scm": "https://github.com/BuoyantIO/linkerd/",
+  "description": "A dynamic linker for microservices.",
+  "maintainer": "hello@buoyant.io",
+  "website": "https://linkerd.io",
+  "tags": ["linkerd", "namerd", "buoyant", "loadbalancer", "service-discovery", "proxy", "microservices", "rpc"],
+  "preInstallNotes": "We recommend a minimum of 0.25 CPUs and 256 MB of RAM available for linkerd. We also recommend running linkerd on every host, and connecting to it via $HOST:4140. To ensure this, set instances to the number of nodes in your cluster.",
+  "postInstallNotes": "linkerd DCOS Service has been successfully installed!\nSee https://linkerd.io for documentation.",
+  "postUninstallNotes": "linkerd DCOS Service has been uninstalled and will no longer run.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/BuoyantIO/linkerd/blob/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/L/linkerd/1/resource.json
+++ b/repo/packages/L/linkerd/1/resource.json
@@ -1,0 +1,17 @@
+{
+  "images": {
+    "icon-small": "https://linkerd.io/images/dcos/linkerd-logo-small.png",
+    "icon-medium": "https://linkerd.io/images/dcos/linkerd-logo-medium.png",
+    "icon-large": "https://linkerd.io/images/dcos/linkerd-logo-large.png",
+    "screenshots": [
+      "https://linkerd.io/images/dcos/linkerd-screenshot.png"
+    ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "linkerd-docker": "buoyantio/linkerd:0.4.0"
+      }
+    }
+  }
+}

--- a/repo/packages/N/namerd/1/config.json
+++ b/repo/packages/N/namerd/1/config.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "required": ["namerd"],
+  "properties": {
+    "namerd": {
+      "type": "object",
+      "required": ["admin-port", "config-filename", "config-uri", "cpus", "http-port", "instances", "mem", "name", "resource-role", "thrift-port"],
+      "properties": {
+        "admin-port": {
+          "default": 9001,
+          "description": "Admin port. Provides an administrative UI for this instance.",
+          "type": "integer"
+        },
+        "config-filename": {
+          "default": "namerd-dcos.yaml",
+          "description": "URI of namerd config file, appends to config-uri. See https://linkerd.io for config docs.",
+          "type": "string"
+        },
+        "config-uri": {
+          "default": "https://s3.amazonaws.com/buoyant-dcos",
+          "description": "URI of namerd config file, prepends to config-filename.",
+          "type": "string"
+        },
+        "cpus": {
+          "default": 0.25,
+          "description": "CPU shares to allocate to each namerd instance.",
+          "minimum": 0.25,
+          "type": "number"
+        },
+        "http-port": {
+          "default": 4180,
+          "description": "httpController port. Provides a REST interface to add/update dtabs.",
+          "type": "integer"
+        },
+        "instances": {
+          "default": 3,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "mem": {
+          "default": 256.0,
+          "description": "Memory (MB) to allocate to each namerd task.",
+          "minimum": 256.0,
+          "type": "number"
+        },
+        "name": {
+          "default": "namerd",
+          "description": "Name for namerd instance(s).",
+          "type": "string"
+        },
+        "resource-role": {
+          "default": "*",
+          "description": "The accepted resource roles (e.g. slave_public). By default, this will deploy to any agents with the * role.",
+          "type": "string"
+        },
+        "thrift-port": {
+          "default": 4100,
+          "description": "thriftNameInterpreter port. namerd serves name data to linkerd on this port.",
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/N/namerd/1/marathon.json.mustache
+++ b/repo/packages/N/namerd/1/marathon.json.mustache
@@ -1,0 +1,61 @@
+{
+  "id": "{{namerd.name}}",
+  "instances": {{namerd.instances}},
+  "cpus": {{namerd.cpus}},
+  "mem": {{namerd.mem}},
+  "acceptedResourceRoles": [ "{{namerd.resource-role}}" ],
+  "constraints": [["hostname", "UNIQUE"]],
+  "maintainer": "hello@buoyant.io",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.namerd-docker}}",
+      "network": "BRIDGE",
+      "privileged": true,
+      "portMappings": [
+        {
+          "containerPort": {{namerd.admin-port}},
+          "hostPort": {{namerd.admin-port}},
+          "servicePort": 0,
+          "protocol": "tcp"
+        },
+        {
+          "containerPort": {{namerd.http-port}},
+          "hostPort": {{namerd.http-port}},
+          "servicePort": 0,
+          "protocol": "tcp"
+        },
+        {
+          "containerPort": {{namerd.thrift-port}},
+          "hostPort": {{namerd.thrift-port}},
+          "servicePort": 0,
+          "protocol": "tcp"
+        }
+      ]
+    }
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/admin/ping"
+    }
+  ],
+  "args": [
+    "/mnt/mesos/sandbox/{{namerd.config-filename}}"
+  ],
+  "requirePorts":true,
+  "ports": [
+    {{namerd.admin-port}},
+    {{namerd.http-port}},
+    {{namerd.thrift-port}}
+  ],
+  "uris": [
+    "{{namerd.config-uri}}/{{namerd.config-filename}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{namerd.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/N/namerd/1/package.json
+++ b/repo/packages/N/namerd/1/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "2.0",
+  "name": "namerd",
+  "version": "0.4.0-0.1",
+  "scm": "https://github.com/BuoyantIO/linkerd/",
+  "description": "A service for managing name delegation for microservices.",
+  "maintainer": "hello@buoyant.io",
+  "website": "https://linkerd.io",
+  "tags": ["linkerd", "namerd", "buoyant", "loadbalancer", "service-discovery", "proxy", "microservices", "rpc"],
+  "preInstallNotes": "We recommend a minimum of 0.25 CPUs and 256 MB of RAM available for namerd.",
+  "postInstallNotes": "namerd DCOS Service has been successfully installed!\nSee https://linkerd.io for documentation.",
+  "postUninstallNotes": "namerd DCOS Service has been uninstalled and will no longer run.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/BuoyantIO/linkerd/blob/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/N/namerd/1/resource.json
+++ b/repo/packages/N/namerd/1/resource.json
@@ -1,0 +1,17 @@
+{
+  "images": {
+    "icon-small": "https://linkerd.io/images/dcos/linkerd-logo-small.png",
+    "icon-medium": "https://linkerd.io/images/dcos/linkerd-logo-medium.png",
+    "icon-large": "https://linkerd.io/images/dcos/linkerd-logo-large.png",
+    "screenshots": [
+      "https://linkerd.io/images/dcos/linkerd-screenshot.png"
+    ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "namerd-docker": "buoyantio/namerd:0.4.0-dcos"
+      }
+    }
+  }
+}


### PR DESCRIPTION
linkerd and namerd 0.4.0 were released yesterday: https://github.com/BuoyantIO/linkerd/releases/tag/0.4.0

this change bumps both DC/OS packages to 0.4.0