### PR TITLE
Update schemas to enforce the difference between v2.0 packages and v3.0 packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ The required fields are:
 - maintainer
 - description
 
+###### `.minDcosReleaseVersion`
+
+Introduced in version-3.x, the Universe now supports the ability for packages to define a
+minimum version of DC/OS their package is compatible with. See [DC/OS Release Versions](https://mesosphere.com/releases/)
+for a list of DC/OS Releases and valid values for `.minDcosReleaseVersion`.
+
+The new property `.minDcosReleaseVersion` can be specified for packages adhering to the
+`.packagingVersion` `3.0` schema.
+
+When `.minDcosReleaseVersion` is specified the package will only be made available to DC/OS
+clusters with a DC/OS Release Version greater than or equal to (`>=`) the value specified.
+
+
 #### `config.json`
 
 This file describes the configuration properties supported by the package. Each property can

--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -1,94 +1,206 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "packagingVersion": {
-      "type": "string",
-      "enum": ["2.0", "3.0"]
-    },
-    "name": {
-      "type": "string"
-    },
-    "version": {
-      "type": "string"
-    },
-    "scm": {
-      "type": "string"
-    },
-    "maintainer": {
-      "type": "string"
-    },
-    "website": {
-      "type": "string"
-    },
-    "description": {
-      "type": "string"
-    },
-    "framework": {
-      "type": "boolean",
-      "default": false,
-      "description": "True if this package installs a new Mesos framework."
-    },
-    "preInstallNotes": {
-      "type": "string",
-      "description": "Pre installation notes that would be useful to the user of this package."
-    },
-    "postInstallNotes": {
-      "type": "string",
-      "description": "Post installation notes that would be useful to the user of this package."
-    },
-    "postUninstallNotes": {
-      "type": "string",
-      "description": "Post uninstallation notes that would be useful to the user of this package."
-    },
-    "tags": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "pattern": "^[^\\s]+$"
-      }
-    },
-    "selected": {
-      "type": "boolean",
-      "description": "Flag indicating if the package is selected in search results",
-      "default": false
-    },
-    "licenses": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name of the license. For example one of [Apache License Version 2.0 | MIT License | BSD License | Proprietary]"
-          },
-          "url": {
-            "type": "string",
-            "pattern": "((?<=\\()[A-Za-z][A-Za-z0-9\\+\\.\\-]*:([A-Za-z0-9\\.\\-_~:/\\?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=]|%[A-Fa-f0-9]{2})+(?=\\)))|([A-Za-z][A-Za-z0-9\\+\\.\\-]*:([A-Za-z0-9\\.\\-_~:/\\?#\\[\\]@!\\$&'\\(\\)\\*\\+,;=]|%[A-Fa-f0-9]{2})+)",
-            "description": "The URL where the license can be accessed"
-          }
-        },
-        "additionalProperties": false,
-        "required": [
-          "name",
-          "url"
-        ]
-      }
-    },
-    "minDcosReleaseVersion": {
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "definitions": {
+
+    "dcosReleaseVersion": {
       "type": "string",
       "pattern": "^(?:0|[1-9][0-9]*)(?:\\.(?:0|[1-9][0-9]*))*$",
-      "description": "The minimum DC/OS Release Version the package can run on."
+      "description": "A string representation of a DC/OS Release Version"
+    },
+
+    "url": {
+      "type": "string",
+      "allOf": [
+        { "format": "uri" },
+        { "pattern": "^https?://" }
+      ]
+    },
+
+
+    "v20Package": {
+      "properties": {
+        "packagingVersion": {
+          "type": "string",
+          "enum": ["2.0"]
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "scm": {
+          "type": "string"
+        },
+        "maintainer": {
+          "type": "string"
+        },
+        "website": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "framework": {
+          "type": "boolean",
+          "default": false,
+          "description": "True if this package installs a new Mesos framework."
+        },
+        "preInstallNotes": {
+          "type": "string",
+          "description": "Pre installation notes that would be useful to the user of this package."
+        },
+        "postInstallNotes": {
+          "type": "string",
+          "description": "Post installation notes that would be useful to the user of this package."
+        },
+        "postUninstallNotes": {
+          "type": "string",
+          "description": "Post uninstallation notes that would be useful to the user of this package."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[^\\s]+$"
+          }
+        },
+        "selected": {
+          "type": "boolean",
+          "description": "Flag indicating if the package is selected in search results",
+          "default": false
+        },
+        "licenses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the license. For example one of [Apache License Version 2.0 | MIT License | BSD License | Proprietary]"
+              },
+              "url": {
+                "$ref": "#/definitions/url",
+                "description": "The URL where the license can be accessed"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "url"
+            ]
+          }
+        }
+      },
+      "required": [
+        "packagingVersion",
+        "name",
+        "version",
+        "maintainer",
+        "description",
+        "tags"
+      ],
+      "additionalProperties": false
+    },
+
+    "v30Package": {
+      "properties": {
+        "packagingVersion": {
+          "type": "string",
+          "enum": ["3.0"]
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "scm": {
+          "type": "string"
+        },
+        "maintainer": {
+          "type": "string"
+        },
+        "website": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "framework": {
+          "type": "boolean",
+          "default": false,
+          "description": "True if this package installs a new Mesos framework."
+        },
+        "preInstallNotes": {
+          "type": "string",
+          "description": "Pre installation notes that would be useful to the user of this package."
+        },
+        "postInstallNotes": {
+          "type": "string",
+          "description": "Post installation notes that would be useful to the user of this package."
+        },
+        "postUninstallNotes": {
+          "type": "string",
+          "description": "Post uninstallation notes that would be useful to the user of this package."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[^\\s]+$"
+          }
+        },
+        "selected": {
+          "type": "boolean",
+          "description": "Flag indicating if the package is selected in search results",
+          "default": false
+        },
+        "licenses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the license. For example one of [Apache License Version 2.0 | MIT License | BSD License | Proprietary]"
+              },
+              "url": {
+                "$ref": "#/definitions/url",
+                "description": "The URL where the license can be accessed"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "url"
+            ]
+          }
+        },
+        "minDcosReleaseVersion": {
+          "$ref": "#/definitions/dcosReleaseVersion",
+          "description": "The minimum DC/OS Release Version the package can run on."
+        }
+      },
+      "required": [
+        "packagingVersion",
+        "name",
+        "version",
+        "maintainer",
+        "description",
+        "tags"
+      ],
+      "additionalProperties": false
     }
+
   },
-  "required": [
-    "packagingVersion",
-    "name",
-    "version",
-    "maintainer",
-    "description",
-    "tags"
-  ],
-  "additionalProperties": false
+
+  "type": "object",
+  "oneOf": [
+    { "$ref": "#/definitions/v20Package" },
+    { "$ref": "#/definitions/v30Package" }
+  ]
+
 }
 

--- a/repo/meta/schema/v3-repo-schema.json
+++ b/repo/meta/schema/v3-repo-schema.json
@@ -110,12 +110,113 @@
 
 
 
-    "package": {
-      "type": "object",
+    "v20Package": {
       "properties": {
         "packagingVersion": {
           "type": "string",
-          "enum": ["2.0", "3.0"]
+          "enum": ["2.0"]
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "releaseVersion": {
+          "type": "integer",
+          "description": "Corresponds to the revision index from the universe directory structure",
+          "minimum": 0
+        },
+        "scm": {
+          "type": "string"
+        },
+        "maintainer": {
+          "type": "string"
+        },
+        "website": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "framework": {
+          "type": "boolean",
+          "default": false,
+          "description": "True if this package installs a new Mesos framework."
+        },
+        "preInstallNotes": {
+          "type": "string",
+          "description": "Pre installation notes that would be useful to the user of this package."
+        },
+        "postInstallNotes": {
+          "type": "string",
+          "description": "Post installation notes that would be useful to the user of this package."
+        },
+        "postUninstallNotes": {
+          "type": "string",
+          "description": "Post uninstallation notes that would be useful to the user of this package."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[^\\s]+$"
+          }
+        },
+        "selected": {
+          "type": "boolean",
+          "description": "Flag indicating if the package is selected in search results",
+          "default": false
+        },
+        "licenses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the license. For example one of [Apache License Version 2.0 | MIT License | BSD License | Proprietary]"
+              },
+              "url": {
+                "$ref": "#/definitions/url"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "url"
+            ]
+          }
+        },
+        "marathon": {
+          "$ref": "#/definitions/marathon"
+        },
+        "resource": {
+          "$ref": "#/definitions/resource"
+        },
+        "config": {
+          "$ref": "#/definitions/config"
+        },
+        "pip": {
+          "$ref": "#/definitions/pip"
+        }
+      },
+      "required": [
+        "packagingVersion",
+        "name",
+        "version",
+        "maintainer",
+        "description",
+        "tags"
+      ],
+      "additionalProperties": false
+    },
+
+    "v30Package": {
+      "properties": {
+        "packagingVersion": {
+          "type": "string",
+          "enum": ["3.0"]
         },
         "name": {
           "type": "string"
@@ -228,7 +329,10 @@
       "type": "array",
       "description": "The list of packages in the repo",
       "items": {
-        "$ref": "#/definitions/package"
+        "oneOf": [
+          { "$ref": "#/definitions/v20Package" },
+          { "$ref": "#/definitions/v30Package" }
+        ]
       }
     }
   },


### PR DESCRIPTION
If a package publisher wants to take advantage of v3.0 package features they will have to set the `packagingVersion` to `3.0` in their package.json