### PR TITLE
Update marathon.json to use port 8085

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,13 @@ package in a running DC/OS cluster.
 
   ```
   dcos marathon app add target/marathon.json
-  dcos package repo add dev-universe http://universe.marathon.mesos/repo
+  dcos package repo add --index=0 dev-universe http://universe.marathon.mesos:8085/repo
   ```
 
   Alternatively, all Pull Requests opened for Universe will have their docker image build and published
-  to DockerHub.  Check the status reports os the Pull Request for a link to the docker image build, in
-  the artifacts of the build you can find the `marathon.json` capable of running the universe server.
+  to DockerHub.  Click the details of the "Universe Server Docker image" status report of the Pull Request.
+  In the artifacts tab of the build results you can find `docker/server/marathon.json` which can be used
+  to run the universe server in your cluster.
 
 The pre-commit hook will run [build.sh](scripts/build.sh) before allowing you to commit. This
 script validates your package definitions.

--- a/docker/server/marathon.json
+++ b/docker/server/marathon.json
@@ -3,13 +3,19 @@
   "instances": 1,
   "cpus": 0.25,
   "mem": 128,
-  "ports": [80, 443],
   "requirePorts": true,
   "container": {
     "type": "DOCKER",
     "docker": {
-      "network": "HOST",
-      "image": "mesosphere/universe-server:$tag"
+      "network": "BRIDGE",
+      "image": "mesosphere/universe-server:$tag",
+      "portMappings": [
+        {
+          "containerPort": 80,
+          "hostPort": 8085,
+          "protocol": "tcp"
+        }
+      ]
     },
     "volumes": []
   },
@@ -19,7 +25,7 @@
       "intervalSeconds": 30,
       "maxConsecutiveFailures": 3,
       "path": "/repo-empty-v3.json",
-      "portIndex": 1,
+      "portIndex": 0,
       "protocol": "HTTP",
       "timeoutSeconds": 5
     }


### PR DESCRIPTION
DC/OS Private Agents don't (by default) have 80 and 443 in their defined port resources, so marathon will never get a resources offer that can be used to run the universe server container.