### PR TITLE
OGC Preview web application

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -401,6 +401,21 @@
       }
     },
     {
+      "currentVersion":"0.10.76",
+      "description":"Discover, browse and export data from OGC service layers exposed by way of WMS/WFS service interfaces, with a special focus given to time-enabled data.",
+      "framework":true,
+      "name":"ogc-preview",
+      "selected":false,
+      "tags":[
+        "long-running",
+        "ogc",
+        "apache"
+      ],
+      "versions":{
+        "0.10.76":"0"
+      }
+    },
+    {
       "currentVersion":"0.0.0-0.1",
       "description":"Your private path to access network resources and services securely: Server service",
       "framework":false,

--- a/repo/packages/O/ogc-preview/0/config.json
+++ b/repo/packages/O/ogc-preview/0/config.json
@@ -1,0 +1,54 @@
+{
+	"type": "object",
+	"description": "OGC Preview Service properties",
+	"properties": {
+		"ogc-preview": {
+			"description": "OGC Preview configuration properties.",
+			"properties": {
+				"framework-name": {
+					"type": "string",
+					"description": "Mesos Framework Name",
+					"default": "ogc-preview"
+				},
+				"haproxy-vhost": {
+					"type": "string",
+					"description": "External address for access to the OGC Preview server. This should be added as an A entry in your DNS.",
+					"default": "ogcpreview.marathon.mesos"
+				},
+				"config-dir": {
+					"type": "string",
+					"description": "Host location containing OGC Preview configuration over-rides (announcements.json, opConfig.js, etc.). This setting should be left blank unless custom settings are required."
+				}
+			},
+			"required": [
+				"framework-name",
+				"haproxy-vhost"
+			],
+			"type": "object"
+		},
+		"geoserver": {
+			"description": "Settings used to connect Apache reverse proxy entries to backing GeoServer.",
+			"properties": {
+				"hostname": {
+					"type": "string",
+					"description": "Cluster internal addressable location of backing GeoServer. Defaults to the marathon-lb hostname to route to service port in a clustered GeoServer configuration.",
+					"default": "marathon-lb.marathon.mesos"
+				},
+        "port": {
+					"type": "integer",
+					"description": "Service port of the GeoServer instance.",
+					"default": 8080
+				}
+			},
+			"required": [
+				"hostname",
+				"port"
+			],
+			"type": "object"
+		}
+	},
+	"required": [
+		"ogc-preview",
+		"geoserver"
+	]
+}

--- a/repo/packages/O/ogc-preview/0/marathon.json.mustache
+++ b/repo/packages/O/ogc-preview/0/marathon.json.mustache
@@ -1,0 +1,46 @@
+{
+	"id": "{{ogc-preview.framework-name}}",
+	"cpus": 0.5,
+	"mem": 16,
+	"instances": 1,
+	"container": {
+		"type": "DOCKER",
+		"docker": {
+			"image": "{{resource.assets.container.docker.ogc-preview}}",
+			"network": "BRIDGE",
+			"portMappings": [{
+				"containerPort": 80,
+				"hostPort": 0,
+				"servicePort": 0,
+				"protocol": "tcp"
+			}],
+			{{#ogc-preview.config-dir}}
+			"volumes": [{
+				"containerPath": "/usr/local/apache2/htdocs/config",
+				"hostPath": "{{ogc-preview.config-dir}}",
+				"mode": "RO"
+			}],
+			{{/ogc-preview.config-dir}}
+			"forcePullImage": true
+		}
+	},
+	"healthChecks": [{
+		"path": "/",
+		"portIndex": 0,
+		"protocol": "HTTP",
+		"gracePeriodSeconds": 30,
+		"intervalSeconds": 30,
+		"maxConsecutiveFailures": 3,
+		"timeoutSeconds": 10
+	}],
+	"env": {
+		"GEOSERVER_HOSTNAME": "{{geoserver.hostname}}",
+		"GEOSERVER_PORT": "{{geoserver.port}}"
+	},
+	"labels": {
+		"HAPROXY_GROUP": "external",
+		"DCOS_PACKAGE_FRAMEWORK_NAME": "{{ogc-preview.framework-name}}",
+		"HAPROXY_0_VHOST": "{{ogc-preview.haproxy-vhost}}",
+		"HAPROXY_0_PORT": "80"
+	}
+}

--- a/repo/packages/O/ogc-preview/0/package.json
+++ b/repo/packages/O/ogc-preview/0/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion" : "2.0",
+  "name" : "ogc-preview",
+  "version" : "0.10.76",
+  "scm" : "https://github.com/AppliedIS/ogc-preview",
+  "maintainer" : "dcos-support@appliedis.com",
+  "description" : "Discover, browse and export data from OGC service layers exposed by way of WMS/WFS service interfaces, with a special focus given to time-enabled data.",
+  "framework" : true,
+  "licenses" : [ {
+    "name" : "Apache License Version 2.0",
+    "url" : "https://raw.githubusercontent.com/AppliedIS/ogc-preview/master/LICENSE"
+  } ],
+  "tags" : [ "long-running", "ogc", "apache" ],
+  "preInstallNotes" : "This package expects an addressable GeoServer running within DCOS. If it is hosted elsewhere, simply update the geoserver hostname and port to the appropriate location.",
+  "postInstallNotes" : "OGC Preview has been successfully installed!\nTo access on the VHOST specified, you must have marathon-lb installed.",
+  "postUninstallNotes" : "OGC Preview has been uninstalled and will no longer run.",
+  "selected" : false
+}

--- a/repo/packages/O/ogc-preview/0/resource.json
+++ b/repo/packages/O/ogc-preview/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "images" : {
+    "icon-small" : "https://raw.githubusercontent.com/AppliedIS/universe-assets/master/ogc-preview/icon-small-ogc-preview.png",
+    "icon-medium" : "https://raw.githubusercontent.com/AppliedIS/universe-assets/master/ogc-preview/icon-medium-ogc-preview.png",
+    "icon-large" : "https://raw.githubusercontent.com/AppliedIS/universe-assets/master/ogc-preview/icon-large-ogc-preview.png"
+  },
+  "assets" : {
+    "container" : {
+      "docker" : {
+        "ogc-preview" : "appliedis/ogc-preview:0.10.76"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Discover, browse and export data from OGC service layers exposed by way of WMS/WFS service interfaces, with a special focus given to time-enabled data. Defaults to using an existing install of the GeoServer package in a previous pull request. Install settings can be provided to point app at an externally hosted GeoServer, as well.