### PR TITLE
PostGres single-node package.

### DIFF
--- a/repo/meta/index.json
+++ b/repo/meta/index.json
@@ -429,6 +429,22 @@
       }
     },
     {
+      "currentVersion":"9.5-2.2",
+      "description":"DCOS implementation of single-node Postgres 9.5 database server with PostGIS 2.2 extension support and pgtune configuration optimization.",
+      "framework":true,
+      "name":"postgres",
+      "selected":false,
+      "tags":[
+        "postgres",
+        "postgresql",
+        "postgis",
+        "database"
+      ],
+      "versions":{
+        "9.5-2.2":"0"
+      }
+    },
+    {
       "currentVersion":"1.2.1",
       "description":"Quobyte is a software defined and fault tolerant distributed file system running on commodity hardware.",
       "framework":true,

--- a/repo/packages/P/postgres/0/config.json
+++ b/repo/packages/P/postgres/0/config.json
@@ -1,0 +1,51 @@
+{
+  "properties":{
+    "postgres":{
+      "description":"Postgres specific configuration properties",
+      "properties":{
+        "framework-name":{
+          "default":"postgres",
+          "description":"The framework name.",
+          "type":"string"
+        },
+        "postgres-password":{
+          "default": "dcospostgres",
+          "description":"Password for postgres superuser. This should be changed! Defaults to dcospostgres.",
+          "type":"string"
+        },
+        "port":{
+          "default": 5432,
+          "description":"The port number of the database server. Defaults to 5432.",
+          "type":"integer"
+        },
+        "memory-mb":{
+          "default": 512,
+          "description":"The amount of memory allocated for the database server in MB. Defaults to 512MB.",
+          "type":"integer"
+        },
+        "connections":{
+          "default": 200,
+          "description":"Number of connections allowed concurrently open. Defaults to 200.",
+          "type":"integer"
+        },
+        "host-data-volume":{
+          "default": "/var/lib/postgres",
+          "description": "Location on slave node of Postgres data directory. For cluster wide persistence this should be a network shared volume and allow ownership to postgres:postgres (995:995). Defaults to /var/lib/postgres.",
+          "type":"string"
+        }
+      },
+      "required":[
+        "framework-name",
+        "postgres-password",
+        "port",
+        "memory-mb",
+        "connections",
+        "host-data-volume"
+      ],
+      "type":"object"
+    }
+  },
+  "required":[
+    "postgres"
+  ]
+}

--- a/repo/packages/P/postgres/0/marathon.json.mustache
+++ b/repo/packages/P/postgres/0/marathon.json.mustache
@@ -1,0 +1,47 @@
+{
+  "id": "{{postgres.framework-name}}",
+  "cpus": 1,
+  "mem": {{postgres.memory-mb}},
+  "instances": 1,
+  "constraints": [["hostname", "UNIQUE"]],
+  "healthChecks": [
+    {
+      "gracePeriodSeconds": 30,
+      "intervalSeconds": 30,
+      "maxConsecutiveFailures": 0,
+      "portIndex": 0,
+      "protocol": "TCP",
+      "timeoutSeconds": 5
+    }
+  ],
+  "env": {
+    "POSTGRES_PASSWORD": "{{postgres.postgres-password}}",
+    "INSTANCE_MEMORY": "{{postgres.memory-mb}}",
+    "CONNECTIONS": "{{postgres.connections}}",
+    "FORCE_PGTUNE": "false"
+  },
+  "container": {
+    "type": "DOCKER",
+    "volumes": [
+      {
+        "containerPath": "/var/lib/postgresql/data",
+        "hostPath": "{{postgres.host-data-volume}}",
+        "mode": "RW"
+      }
+    ],
+    "docker": {
+      "image": "{{resource.assets.container.docker.postgis}}",
+			"network": "BRIDGE",
+			"portMappings": [{
+				"containerPort": 5432,
+				"hostPort": {{postgres.port}},
+				"servicePort": {{postgres.port}},
+				"protocol": "tcp"
+			}],
+      "forcePullImage": true
+    }
+  },
+  "labels": {
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{postgres.framework-name}}"
+  }
+}

--- a/repo/packages/P/postgres/0/package.json
+++ b/repo/packages/P/postgres/0/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "2.0",
+  "name": "postgres",
+  "version": "9.5-2.2",
+  "tags": ["postgres", "postgresql", "postgis", "database"],
+  "framework": true,
+  "maintainer": "dcos-support@appliedis.com",
+  "description": "DCOS implementation of single-node Postgres 9.5 database server with PostGIS 2.2 extension support and pgtune configuration optimization.",
+  "scm": "https://github.com/AppliedIS/dockerfiles/tree/master/postgis/9.5-2.2",
+  "website": "https://github.com/AppliedIS/dockerfiles",
+  "preInstallNotes":"This DCOS implementation of Postgres is not intended for production workloads as it does not have any support for failover or persistent volumes. It should not be scaled past a single instance as doing so has the potential to corrupt the Postgres data directory.",
+  "postInstallNotes": "Postgres is in the process of starting up and will be accessible within the cluster shortly.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/mesos/elasticsearch/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/P/postgres/0/resource.json
+++ b/repo/packages/P/postgres/0/resource.json
@@ -1,0 +1,15 @@
+{
+  "images": {
+    "icon-small": "https://raw.githubusercontent.com/AppliedIS/universe-assets/master/postgres/icon-small-postgres.png",
+    "icon-medium": "https://raw.githubusercontent.com/AppliedIS/universe-assets/master/postgres/icon-medium-postgres.png",
+    "icon-large": "https://raw.githubusercontent.com/AppliedIS/universe-assets/master/postgres/icon-large-postgres.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "postgres": "appliedis/postgres:9.5",
+        "postgis": "appliedis/postgis:9.5-2.2"
+      }
+    }
+  }
+}


### PR DESCRIPTION
PostGres package running PostGres 9.5 with PostGIS 2.2 extensions in DCOS in a single-node layout. Future release will support DB replication to allow for multiple read-replicas.