### PR TITLE
[WIP] Added authn parameters for Spark.

### DIFF
--- a/repo/packages/S/spark/12/config.json
+++ b/repo/packages/S/spark/12/config.json
@@ -190,11 +190,6 @@
                             "description": "File containing DCOS service-account credential.",
                             "type": "string"
                         },
-                        "mesos_credential": {
-                            "default": "{\"principal\": \"mesos_agent\", \"secret\": \"dcos_spark\"}",
-                            "description": "Mesos credentials. The secret is not used.",
-                            "type": "string"
-                        },
                         "ssl_files_dir": {
                             "default": "/run/dcos/pki",
                             "description": "Directory containing SSL-related files.",

--- a/repo/packages/S/spark/12/config.json
+++ b/repo/packages/S/spark/12/config.json
@@ -194,7 +194,22 @@
                             "default": "{\"principal\": \"mesos_agent\", \"secret\": \"dcos_spark\"}",
                             "description": "Mesos credentials. The secret is not used.",
                             "type": "string"
-                        }
+                        },
+                        "ssl_cert_file": {
+                            "default": "/run/dcos/pki/tls/certs/mesos-slave.crt",
+                            "description": "Path to SSL cert file on the host.",
+                            "type": "string"
+                         },
+                         "ssl_key_file": {
+                              "default": "/run/dcos/pki/tls/private/mesos-slave.key",
+                              "description": "Path to SSL key file on the host.",
+                              "type": "string"
+                         },
+                         "ssl_ca_dir": {
+                              "default": "/run/dcos/pki/certs",
+                              "description": "Path to SSL CA directory on the host.",
+                              "type": "string"
+                         }
                     },
                     "type": "object"
                 }

--- a/repo/packages/S/spark/12/config.json
+++ b/repo/packages/S/spark/12/config.json
@@ -165,7 +165,7 @@
                             "description": "Set to true to enable authentication.",
                             "type": "boolean"
                         },
-                        "service_authentication_credential_path": {
+                        "service_account_secret_name": {
                             "default": "",
                             "description": "Path to a service-account credential in the secret store. Only needed when DC/OS service authentication is enabled.",
                             "type": "string"

--- a/repo/packages/S/spark/12/config.json
+++ b/repo/packages/S/spark/12/config.json
@@ -195,6 +195,11 @@
                             "description": "Mesos credentials. The secret is not used.",
                             "type": "string"
                         },
+                        "ssl_files_dir": {
+                            "default": "/run/dcos/pki",
+                            "description": "Directory containing SSL-related files.",
+                            "type": "string"
+                         },
                         "ssl_cert_file": {
                             "default": "/run/dcos/pki/tls/certs/mesos-slave.crt",
                             "description": "Path to SSL cert file on the host.",

--- a/repo/packages/S/spark/12/config.json
+++ b/repo/packages/S/spark/12/config.json
@@ -156,6 +156,47 @@
                             "type": "string"
                         }
                     }
+                },
+                "authn": {
+                    "description": "Spark authentication configuration properties",
+                    "properties": {
+                        "enabled": {
+                            "default": false,
+                            "description": "Set to true to enable authentication.",
+                            "type": "boolean"
+                        },
+                        "opt_mesosphere_dir": {
+                            "default": "/opt/mesosphere",
+                            "description": "Volume to mount in docker for modules.",
+                            "type": "string"
+                        },
+                        "dcos_service_account_credential_dir": {
+                            "default": "/run/dcos/etc/agent",
+                            "description": "Volume to mount in docker for service-account credential.",
+                            "type": "string"
+                        },
+                        "module_json": {
+                            "default": "file:///opt/mesosphere/etc/mesos-scheduler-modules/dcos_authenticatee_module.json",
+                            "description": "JSON file describing the module within the module_dir.",
+                            "type": "string"
+                        },
+                        "module_name": {
+                            "default": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+                            "description": "Authenticatee module name.",
+                            "type": "string"
+                        },
+                        "dcos_service_account_credential_json": {
+                            "default": "file:///run/dcos/etc/agent/service_account.json",
+                            "description": "File containing DCOS service-account credential.",
+                            "type": "string"
+                        },
+                        "mesos_credential": {
+                            "default": "{\"principal\": \"mesos_agent\", \"secret\": \"dcos_spark\"}",
+                            "description": "Mesos credentials. The secret is not used.",
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
                 }
             }
         },

--- a/repo/packages/S/spark/12/config.json
+++ b/repo/packages/S/spark/12/config.json
@@ -165,11 +165,6 @@
                             "description": "Set to true to enable authentication.",
                             "type": "boolean"
                         },
-                        "opt_mesosphere_dir": {
-                            "default": "/opt/mesosphere",
-                            "description": "Volume to mount in docker for modules.",
-                            "type": "string"
-                        },
                         "dcos_service_account_credential_dir": {
                             "default": "/run/dcos/etc/mesos",
                             "description": "Volume to mount in docker for service-account credential.",

--- a/repo/packages/S/spark/12/config.json
+++ b/repo/packages/S/spark/12/config.json
@@ -175,16 +175,6 @@
                             "description": "Volume to mount in docker for service-account credential.",
                             "type": "string"
                         },
-                        "module_json": {
-                            "default": "file:///opt/mesosphere/etc/mesos-scheduler-modules/dcos_authenticatee_module.json",
-                            "description": "JSON file describing the module within the module_dir.",
-                            "type": "string"
-                        },
-                        "module_name": {
-                            "default": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
-                            "description": "Authenticatee module name.",
-                            "type": "string"
-                        },
                         "dcos_service_account_credential_json": {
                             "default": "file:///run/dcos/etc/mesos/agent_service_account.json",
                             "description": "File containing DCOS service-account credential.",

--- a/repo/packages/S/spark/12/config.json
+++ b/repo/packages/S/spark/12/config.json
@@ -171,7 +171,7 @@
                             "type": "string"
                         },
                         "dcos_service_account_credential_dir": {
-                            "default": "/run/dcos/etc/agent",
+                            "default": "/run/dcos/etc/mesos",
                             "description": "Volume to mount in docker for service-account credential.",
                             "type": "string"
                         },
@@ -186,7 +186,7 @@
                             "type": "string"
                         },
                         "dcos_service_account_credential_json": {
-                            "default": "file:///run/dcos/etc/agent/service_account.json",
+                            "default": "file:///run/dcos/etc/mesos/agent_service_account.json",
                             "description": "File containing DCOS service-account credential.",
                             "type": "string"
                         },

--- a/repo/packages/S/spark/12/config.json
+++ b/repo/packages/S/spark/12/config.json
@@ -165,14 +165,9 @@
                             "description": "Set to true to enable authentication.",
                             "type": "boolean"
                         },
-                        "dcos_service_account_credential_dir": {
-                            "default": "/run/dcos/etc/mesos",
-                            "description": "Volume to mount in docker for service-account credential.",
-                            "type": "string"
-                        },
-                        "dcos_service_account_credential_json": {
-                            "default": "file:///run/dcos/etc/mesos/agent_service_account.json",
-                            "description": "File containing DCOS service-account credential.",
+                        "service_authentication_credential_path": {
+                            "default": "",
+                            "description": "Path to a service-account credential in the secret store. Only needed when DC/OS service authentication is enabled.",
                             "type": "string"
                         },
                         "ssl_files_dir": {

--- a/repo/packages/S/spark/12/marathon.json.mustache
+++ b/repo/packages/S/spark/12/marathon.json.mustache
@@ -28,6 +28,10 @@
         "MESOS_MODULES": "{{security.authn.module_json}}",
         "MESOS_AUTHENTICATEE": "{{security.authn.module_name}}",
         "MESOS_CREDENTIAL": "{{security.authn.mesos_credential}}",
+        "SSL_CERT_FILE": "{{authn.ssl_cert_file}}",
+        "SSL_KEY_FILE": "{{authn.ssl_key_file}}",
+        "SSL_CA_DIR": "{{authn.ssl_ca_dir}}",
+        "SSL_ENABLED": "true",
 {{/security.authn.enabled}}
         "ENABLE_HISTORY_SERVER": "{{history-server.enabled}}",
         "HISTORY_LOG_DIR": "{{history-server.log-dir}}",

--- a/repo/packages/S/spark/12/marathon.json.mustache
+++ b/repo/packages/S/spark/12/marathon.json.mustache
@@ -23,6 +23,12 @@
         "SPARK_SSL_PROTOCOL": "{{security.ssl.protocol}}",
         "SPARK_SSL_ENABLEDALGORITHMS": "{{security.ssl.enabledAlgorithms}}",
 {{/security.ssl.enabled}}
+{{#security.authn.enabled}}
+        "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "{{security.authn.dcos_service_account_credential_json}}",
+        "MESOS_MODULES": "{{security.authn.module_json}}",
+        "MESOS_AUTHENTICATEE": "{{security.authn.module_name}}",
+        "MESOS_CREDENTIAL": "{{security.authn.mesos_credential}}",
+{{/security.authn.enabled}}
         "ENABLE_HISTORY_SERVER": "{{history-server.enabled}}",
         "HISTORY_LOG_DIR": "{{history-server.log-dir}}",
         "HISTORY_CLEANER_ENABLED": "{{history-server.cleaner-enabled}}",
@@ -39,6 +45,20 @@
     ],
     "container": {
         "type": "DOCKER",
+{{#security.authn.enabled}}
+        "volumes": [
+            {
+                "containerPath": "{{security.authn.opt_mesosphere_dir}}",
+                "hostPath": "{{security.authn.opt_mesosphere_dir}}",
+                "mode": "RO"
+            },
+            {
+              "containerPath": "{{security.authn.dcos_service_account_credential_dir}}",
+              "hostPath": "{{security.authn.dcos_service_account_credential_dir}}",
+              "mode": "RO"
+            }
+        ],
+{{/security.authn.enabled}}
         "docker": {
             "image": "{{resource.assets.container.docker.spark_docker}}",
             "network": "HOST",

--- a/repo/packages/S/spark/12/marathon.json.mustache
+++ b/repo/packages/S/spark/12/marathon.json.mustache
@@ -6,7 +6,7 @@
 {{#security.authn.enabled}}
     "secrets": {
         "serviceCredential": {
-            "source": "{{security.authn.service_authentication_credential_path}}"
+            "source": "{{security.authn.service_account_secret_name}}"
       }
     },
 {{/security.authn.enabled}}

--- a/repo/packages/S/spark/12/marathon.json.mustache
+++ b/repo/packages/S/spark/12/marathon.json.mustache
@@ -28,9 +28,9 @@
         "MESOS_MODULES": "{{security.authn.module_json}}",
         "MESOS_AUTHENTICATEE": "{{security.authn.module_name}}",
         "MESOS_CREDENTIAL": "{{security.authn.mesos_credential}}",
-        "SSL_CERT_FILE": "{{authn.ssl_cert_file}}",
-        "SSL_KEY_FILE": "{{authn.ssl_key_file}}",
-        "SSL_CA_DIR": "{{authn.ssl_ca_dir}}",
+        "SSL_CERT_FILE": "{{security.authn.ssl_cert_file}}",
+        "SSL_KEY_FILE": "{{security.authn.ssl_key_file}}",
+        "SSL_CA_DIR": "{{security.authn.ssl_ca_dir}}",
         "SSL_ENABLED": "true",
 {{/security.authn.enabled}}
         "ENABLE_HISTORY_SERVER": "{{history-server.enabled}}",

--- a/repo/packages/S/spark/12/marathon.json.mustache
+++ b/repo/packages/S/spark/12/marathon.json.mustache
@@ -31,7 +31,7 @@
         "SPARK_SSL_ENABLEDALGORITHMS": "{{security.ssl.enabledAlgorithms}}",
 {{/security.ssl.enabled}}
 {{#security.authn.enabled}}
-        "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "{ \"secret\": \"serviceCredential\" }",
+        "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
         "MESOS_MODULES": "file:///opt/mesosphere/etc/mesos-scheduler-modules/dcos_authenticatee_module.json",
         "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
         "SSL_CERT_FILE": "{{security.authn.ssl_cert_file}}",

--- a/repo/packages/S/spark/12/marathon.json.mustache
+++ b/repo/packages/S/spark/12/marathon.json.mustache
@@ -27,7 +27,6 @@
         "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "{{security.authn.dcos_service_account_credential_json}}",
         "MESOS_MODULES": "{{security.authn.module_json}}",
         "MESOS_AUTHENTICATEE": "{{security.authn.module_name}}",
-        "MESOS_CREDENTIAL": "{{security.authn.mesos_credential}}",
         "SSL_CERT_FILE": "{{security.authn.ssl_cert_file}}",
         "SSL_KEY_FILE": "{{security.authn.ssl_key_file}}",
         "SSL_CA_DIR": "{{security.authn.ssl_ca_dir}}",

--- a/repo/packages/S/spark/12/marathon.json.mustache
+++ b/repo/packages/S/spark/12/marathon.json.mustache
@@ -25,8 +25,8 @@
 {{/security.ssl.enabled}}
 {{#security.authn.enabled}}
         "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "{{security.authn.dcos_service_account_credential_json}}",
-        "MESOS_MODULES": "{{security.authn.module_json}}",
-        "MESOS_AUTHENTICATEE": "{{security.authn.module_name}}",
+        "MESOS_MODULES": "file:///opt/mesosphere/etc/mesos-scheduler-modules/dcos_authenticatee_module.json",
+        "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
         "SSL_CERT_FILE": "{{security.authn.ssl_cert_file}}",
         "SSL_KEY_FILE": "{{security.authn.ssl_key_file}}",
         "SSL_CA_DIR": "{{security.authn.ssl_ca_dir}}",

--- a/repo/packages/S/spark/12/marathon.json.mustache
+++ b/repo/packages/S/spark/12/marathon.json.mustache
@@ -56,8 +56,8 @@
                 "mode": "RO"
             },
             {
-                "containerPath": "{{security.authn.opt_mesosphere_dir}}",
-                "hostPath": "{{security.authn.opt_mesosphere_dir}}",
+                "containerPath": "/opt/mesosphere",
+                "hostPath": "/opt/mesosphere",
                 "mode": "RO"
             },
             {

--- a/repo/packages/S/spark/12/marathon.json.mustache
+++ b/repo/packages/S/spark/12/marathon.json.mustache
@@ -3,6 +3,13 @@
     "cpus": {{service.cpus}},
     "mem": {{service.mem}},
     "cmd": "/sbin/init.sh",
+{{#authn.enabled}}
+    "secrets": {
+        "serviceCredential": {
+            "source": "{{authn.service_authentication_credential_path}}"
+      }
+    },
+{{/authn.enabled}}
     "env": {
         "DCOS_SERVICE_NAME": "{{service.name}}",
         "SPARK_HDFS_CONFIG_URL": "{{hdfs.config-url}}",
@@ -24,7 +31,7 @@
         "SPARK_SSL_ENABLEDALGORITHMS": "{{security.ssl.enabledAlgorithms}}",
 {{/security.ssl.enabled}}
 {{#security.authn.enabled}}
-        "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "{{security.authn.dcos_service_account_credential_json}}",
+        "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "{ \"secret\": \"serviceCredential\" }",
         "MESOS_MODULES": "file:///opt/mesosphere/etc/mesos-scheduler-modules/dcos_authenticatee_module.json",
         "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
         "SSL_CERT_FILE": "{{security.authn.ssl_cert_file}}",
@@ -59,11 +66,6 @@
                 "containerPath": "/opt/mesosphere",
                 "hostPath": "/opt/mesosphere",
                 "mode": "RO"
-            },
-            {
-              "containerPath": "{{security.authn.dcos_service_account_credential_dir}}",
-              "hostPath": "{{security.authn.dcos_service_account_credential_dir}}",
-              "mode": "RO"
             }
         ],
 {{/security.authn.enabled}}

--- a/repo/packages/S/spark/12/marathon.json.mustache
+++ b/repo/packages/S/spark/12/marathon.json.mustache
@@ -52,6 +52,11 @@
 {{#security.authn.enabled}}
         "volumes": [
             {
+                "containerPath": "{{security.authn.ssl_files_dir}}",
+                "hostPath": "{{security.authn.ssl_files_dir}}",
+                "mode": "RO"
+            },
+            {
                 "containerPath": "{{security.authn.opt_mesosphere_dir}}",
                 "hostPath": "{{security.authn.opt_mesosphere_dir}}",
                 "mode": "RO"

--- a/repo/packages/S/spark/12/marathon.json.mustache
+++ b/repo/packages/S/spark/12/marathon.json.mustache
@@ -3,13 +3,13 @@
     "cpus": {{service.cpus}},
     "mem": {{service.mem}},
     "cmd": "/sbin/init.sh",
-{{#authn.enabled}}
+{{#security.authn.enabled}}
     "secrets": {
         "serviceCredential": {
-            "source": "{{authn.service_authentication_credential_path}}"
+            "source": "{{security.authn.service_authentication_credential_path}}"
       }
     },
-{{/authn.enabled}}
+{{/security.authn.enabled}}
     "env": {
         "DCOS_SERVICE_NAME": "{{service.name}}",
         "SPARK_HDFS_CONFIG_URL": "{{hdfs.config-url}}",

--- a/repo/packages/S/spark/12/resource.json
+++ b/repo/packages/S/spark/12/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "spark_docker": "mesosphere/spark:1.0.0-1.6.1-2"
+        "spark_docker": "mesosphere/spark:spark-1.6.1-2-mesos-1.0.0-rc1"
       }
     }
   },


### PR DESCRIPTION
**[NOTE]: BUMP SPARK VERSION NUMBER BEFORE MERGE!**

Usage:
1. Create a new secret named `sparkSecret` from the contents of `agent_service_account.json` from the live cluster.
2. When launching Spark, specify `sparkSecret` in the `service_account_secret_name` field and set principal to `dcos_mesos_agent`.
