### PR TITLE
dcos-tunnel: Add dcos-tunnel package

### DIFF
--- a/repo/packages/T/tunnel-cli/0/package.json
+++ b/repo/packages/T/tunnel-cli/0/package.json
@@ -1,0 +1,9 @@
+{
+  "packagingVersion": "3.0",
+  "name": "tunnel-cli",
+  "version": "0.1.0",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.8",
+  "description": "Proxy and VPN access to your DC/OS cluster",
+  "tags": [ "mesosphere", "subcommand", "proxy", "vpn", "socks", "http", "cli" ]
+}

--- a/repo/packages/T/tunnel-cli/0/resource.json
+++ b/repo/packages/T/tunnel-cli/0/resource.json
@@ -1,0 +1,30 @@
+{
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "dcf28d22aae40b8ba5788ffaaee06581b530b112b8160e741d47327ef083edb0"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.1.0/dcos-tunnel.zip"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "c70c6d505075ed1976e74c171c4a0982fec38a9b1426f8cf519d1b5ed78a7408"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.1.0/dcos-tunnel.zip"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a DC/OS CLI only package that provides (in this initial version)
SOCKS proxy, HTTP proxy, and VPN access to a DC/OS cluster through the
DC/OS CLI.