### PR TITLE
New version of Datadog package to monitor Mesos

### DIFF
--- a/repo/packages/D/datadog/1/config.json
+++ b/repo/packages/D/datadog/1/config.json
@@ -1,0 +1,54 @@
+{
+    "properties": {
+        "datadog": {
+            "description": "Datadog specific configuration properties",
+            "properties": {
+                "api_key": {
+                    "description": "Your Datadog API key.",
+                    "type": "string"
+                },
+                "app_id": {
+                    "default": "datadog-agent",
+                    "description": "Marathon Application ID",
+                    "type": "string"
+                },
+                "cpus": {
+                    "default": 0.05,
+                    "description": "CPU shares to allocate to each Marathon instance.",
+                    "minimum": 0.0,
+                    "type": "number"
+                },
+                "instances": {
+                    "default": 1,
+                    "description": "Number of Marathon instances to run.",
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "mem": {
+                    "default": 128.0,
+                    "description": "Memory (MB) to allocate to each Marathon task.",
+                    "minimum": 128.0,
+                    "type": "number"
+                },
+                "statsd_port": {
+                    "default": 8125,
+                    "description": "statsD port",
+                    "type": "integer"
+                },
+                "supervisor_port": {
+                    "default": 9001,
+                    "description": "Agent supervisord port",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "api_key"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "datadog"
+    ],
+    "type": "object"
+}

--- a/repo/packages/D/datadog/1/marathon.json.mustache
+++ b/repo/packages/D/datadog/1/marathon.json.mustache
@@ -1,0 +1,62 @@
+{
+    "id": "{{datadog.app_id}}",
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.2d3be5bc32f6}}",
+            "parameters": [
+                {
+                    "key": "name", "value": "dd-agent"
+                },
+                {
+                    "key": "env", "value": "API_KEY={{datadog.api_key}}"
+                },
+                {
+                    "key": "env", "value": "MESOS_SLAVE=true"
+                }
+            ],
+            "network": "BRIDGE",
+            "portMappings": [
+                { "hostPort": {{datadog.statsd_port}}, "containerPort": 8125, "protocol": "udp" },
+                { "hostPort": {{datadog.supervisor_port}}, "containerPort": 9001, "protocol": "tcp" }
+            ]
+        },
+        "volumes": [
+            {
+                "containerPath": "/var/run/docker.sock",
+                "hostPath": "/var/run/docker.sock",
+                "mode": "RW"
+            },
+            {
+                "containerPath": "/host/proc",
+                "hostPath": "/proc",
+                "mode": "RO"
+            },
+            {
+                "containerPath": "/host/sys/fs/cgroup",
+                "hostPath": "/sys/fs/cgroup",
+                "mode": "RO"
+            }
+        ]
+    },
+    "cpus": {{datadog.cpus}},
+    "mem": {{datadog.mem}},
+    "instances": {{datadog.instances}},
+    "acceptedResourceRoles": ["slave_public", "*"],
+    "constraints": [
+        ["hostname", "UNIQUE"],
+        ["hostname", "GROUP_BY"]
+    ],
+    "healthChecks": [
+        {
+            "path": "/",
+            "portIndex": 1,
+            "protocol": "HTTP",
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "ignoreHttp1xx": false
+        }
+    ]
+}

--- a/repo/packages/D/datadog/1/package.json
+++ b/repo/packages/D/datadog/1/package.json
@@ -1,0 +1,23 @@
+{
+    "packagingVersion": "3.0",
+    "description": "Cloud-scale monitoring",
+    "framework": false,
+    "licenses": [
+        {
+            "name": "Simplified BSD license",
+            "url": "https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE"
+        }
+    ],
+    "maintainer": "package@datadoghq.com",
+    "name": "datadog",
+    "postInstallNotes": "Datadog on DCOS successfully installed.\nHead over to https://app.datadoghq.com to monitor your DCOS cluster.",
+    "postUninstallNotes": "Datadog on DCOS successfully uninstalled.\n.",
+    "preInstallNotes": "Pass your API key as a package option (datadog.api_key).\nAlso pass the number of Mesos slaves as an option (datadog.instances).\nMarathon will make sure that the Datadog Agent runs only once per slave.",
+    "scm": "https://github.com/datadog/dd-agent.git",
+    "tags": [
+        "datadog",
+        "monitoring"
+    ],
+    "version": "5.8.3",
+    "website": "http://www.datadog.com"
+}

--- a/repo/packages/D/datadog/1/resource.json
+++ b/repo/packages/D/datadog/1/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "2d3be5bc32f6": "datadog/docker-dd-agent:11.2.583"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-large.png"
+  }
+}


### PR DESCRIPTION
This new package is an update to the already existing [Datadog package](https://github.com/mesosphere/universe/tree/version-3.x/repo/packages/D/datadog/0). It upgrades to the latest version of our agent, uses `packagingVersion: 3.0` and collects more metrics.