### PR TITLE
darwin universe builds

### DIFF
--- a/docker/server/build.bash
+++ b/docker/server/build.bash
@@ -50,8 +50,17 @@ function gzipJsonFiles {(
     gzip -f "${f}"
     mv "${f}.tmp" "${f}"
 
-    sizeOrig=$(stat -c "%s" "${f}")
-    sizeGZip=$(stat -c "%s" "${f}.gz")
+    sizeOrig=0
+    sizeGZip=0
+
+    if [[ `uname` == 'Darwin' ]]; then
+      sizeOrig=$(stat -f "%z" "${f}")
+      sizeGZip=$(stat -f "%z" "${f}.gz")
+    else
+      sizeOrig=$(stat -c "%s" "${f}")
+      sizeGZip=$(stat -c "%s" "${f}.gz")
+    fi
+
     msg "GZipped $f [${sizeOrig} B -> ${sizeGZip} B]"
 
     if [ ${sizeOrig} -le ${sizeGZip} ]; then


### PR DESCRIPTION
now works on darwin and linux.  defaults to the assumed linux platform unless darwin is detected.

references for command equivancy:  
(linux) http://www.computerhope.com/unix/stat.htm and 
(darwin) https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/stat.1.html

