### PR TITLE
Updating Elasticsearch to scheduler 1.0.1

### DIFF
--- a/repo/packages/E/elasticsearch/1/config.json
+++ b/repo/packages/E/elasticsearch/1/config.json
@@ -1,0 +1,136 @@
+{
+  "properties":{
+    "mesos":{
+      "description":"Mesos specific configuration properties",
+      "properties":{
+        "master":{
+          "default":"zk://master.mesos:2181/mesos",
+          "description":"The URL of the Mesos master. This should point to the Mesos ZNode on the Zookeeper machine.",
+          "type":"string"
+        }
+      },
+      "required":[
+        "master"
+      ],
+      "type":"object"
+    },
+    "elasticsearch":{
+      "description":"Elasticsearch specific configuration properties",
+      "properties":{
+        "framework-name":{
+          "default":"elasticsearch",
+          "description":"The framework name.",
+          "type":"string"
+        },
+        "failover-timeout":{
+          "default":"2592000.0",
+          "description":"The time before Mesos kills a scheduler and tasks if it has not recovered (ms).",
+          "type":"string"
+        },
+        "zookeeper-mesos-timeout":{
+          "default":"20000",
+          "description":"The timeout for connecting to zookeeper for Mesos (ms).",
+          "type":"string"
+        },
+        "port":{
+          "default":"31105",
+          "description":"The port number of the ES-Mesos management front-end. Defaults to 8080.",
+          "type":"string"
+        },
+        "force-pull-image":{
+          "default":false,
+          "description":"Forces docker to re-pull the image.",
+          "type":"boolean"
+        },
+        "executor":{
+          "properties":{
+            "ram":{
+              "default":"2048",
+              "description":"The amount of ram that Mesos shall give give to the executors.",
+              "type":"string"
+            },
+            "cpu":{
+              "default":"1.0",
+              "description":"The amount of CPU resource to allocate to the elasticsearch instance.",
+              "type":"string"
+            },
+            "disk":{
+              "default":"1024",
+              "description":"The amount of Disk resource to allocate to the elasticsearch instance (MB).",
+              "type":"string"
+            },
+            "instances":{
+              "default":"3",
+              "description":"The number of elasticsearch nodes to be instantiated. It is recommended that you provide an odd number, to prevent split brain issues.",
+              "type":"string"
+            },
+            "cluster-name":{
+              "default":"mesos-ha",
+              "description":"Name of the elasticsearch cluster",
+              "type":"string"
+            },
+            "name":{
+              "default":"elasticsearch-executor",
+              "description":"The name given to the executor task.",
+              "type":"string"
+            }
+          },
+          "required":[
+            "ram",
+            "cpu",
+            "disk",
+            "instances",
+            "cluster-name",
+            "name"
+          ],
+          "type":"object"
+        },
+        "scheduler":{
+          "properties":{
+            "cpu":{
+              "default":"0.2",
+              "description":"The amount of CPU that Mesos shall allocate to the scheduler.",
+              "type":"string"
+            },
+            "ram":{
+              "default":"512",
+              "description":"The amount of RAM that Mesos shall allocate to the scheduler.",
+              "type":"string"
+            },
+            "instances":{
+              "default":"1",
+              "description":"The number of scheduler instances.",
+              "type":"string"
+            },
+            "java-heap":{
+              "default":"-Xms128m -Xmx256m",
+              "description":"The java heap space environmental variables to pass to the scheduler",
+              "type":"string"
+            }
+          },
+          "required":[
+            "cpu",
+            "ram",
+            "instances",
+            "java-heap"
+          ],
+          "type":"object"
+        }
+      },
+      "required":[
+        "framework-name",
+        "failover-timeout",
+        "zookeeper-mesos-timeout",
+        "port",
+        "force-pull-image",
+        "executor",
+        "scheduler"
+      ],
+      "type":"object"
+    }
+  },
+  "required":[
+    "mesos",
+    "elasticsearch"
+  ]
+}

--- a/repo/packages/E/elasticsearch/1/marathon.json.mustache
+++ b/repo/packages/E/elasticsearch/1/marathon.json.mustache
@@ -1,0 +1,53 @@
+{
+  "id": "{{elasticsearch.framework-name}}",
+  "cpus": {{elasticsearch.scheduler.cpu}},
+  "mem": {{elasticsearch.scheduler.ram}},
+  "ports": [0],
+  "instances": {{elasticsearch.scheduler.instances}},
+  "healthChecks": [
+    {
+      "gracePeriodSeconds": 120,
+      "intervalSeconds": 30,
+      "maxConsecutiveFailures": 0,
+      "path": "/",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "timeoutSeconds": 5
+    }
+  ],
+  "args": [
+    "--zookeeperMesosUrl", "{{mesos.master}}",
+    "--zookeeperMesosTimeout", "{{elasticsearch.zookeeper-mesos-timeout}}",
+    "--webUiPort", "{{elasticsearch.port}}",
+    "--frameworkFailoverTimeout", "{{elasticsearch.failover-timeout}}",
+    "--frameworkName", "{{elasticsearch.framework-name}}",
+
+    "--elasticsearchNodes", "{{elasticsearch.executor.instances}}",
+    "--elasticsearchClusterName", "{{elasticsearch.executor.cluster-name}}",
+    "--elasticsearchCpu", "{{elasticsearch.executor.cpu}}",
+    "--elasticsearchDisk", "{{elasticsearch.executor.disk}}",
+    "--elasticsearchRam", "{{elasticsearch.executor.ram}}",
+    {{#elasticsearch.executor.settings-location}}
+    "--elasticsearchSettingsLocation", "{{elasticsearch.executor.settings-location}}",
+    {{/elasticsearch.executor.settings-location}}
+
+    "--executorForcePullImage", "{{elasticsearch.force-pull-image}}",
+    "--executorName", "{{elasticsearch.executor.name}}"
+  ],
+  "env": {
+    "JAVA_OPTS": "{{elasticsearch.scheduler.java-heap}}"
+  },
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.elasticsearch-scheduler}}",
+      "network": "HOST",
+      "forcePullImage": {{elasticsearch.force-pull-image}}
+    }
+  },
+  "ports": [{{elasticsearch.port}}],
+  "requirePorts": true,
+  "labels": {
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{elasticsearch.framework-name}}"
+  }
+}

--- a/repo/packages/E/elasticsearch/1/package.json
+++ b/repo/packages/E/elasticsearch/1/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "elasticsearch",
+  "version": "1.0.1",
+  "tags": ["elastic", "monitoring", "debug"],
+  "framework": true,
+  "maintainer": "pnw@trifork.com",
+  "description": "DCOS implementation of the Mesos-Elasticsearch framework",
+  "scm": "https://github.com/mesos/elasticsearch.git",
+  "website": "https://github.com/mesos/elasticsearch",
+  "preInstallNotes":"The ElasticSearch DCOS Service implementation is alpha and there may be bugs, incomplete features, incorrect documentation or other discrepancies.",
+  "postInstallNotes": "Elasticsearch is staging. Check Marathon and the ES management front-end for status.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/mesos/elasticsearch/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/E/elasticsearch/1/resource.json
+++ b/repo/packages/E/elasticsearch/1/resource.json
@@ -1,0 +1,13 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-elasticsearch-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-elasticsearch-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-elasticsearch-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "elasticsearch-scheduler": "mesos/elasticsearch-scheduler:1.0.1"      }
+    }
+  }
+}


### PR DESCRIPTION
This update removes the need for defining a discrete executor image and makes the settings location optional.  Moved to packagingVersion 3.0.