### PR TITLE
Add Confluent Platform components for DC/OS 1.8 release

### DIFF
--- a/repo/packages/C/confluent-connect/0/config.json
+++ b/repo/packages/C/confluent-connect/0/config.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "connect": {
+      "properties": {
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each connect worker instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 1024.0,
+          "description": "Memory (MB) to allocate to each connect worker task.",
+          "minimum": 256.0,
+          "type": "number"
+        },
+        "name": {
+          "default": "connect",
+          "description": "Name for this connect worker application",
+          "type": "string"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy connect worker only on nodes with this role.",
+          "type": "string"
+        },
+        "vip-label": {
+          "default": "8.0.8.3:8083",
+          "description": "Label for external access to connect workers. Format is <IP>:<port>",
+          "type": "string"
+        },
+        "bootstrap-servers": {
+          "default": "broker-0.confluent.mesos:9092",
+          "description": "Bootstrap servers for target Kafka cluster. Format is comma-separated list of <host>:<port>",
+
+          "type": "string"
+        },
+        "key-converter-schema-registry-url": {
+          "default": "http://8.0.8.1:8081",
+          "description": "Schema Registry service (for message keys). Format is http://<host>:<port>",
+
+          "type": "string"
+        },
+        "value-converter-schema-registry-url": {
+          "default": "http://8.0.8.1:8081",
+          "description": "Schema Registry service (for message data). Format is http://<host>:<port>",
+
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-connect/0/marathon.json.mustache
+++ b/repo/packages/C/confluent-connect/0/marathon.json.mustache
@@ -1,0 +1,51 @@
+{
+  "id": "/{{connect.name}}",
+  "instances": {{connect.instances}},
+  "cpus": {{connect.cpus}},
+  "mem": {{connect.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.connect-docker}}",
+	  "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [
+        {
+          "containerPort": 8083,
+          "hostPort": 0,
+          "servicePort": 18083,
+          "protocol": "tcp",
+          "labels": {
+            "VIP_0": "{{connect.vip-label}}"
+          }
+        }
+      ]
+    }
+  },
+  "env": {
+    "CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL": "{{connect.key-converter-schema-registry-url}}",
+    "CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL": "{{connect.value-converter-schema-registry-url}}",
+    "CONNECT_BOOTSTRAP_SERVERS": "{{connect.bootstrap-servers}}"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{connect.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{connect.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-connect/0/package.json
+++ b/repo/packages/C/confluent-connect/0/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion": "2.0",
+  "name": "confluent-connect",
+  "version": "0.9.0-3.0.0",
+  "scm": "https://github.com/confluentinc/connect",
+  "description": "confluent-connect package",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "connect"],
+  "preInstallNotes": "Preparing to install confluent-connect",
+  "postInstallNotes": "confluent-connect has been installed.",
+  "postUninstallNotes": "confluent-connect was uninstalled successfully.",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/connect/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-connect/0/resource.json
+++ b/repo/packages/C/confluent-connect/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "connect-docker": "dbtucker/connect:3.0.0"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}

--- a/repo/packages/C/confluent-connect/1/config.json
+++ b/repo/packages/C/confluent-connect/1/config.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "connect": {
+      "properties": {
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 2,
+          "description": "CPU shares to allocate to each connect worker instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 1024,
+          "description": "Memory (MB) to allocate to each connect worker instance.",
+          "minimum": 512,
+          "type": "number"
+        },
+        "heap": {
+          "default": 768,
+          "description": "JVM heap allocation (in MB) for connect worker task; should be ~256MB less than total memory for the instance.",
+          "minimum": 256,
+          "type": "number"
+        },
+        "name": {
+          "default": "connect",
+          "description": "Name for this connect worker application",
+          "type": "string"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy connect worker only on nodes with this role.",
+          "type": "string"
+        },
+        "vip-label": {
+          "default": "8.0.8.3:8083",
+          "description": "Label for external access to connect workers. Format is <IP>:<port>",
+          "type": "string"
+        },
+        "bootstrap-servers": {
+          "default": "broker-0.confluent.mesos:9092",
+          "description": "Bootstrap servers for target Kafka cluster. Format is comma-separated list of <host>:<port>",
+
+          "type": "string"
+        },
+        "zookeeper-connect": {
+          "default": "leader.mesos:2181/confluent",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        },
+        "key-converter-schema-registry-url": {
+          "default": "http://8.0.8.1:8081",
+          "description": "Schema Registry service (for message keys). Format is http://<host>:<port>",
+
+          "type": "string"
+        },
+        "value-converter-schema-registry-url": {
+          "default": "http://8.0.8.1:8081",
+          "description": "Schema Registry service (for message data). Format is http://<host>:<port>",
+
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-connect/1/config.json
+++ b/repo/packages/C/confluent-connect/1/config.json
@@ -43,7 +43,7 @@
           "type": "string"
         },
         "bootstrap-servers": {
-          "default": "broker-0.confluent.mesos:9092",
+          "default": "broker.confluent.l4lb.thisdcos.directory:9092",
           "description": "Bootstrap servers for target Kafka cluster. Format is comma-separated list of <host>:<port>",
 
           "type": "string"

--- a/repo/packages/C/confluent-connect/1/marathon.json.mustache
+++ b/repo/packages/C/confluent-connect/1/marathon.json.mustache
@@ -23,9 +23,6 @@
       ]
     }
   },
-  "uris": [
-    "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/docker.tar.gz"
-  ],
   "env": {
     "CONNECT_BOOTSTRAP_SERVERS": "{{connect.bootstrap-servers}}",
     "UNUSED_CONNECT_REST_PORT": "8083",

--- a/repo/packages/C/confluent-connect/1/marathon.json.mustache
+++ b/repo/packages/C/confluent-connect/1/marathon.json.mustache
@@ -1,0 +1,66 @@
+{
+  "id": "/{{connect.name}}",
+  "instances": {{connect.instances}},
+  "cpus": {{connect.cpus}},
+  "mem": {{connect.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.connect-docker}}",
+	  "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [
+        {
+          "containerPort": 8083,
+          "hostPort": 0,
+          "servicePort": 18083,
+          "protocol": "tcp",
+          "labels": {
+            "VIP_0": "{{connect.vip-label}}"
+          }
+        }
+      ]
+    }
+  },
+  "uris": [
+    "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/docker.tar.gz"
+  ],
+  "env": {
+    "CONNECT_BOOTSTRAP_SERVERS": "{{connect.bootstrap-servers}}",
+    "UNUSED_CONNECT_REST_PORT": "8083",
+    "CONNECT_GROUP_ID": "mesos-connect-group",
+    "CONNECT_CONFIG_STORAGE_TOPIC": "mesos-connect-configs",
+    "CONNECT_OFFSET_STORAGE_TOPIC": "mesos-connect-offsets",
+    "CONNECT_STATUS_STORAGE_TOPIC": "mesos-connect-status",
+	"CONNECT_KEY_CONVERTER" : "io.confluent.connect.avro.AvroConverter",
+    "CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL": "{{connect.key-converter-schema-registry-url}}",
+	"CONNECT_VALUE_CONVERTER" : "io.confluent.connect.avro.AvroConverter",
+    "CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL": "{{connect.value-converter-schema-registry-url}}",
+	"CONNECT_INTERNAL_KEY_CONVERTER" : "org.apache.kafka.connect.json.JsonConverter",
+	"CONNECT_INTERNAL_VALUE_CONVERTER" : "org.apache.kafka.connect.json.JsonConverter",
+    "CONNECT_ZOOKEEPER_CONNECT": "{{connect.zookeeper-connect}}",
+    "UNUSED_CONNECT_REST_ADVERTISED_HOST_NAME": "{{connect.name}}",
+    "KAFKA_HEAP_OPTS": "-Xmx{{connect.heap}}M"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{connect.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{connect.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-connect/1/package.json
+++ b/repo/packages/C/confluent-connect/1/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion": "2.0",
+  "name": "confluent-connect",
+  "version": "0.9.1-3.0.0",
+  "scm": "https://github.com/confluentinc/connect",
+  "description": "confluent-connect package",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "connect"],
+  "preInstallNotes": "Preparing to install confluent-connect",
+  "postInstallNotes": "confluent-connect has been installed.",
+  "postUninstallNotes": "confluent-connect was uninstalled successfully.",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/connect/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-connect/1/package.json
+++ b/repo/packages/C/confluent-connect/1/package.json
@@ -1,5 +1,5 @@
 {
-  "packagingVersion": "2.0",
+  "packagingVersion": "3.0",
   "name": "confluent-connect",
   "version": "0.9.1-3.0.0",
   "scm": "https://github.com/confluentinc/connect",
@@ -9,6 +9,7 @@
   "preInstallNotes": "Preparing to install confluent-connect",
   "postInstallNotes": "confluent-connect has been installed.",
   "postUninstallNotes": "confluent-connect was uninstalled successfully.",
+  "minDcosReleaseVersion" : "1.8",
   "licenses": [
     {
       "name": "Apache License v2",

--- a/repo/packages/C/confluent-connect/1/resource.json
+++ b/repo/packages/C/confluent-connect/1/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "connect-docker": "dbtucker/cp-kafka-connect:3.0.0"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}

--- a/repo/packages/C/confluent-control-center/0/config.json
+++ b/repo/packages/C/confluent-control-center/0/config.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "control-center": {
+      "properties": {
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each control-center instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 2048.0,
+          "description": "Memory (MB) to allocate to each control-center task.",
+          "minimum": 1024.0,
+          "type": "number"
+        },
+        "name": {
+          "default": "control-center",
+          "description": "Name for this control-center application",
+          "type": "string"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy control-center only on nodes with this role.",
+          "type": "string"
+        },
+        "bootstrap-servers": {
+          "default": "broker-0.confluent.mesos:9092",
+          "description": "Seed list of brokers to which this instance will attach.  Format is comma-separated list of <broker>:<port>",
+          "type": "string"
+        },
+        "confluent-controlcenter-connect-cluster": {
+          "default": "8.0.8.3:8083",
+          "description": "Kafka Connect Workers to which this instance will deploy connectors.  Format is comma-separated list of <broker>:<port>; default is the expected VIP of the confluent-connect service",
+          "type": "string"
+        },
+        "confluent-controlcenter-internal-topics-partitions": {
+          "default": "3",
+          "description": "Parition count for internal control-center kafka topics",
+          "type": "number"
+        },
+        "confluent-controlcenter-internal-topics-replication": {
+          "default": "2",
+          "description": "Replication factor for internal control-center kafka topics",
+          "type": "number"
+        },
+        "confluent-monitoring-interceptor-topic-partitions": {
+          "default": "3",
+          "description": "Parition count for kafka topics used to store data from the interceptor classes",
+          "type": "number"
+        },
+        "confluent-monitoring-interceptor-topic-replication": {
+          "default": "2",
+          "description": "Replication factor for kafka topics used to store data from the interceptor classes",
+          "type": "number"
+        },
+        "zookeeper-connect": {
+          "default": "leader.mesos:2181/confluent",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-control-center/0/marathon.json.mustache
+++ b/repo/packages/C/confluent-control-center/0/marathon.json.mustache
@@ -1,0 +1,46 @@
+{
+  "id": "/{{control-center.name}}",
+  "instances": {{control-center.instances}},
+  "cpus": {{control-center.cpus}},
+  "mem": {{control-center.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.confluent-docker}}",
+      "network": "BRIDGE",    
+      "portMappings": [
+        { "containerPort": 9021, "hostPort": 0 }
+      ]
+    }
+  },
+  "env": {
+    "CC_BOOTSTRAP_SERVERS": "{{control-center.bootstrap-servers}}",
+    "CC_CONFLUENT_CONTROLCENTER_CONNECT_CLUSTER": "{{control-center.confluent-controlcenter-connect-cluster}}",
+    "CC_CONFLUENT_CONTROLCENTER_INTERNAL_TOPICS_PARTITIONS": "{{control-center.confluent-controlcenter-internal-topics-partitions}}",
+    "CC_CONFLUENT_CONTROLCENTER_INTERNAL_TOPICS_REPLICATION": "{{control-center.confluent-controlcenter-internal-topics-replication}}",
+    "CC_CONFLUENT_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS": "{{control-center.confluent-monitoring-interceptor-topic-partitions}}",
+    "CC_CONFLUENT_MONITORYING_INTERCEPTOR_TOPIC_REPLICATION": "{{control-center.confluent-monitoring-interceptor-topic-replication}}",
+    "CC_ZOOKEEPER_CONNECT": "{{control-center.zookeeper-connect}}"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{control-center.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{control-center.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-control-center/0/package.json
+++ b/repo/packages/C/confluent-control-center/0/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion": "2.0",
+  "name": "confluent-control-center",
+  "version": "0.9.0-3.0.0",
+  "scm": "https://github.com/confluentinc/control-center",
+  "description": "confluent-control-center package",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "schema", "registry"],
+  "preInstallNotes": "Preparing to install confluent-control-center",
+  "postInstallNotes": "confluent-control-center has been installed.",
+  "postUninstallNotes": "confluent-control-center was uninstalled successfully.",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/control-center/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-control-center/0/resource.json
+++ b/repo/packages/C/confluent-control-center/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "confluent-docker": "dbtucker/control-center:3.0.0"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}

--- a/repo/packages/C/confluent-control-center/1/config.json
+++ b/repo/packages/C/confluent-control-center/1/config.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "control-center": {
+      "properties": {
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 2,
+          "description": "CPU shares to allocate to each control-center instance.",
+          "minimum": 2,
+          "type": "number"
+        },
+        "mem": {
+          "default": 4096,
+          "description": "Memory (MB) to allocate to each control-center task.",
+          "minimum": 2048,
+          "type": "number"
+        },
+        "name": {
+          "default": "control-center",
+          "description": "Name for this control-center application",
+          "type": "string"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy control-center only on nodes with this role.",
+          "type": "string"
+        },
+        "bootstrap-servers": {
+          "default": "broker-0.confluent.mesos:9092",
+          "description": "Seed list of brokers to which this instance will attach.  Format is comma-separated list of <broker>:<port>",
+          "type": "string"
+        },
+        "confluent-controlcenter-connect-cluster": {
+          "default": "8.0.8.3:8083",
+          "description": "Kafka Connect Workers to which this instance will deploy connectors.  Format is comma-separated list of <broker>:<port>; default is the expected VIP of the confluent-connect service",
+          "type": "string"
+        },
+        "confluent-controlcenter-internal-topics-partitions": {
+          "default": "3",
+          "description": "Parition count for internal control-center kafka topics",
+          "type": "number"
+        },
+        "confluent-controlcenter-internal-topics-replication": {
+          "default": "2",
+          "description": "Replication factor for internal control-center kafka topics",
+          "type": "number"
+        },
+        "confluent-monitoring-interceptor-topic-partitions": {
+          "default": "3",
+          "description": "Parition count for kafka topics used to store data from the interceptor classes",
+          "type": "number"
+        },
+        "confluent-monitoring-interceptor-topic-replication": {
+          "default": "2",
+          "description": "Replication factor for kafka topics used to store data from the interceptor classes",
+          "type": "number"
+        },
+        "zookeeper-connect": {
+          "default": "leader.mesos:2181/confluent",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-control-center/1/config.json
+++ b/repo/packages/C/confluent-control-center/1/config.json
@@ -32,7 +32,7 @@
           "type": "string"
         },
         "bootstrap-servers": {
-          "default": "broker-0.confluent.mesos:9092",
+          "default": "broker.confluent.l4lb.thisdcos.directory:9092",
           "description": "Seed list of brokers to which this instance will attach.  Format is comma-separated list of <broker>:<port>",
           "type": "string"
         },

--- a/repo/packages/C/confluent-control-center/1/marathon.json.mustache
+++ b/repo/packages/C/confluent-control-center/1/marathon.json.mustache
@@ -1,0 +1,51 @@
+{
+  "id": "/{{control-center.name}}",
+  "instances": {{control-center.instances}},
+  "cpus": {{control-center.cpus}},
+  "mem": {{control-center.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.confluent-docker}}",
+	  "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [
+        { "containerPort": 9021, "hostPort": 0 }
+      ]
+    }
+  },
+  "uris": [
+     "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/docker.tar.gz"
+  ],
+  "env": {
+    "BOOTSTRAP_SERVERS": "{{control-center.bootstrap-servers}}",
+    "CONTROL_CENTER_CONFLUENT_CONTROLCENTER_CONNECT_CLUSTER": "{{control-center.confluent-controlcenter-connect-cluster}}",
+    "CONTROL_CENTER_CONFLUENT_CONTROLCENTER_INTERNAL_TOPICS_PARTITIONS": "{{control-center.confluent-controlcenter-internal-topics-partitions}}",
+    "CONTROL_CENTER_CONFLUENT_CONTROLCENTER_INTERNAL_TOPICS_REPLICATION": "{{control-center.confluent-controlcenter-internal-topics-replication}}",
+    "CONTROL_CENTER_CONFLUENT_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS": "{{control-center.confluent-monitoring-interceptor-topic-partitions}}",
+    "CONTROL_CENTER_CONFLUENT_MONITORYING_INTERCEPTOR_TOPIC_REPLICATION": "{{control-center.confluent-monitoring-interceptor-topic-replication}}",
+    "CONTROL_CENTER_REPLICATION_FACTOR": "{{control-center.confluent-controlcenter-internal-topics-replication}}",
+    "ZOOKEEPER_CONNECT": "{{control-center.zookeeper-connect}}"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{control-center.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{control-center.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-control-center/1/marathon.json.mustache
+++ b/repo/packages/C/confluent-control-center/1/marathon.json.mustache
@@ -15,9 +15,6 @@
       ]
     }
   },
-  "uris": [
-     "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/docker.tar.gz"
-  ],
   "env": {
     "BOOTSTRAP_SERVERS": "{{control-center.bootstrap-servers}}",
     "CONTROL_CENTER_CONFLUENT_CONTROLCENTER_CONNECT_CLUSTER": "{{control-center.confluent-controlcenter-connect-cluster}}",

--- a/repo/packages/C/confluent-control-center/1/package.json
+++ b/repo/packages/C/confluent-control-center/1/package.json
@@ -1,5 +1,5 @@
 {
-  "packagingVersion": "2.0",
+  "packagingVersion": "3.0",
   "name": "confluent-control-center",
   "version": "0.9.1-3.0.0",
   "scm": "https://github.com/confluentinc/control-center",
@@ -9,6 +9,7 @@
   "preInstallNotes": "Preparing to install confluent-control-center",
   "postInstallNotes": "confluent-control-center has been installed.",
   "postUninstallNotes": "confluent-control-center was uninstalled successfully.",
+  "minDcosReleaseVersion" : "1.8",
   "licenses": [
     {
       "name": "Apache License v2",

--- a/repo/packages/C/confluent-control-center/1/package.json
+++ b/repo/packages/C/confluent-control-center/1/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion": "2.0",
+  "name": "confluent-control-center",
+  "version": "0.9.1-3.0.0",
+  "scm": "https://github.com/confluentinc/control-center",
+  "description": "confluent-control-center package",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "schema", "registry"],
+  "preInstallNotes": "Preparing to install confluent-control-center",
+  "postInstallNotes": "confluent-control-center has been installed.",
+  "postUninstallNotes": "confluent-control-center was uninstalled successfully.",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/control-center/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-control-center/1/resource.json
+++ b/repo/packages/C/confluent-control-center/1/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "confluent-docker": "confluentinc/cp-control-center:3.0.0"
+        "confluent-docker": "dbtucker/cp-control-center:3.0.0"
       }
     }
   },

--- a/repo/packages/C/confluent-control-center/1/resource.json
+++ b/repo/packages/C/confluent-control-center/1/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "confluent-docker": "confluentinc/cp-control-center:3.0.0"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}

--- a/repo/packages/C/confluent-rest-proxy/0/config.json
+++ b/repo/packages/C/confluent-rest-proxy/0/config.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "proxy": {
+      "properties": {
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each rest-proxy instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 1024.0,
+          "description": "Memory (MB) to allocate to each rest-proxy task.",
+          "minimum": 256.0,
+          "type": "number"
+        },
+        "name": {
+          "default": "rest-proxy",
+          "description": "Name for this rest-proxy application",
+          "type": "string"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy rest-proxy only on nodes with this role.",
+          "type": "string"
+        },
+        "vip-label": {
+          "default": "8.0.8.2:8082",
+          "description": "Label for external access to rest-proxy service. Format is <IP>:<port>",
+          "type": "string"
+        },
+        "zookeeper-connect": {
+          "default": "leader.mesos:2181/confluent",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        },
+        "schema-registry-url": {
+          "default": "http://8.0.8.1:8081",
+          "description": "Connection URL for schema registry.  Recommended setting is the logical VIP address configured with the Schema Registry service",
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name", "schema-registry-url"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-rest-proxy/0/marathon.json.mustache
+++ b/repo/packages/C/confluent-rest-proxy/0/marathon.json.mustache
@@ -1,0 +1,49 @@
+{
+  "id": "/{{proxy.name}}",
+  "instances": {{proxy.instances}},
+  "cpus": {{proxy.cpus}},
+  "mem": {{proxy.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.proxy-docker}}",
+      "network": "BRIDGE",    
+      "portMappings": [
+        {
+          "containerPort": 8082,
+          "hostPort": 0,
+          "servicePort": 18082,
+          "protocol": "tcp",
+          "labels": {
+            "VIP_0": "{{proxy.vip-label}}"
+          }
+        }
+      ]
+    }
+  },
+  "env": {
+    "RP_ZOOKEEPER_CONNECT": "{{proxy.zookeeper-connect}}",
+    "RP_SCHEMA_REGISTRY_URL": "{{proxy.schema-registry-url}}"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{proxy.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{proxy.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-rest-proxy/0/package.json
+++ b/repo/packages/C/confluent-rest-proxy/0/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion": "2.0",
+  "name": "confluent-rest-proxy",
+  "version": "0.9.0-3.0.0",
+  "scm": "https://github.com/confluentinc/kafka-rest",
+  "description": "Confluent Platform REST Proxy service",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "proxy", "rest"],
+  "preInstallNotes": "Preparing to install confluent-rest-proxy",
+  "postInstallNotes": "confluent-rest-proxy has been installed.",
+  "postUninstallNotes": "confluent-rest-proxy was uninstalled successfully.",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/kafka-rest/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-rest-proxy/0/resource.json
+++ b/repo/packages/C/confluent-rest-proxy/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "proxy-docker": "confluent/rest-proxy:3.0.0"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}

--- a/repo/packages/C/confluent-rest-proxy/1/config.json
+++ b/repo/packages/C/confluent-rest-proxy/1/config.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "proxy": {
+      "properties": {
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 2,
+          "description": "CPU shares to allocate to each rest-proxy instance.",
+          "minimum": 2,
+          "type": "number"
+        },
+        "mem": {
+          "default": 1024,
+          "description": "Memory (MB) to allocate to each rest-proxy instance.",
+          "minimum": 512,
+          "type": "number"
+        },
+        "heap": {
+          "default": 768,
+          "description": "JVM heap allocation (in MB) for rest-proxy task; should be ~256MB less than total memory for the instance.",
+          "minimum": 256,
+          "type": "number"
+        },
+        "name": {
+          "default": "rest-proxy",
+          "description": "Name for this rest-proxy application",
+          "type": "string"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy rest-proxy only on nodes with this role.",
+          "type": "string"
+        },
+        "vip-label": {
+          "default": "8.0.8.2:8082",
+          "description": "Label for external access to rest-proxy service. Format is <IP>:<port>",
+          "type": "string"
+        },
+        "zookeeper-connect": {
+          "default": "leader.mesos:2181/confluent",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        },
+        "schema-registry-url": {
+          "default": "http://8.0.8.1:8081",
+          "description": "Connection URL for schema registry.  Recommended setting is the logical VIP address configured with the Schema Registry service",
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name", "schema-registry-url"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-rest-proxy/1/marathon.json.mustache
+++ b/repo/packages/C/confluent-rest-proxy/1/marathon.json.mustache
@@ -1,0 +1,54 @@
+{
+  "id": "/{{proxy.name}}",
+  "instances": {{proxy.instances}},
+  "cpus": {{proxy.cpus}},
+  "mem": {{proxy.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.proxy-docker}}",
+	  "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [
+        {
+          "containerPort": 8082,
+          "hostPort": 0,
+          "servicePort": 18082,
+          "protocol": "tcp",
+          "labels": {
+            "VIP_0": "{{proxy.vip-label}}"
+          }
+        }
+      ]
+    }
+  },
+  "uris": [
+    "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/docker.tar.gz"
+  ],
+  "env": {
+    "KAFKAREST_HEAP_OPTS": "-Xmx{{proxy.heap}}M",
+    "KAFKA_REST_ZOOKEEPER_CONNECT": "{{proxy.zookeeper-connect}}",
+    "KAFKA_REST_SCHEMA_REGISTRY_URL": "{{proxy.schema-registry-url}}"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{proxy.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{proxy.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-rest-proxy/1/marathon.json.mustache
+++ b/repo/packages/C/confluent-rest-proxy/1/marathon.json.mustache
@@ -23,9 +23,6 @@
       ]
     }
   },
-  "uris": [
-    "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/docker.tar.gz"
-  ],
   "env": {
     "KAFKAREST_HEAP_OPTS": "-Xmx{{proxy.heap}}M",
     "KAFKA_REST_ZOOKEEPER_CONNECT": "{{proxy.zookeeper-connect}}",

--- a/repo/packages/C/confluent-rest-proxy/1/package.json
+++ b/repo/packages/C/confluent-rest-proxy/1/package.json
@@ -1,5 +1,5 @@
 {
-  "packagingVersion": "2.0",
+  "packagingVersion": "3.0",
   "name": "confluent-rest-proxy",
   "version": "0.9.1-3.0.0",
   "scm": "https://github.com/confluentinc/kafka-rest",
@@ -9,6 +9,7 @@
   "preInstallNotes": "Preparing to install confluent-rest-proxy",
   "postInstallNotes": "confluent-rest-proxy has been installed.",
   "postUninstallNotes": "confluent-rest-proxy was uninstalled successfully.",
+  "minDcosReleaseVersion" : "1.8",
   "licenses": [
     {
       "name": "Apache License v2",

--- a/repo/packages/C/confluent-rest-proxy/1/package.json
+++ b/repo/packages/C/confluent-rest-proxy/1/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion": "2.0",
+  "name": "confluent-rest-proxy",
+  "version": "0.9.1-3.0.0",
+  "scm": "https://github.com/confluentinc/kafka-rest",
+  "description": "Confluent Platform REST Proxy service",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "proxy", "rest"],
+  "preInstallNotes": "Preparing to install confluent-rest-proxy",
+  "postInstallNotes": "confluent-rest-proxy has been installed.",
+  "postUninstallNotes": "confluent-rest-proxy was uninstalled successfully.",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/kafka-rest/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-rest-proxy/1/resource.json
+++ b/repo/packages/C/confluent-rest-proxy/1/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "proxy-docker": "confluentinc/cp-kafka-rest:3.0.0"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}

--- a/repo/packages/C/confluent-rest-proxy/1/resource.json
+++ b/repo/packages/C/confluent-rest-proxy/1/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "proxy-docker": "confluentinc/cp-kafka-rest:3.0.0"
+        "proxy-docker": "dbtucker/cp-kafka-rest:3.0.0"
       }
     }
   },

--- a/repo/packages/C/confluent-schema-registry/0/config.json
+++ b/repo/packages/C/confluent-schema-registry/0/config.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "registry": {
+      "properties": {
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each schema-registry instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 1024.0,
+          "description": "Memory (MB) to allocate to each schema-registry task.",
+          "minimum": 256.0,
+          "type": "number"
+        },
+        "name": {
+          "default": "schema-registry",
+          "description": "Name for this schema-registry application",
+          "type": "string"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy schema-registry only on nodes with this role.",
+          "type": "string"
+        },
+        "vip-label": {
+          "default": "8.0.8.1:8081",
+          "description": "Label for external access to schema-registry service. Format is <IP>:<port>",
+          "type": "string"
+        },
+        "kafkastore-connection-url": {
+          "default": "leader.mesos:2181/confluent",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-schema-registry/0/marathon.json.mustache
+++ b/repo/packages/C/confluent-schema-registry/0/marathon.json.mustache
@@ -1,0 +1,48 @@
+{
+  "id": "/{{registry.name}}",
+  "instances": {{registry.instances}},
+  "cpus": {{registry.cpus}},
+  "mem": {{registry.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.registry-docker}}",
+      "network": "BRIDGE",    
+      "portMappings": [
+        {
+          "containerPort": 8081,
+          "hostPort": 0,
+          "servicePort": 18081,
+          "protocol": "tcp",
+          "labels": {
+            "VIP_0": "{{registry.vip-label}}"
+          }
+        }
+      ]
+    }
+  },
+  "env": {
+    "SR_KAFKASTORE_CONNECTION_URL": "{{registry.kafkastore-connection-url}}"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{registry.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{registry.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-schema-registry/0/package.json
+++ b/repo/packages/C/confluent-schema-registry/0/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion": "2.0",
+  "name": "confluent-schema-registry",
+  "version": "0.9.0-3.0.0",
+  "scm": "https://github.com/confluentinc/schema-registry",
+  "description": "confluent-schema-registry package",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "schema", "registry"],
+  "preInstallNotes": "Preparing to install confluent-schema-registry",
+  "postInstallNotes": "confluent-schema-registry has been installed.",
+  "postUninstallNotes": "confluent-schema-registry was uninstalled successfully.",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/schema-registry/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-schema-registry/0/resource.json
+++ b/repo/packages/C/confluent-schema-registry/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "registry-docker": "confluent/schema-registry:3.0.0"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}

--- a/repo/packages/C/confluent-schema-registry/1/config.json
+++ b/repo/packages/C/confluent-schema-registry/1/config.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "registry": {
+      "properties": {
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run (currently limited to 1).",
+          "minimum": 1,
+          "maximum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each schema-registry instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 512,
+          "description": "Memory (MB) to allocate to each schema-registry instance.",
+          "minimum": 320,
+          "type": "number"
+        },
+        "heap": {
+          "default": 256,
+          "description": "JVM heap allocation (in MB) for connect worker task; should be no greater than ~64MB less than total memory for the instance.",
+          "minimum": 256,
+          "type": "number"
+        },
+        "name": {
+          "default": "schema-registry",
+          "description": "Name for this schema-registry application",
+          "type": "string"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy schema-registry only on nodes with this role.",
+          "type": "string"
+        },
+        "vip-label": {
+          "default": "8.0.8.1:8081",
+          "description": "Label for external access to schema-registry service. Format is <IP>:<port>",
+          "type": "string"
+        },
+        "kafkastore-connection-url": {
+          "default": "leader.mesos:2181/confluent",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-schema-registry/1/marathon.json.mustache
+++ b/repo/packages/C/confluent-schema-registry/1/marathon.json.mustache
@@ -23,9 +23,6 @@
       ]
     }
   },
-  "uris": [
-     "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/docker.tar.gz"
-  ],
   "env": {
     "SCHEMA_REGISTRY_HEAP_OPTS": "-Xmx{{registry.heap}}M",
     "SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL": "{{registry.kafkastore-connection-url}}"

--- a/repo/packages/C/confluent-schema-registry/1/marathon.json.mustache
+++ b/repo/packages/C/confluent-schema-registry/1/marathon.json.mustache
@@ -1,0 +1,53 @@
+{
+  "id": "/{{registry.name}}",
+  "instances": {{registry.instances}},
+  "cpus": {{registry.cpus}},
+  "mem": {{registry.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.registry-docker}}",
+	  "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [
+        {
+          "containerPort": 8081,
+          "hostPort": 0,
+          "servicePort": 18081,
+          "protocol": "tcp",
+          "labels": {
+            "VIP_0": "{{registry.vip-label}}"
+          }
+        }
+      ]
+    }
+  },
+  "uris": [
+     "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/docker.tar.gz"
+  ],
+  "env": {
+    "SCHEMA_REGISTRY_HEAP_OPTS": "-Xmx{{registry.heap}}M",
+    "SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL": "{{registry.kafkastore-connection-url}}"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{registry.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{registry.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-schema-registry/1/package.json
+++ b/repo/packages/C/confluent-schema-registry/1/package.json
@@ -1,5 +1,5 @@
 {
-  "packagingVersion": "2.0",
+  "packagingVersion": "3.0",
   "name": "confluent-schema-registry",
   "version": "0.9.1-3.0.0",
   "scm": "https://github.com/confluentinc/schema-registry",
@@ -9,6 +9,7 @@
   "preInstallNotes": "Preparing to install confluent-schema-registry",
   "postInstallNotes": "confluent-schema-registry has been installed.",
   "postUninstallNotes": "confluent-schema-registry was uninstalled successfully.",
+  "minDcosReleaseVersion" : "1.8",
   "licenses": [
     {
       "name": "Apache License v2",

--- a/repo/packages/C/confluent-schema-registry/1/package.json
+++ b/repo/packages/C/confluent-schema-registry/1/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion": "2.0",
+  "name": "confluent-schema-registry",
+  "version": "0.9.1-3.0.0",
+  "scm": "https://github.com/confluentinc/schema-registry",
+  "description": "confluent-schema-registry package",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "schema", "registry"],
+  "preInstallNotes": "Preparing to install confluent-schema-registry",
+  "postInstallNotes": "confluent-schema-registry has been installed.",
+  "postUninstallNotes": "confluent-schema-registry was uninstalled successfully.",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/schema-registry/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-schema-registry/1/resource.json
+++ b/repo/packages/C/confluent-schema-registry/1/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "registry-docker": "dbtucker/cp-schema-registry:3.0.0"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}


### PR DESCRIPTION
These versions leverage test docker images.   Final version will reference the confluentinc/cp-* images when stable.  
