### PR TITLE
Creating an AWS ECR Login Package

### DIFF
--- a/repo/packages/E/ecr-login/0/config.json
+++ b/repo/packages/E/ecr-login/0/config.json
@@ -3,46 +3,46 @@
     "ecr-login": {
       "description": "ECR login configuration properties",
       "properties": {
-        "registryAccounts": {
+        "registry_accounts": {
           "description": "The AWS account numbers where the ECR registries are located. Space-delimited, max of 10 accounts.",
           "type": "string",
           "pattern": "^[0-9 ]{12,132}$"
         },
-        "registryRegion": {
+        "registry_region": {
           "default": "us-east-1",
           "description": "The AWS account region where the ECR registry is located.",
           "type": "string",
           "pattern": "^[a-z0-9-]{5,25}$"
         },
-        "refreshInterval": {
+        "refresh_interval": {
           "default": 21600,
           "description": "The number of seconds to pause between Docker logins. AWS requires a refresh every 12 hours, so set below. Default: 6 hours (21600 seconds)",
           "minimum": 60,
           "type": "integer"
         },
-        "hostDirectory": {
+        "host_directory": {
           "default": "/home/core",
           "description": "The host disk location where the Docker config will be saved.",
           "type": "string"
         },
-        "dockercfgFileName": {
+        "dockercfg_filename": {
           "default": ".dockercfg",
           "description": "The Docker config file name. Default: .dockercfg",
           "type": "string"
         },
-        "awsAccessKey": {
+        "aws_access_key": {
           "description": "AWS access key with permissions to log into ECR. Optional on EC2 if an IAM role is defined.",
           "type": "string"
         },
-        "awsSecretAccessKey": {
+        "aws_secret_access_key": {
           "description": "AWS secret access key with permissions to log into ECR. Optional on EC2 if an IAM role is defined.",
           "type": "string"
         },
-        "awsSessionToken": {
+        "aws_session_token": {
           "description": "AWS session token with permissions to log into ECR. Optional on EC2 if an IAM role is defined or if permanent keys are used.",
           "type": "string"
         },
-        "appId": {
+        "app_id": {
           "default": "ecr-login",
           "description": "Marathon Application ID",
           "type": "string"
@@ -67,8 +67,8 @@
         }
       },
       "required": [
-        "registryAccount",
-        "registryRegion"
+        "registry_accounts",
+        "registry_region"
       ],
       "type": "object"
     }

--- a/repo/packages/E/ecr-login/0/config.json
+++ b/repo/packages/E/ecr-login/0/config.json
@@ -1,0 +1,80 @@
+{
+  "properties": {
+    "ecr-login": {
+      "description": "ECR login configuration properties",
+      "properties": {
+        "registryAccounts": {
+          "description": "The AWS account numbers where the ECR registries are located. Space-delimited, max of 10 accounts.",
+          "type": "string",
+          "pattern": "^[0-9 ]{12,132}$"
+        },
+        "registryRegion": {
+          "default": "us-east-1",
+          "description": "The AWS account region where the ECR registry is located.",
+          "type": "string",
+          "pattern": "^[a-z0-9-]{5,25}$"
+        },
+        "refreshInterval": {
+          "default": 21600,
+          "description": "The number of seconds to pause between Docker logins. AWS requires a refresh every 12 hours, so set below. Default: 6 hours (21600 seconds)",
+          "minimum": 60,
+          "type": "integer"
+        },
+        "hostDirectory": {
+          "default": "/home/core",
+          "description": "The host disk location where the Docker config will be saved.",
+          "type": "string"
+        },
+        "dockercfgFileName": {
+          "default": ".dockercfg",
+          "description": "The Docker config file name. Default: .dockercfg",
+          "type": "string"
+        },
+        "awsAccessKey": {
+          "description": "AWS access key with permissions to log into ECR. Optional on EC2 if an IAM role is defined.",
+          "type": "string"
+        },
+        "awsSecretAccessKey": {
+          "description": "AWS secret access key with permissions to log into ECR. Optional on EC2 if an IAM role is defined.",
+          "type": "string"
+        },
+        "awsSessionToken": {
+          "description": "AWS session token with permissions to log into ECR. Optional on EC2 if an IAM role is defined or if permanent keys are used.",
+          "type": "string"
+        },
+        "appId": {
+          "default": "ecr-login",
+          "description": "Marathon Application ID",
+          "type": "string"
+        },
+        "cpus": {
+          "default": 0.01,
+          "description": "CPU shares to allocate to each Marathon instance.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of Marathon instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "mem": {
+          "default": 64.0,
+          "description": "Memory (MB) to allocate to each Marathon task.",
+          "minimum": 64.0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "registryAccount",
+        "registryRegion"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "ecr-login"
+  ],
+  "type": "object"
+}

--- a/repo/packages/E/ecr-login/0/marathon.json.mustache
+++ b/repo/packages/E/ecr-login/0/marathon.json.mustache
@@ -1,0 +1,54 @@
+{
+  "id": "{{ecr-login.appId}}",
+  "cpus": {{ecr-login.cpus}},
+  "mem": {{ecr-login.mem}},
+  "instances": {{ecr-login.instances}},
+  "maintainer": "fuller@adobe.com",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.latest}}",
+      "network": "HOST",
+      "forcePullImage": false,
+      "privileged": false
+    }
+  },
+  "env": {
+    "AWS_DEFAULT_REGION": "{{ecr-login.registryRegion}}",
+    "REGION": "{{ecr-login.registryRegion}}",
+    "REGISTRIES": "{{ecr-login.registryAccounts}}",
+    "FILE_LOCATION": "{{ecr-login.hostDirectory}}/{{ecr-login.dockercfgFileName}}",
+    "INTERVAL": "{{ecr-login.hostDirectory}}/{{ecr-login.refreshInterval}}",
+    {{#ecr-login.awsAccessKey}}
+    "AWS_ACCESS_KEY_ID": {{ecr-login.awsAccessKey}},
+    {{/ecr-login.awsAccessKey}}
+    {{#ecr-login.awsSecretAccessKey}}
+    "AWS_ACCESS_KEY_ID": {{ecr-login.awsSecretAccessKey}}
+    {{/ecr-login.awsSecretAccessKey}},
+    {{#ecr-login.awsSessionToken}}
+    "AWS_ACCESS_KEY_ID": {{ecr-login.awsSessionToken}}
+    {{/ecr-login.awsSessionToken}}
+  },
+  "volumes": [
+    {
+      "hostPath": "{{ecr-login.hostDirectory}}",
+      "containerPath": "{{ecr-login.hostDirectory}}",
+      "mode": "RW"
+    }
+  ],
+  "healthChecks": [
+    {
+      "protocol": "COMMAND",
+      "command": { "value": "if [[ $(expr $(date +%s) - $(date +%s -r {{ecr-login.hostDirectory}}/{{ecr-login.dockercfgFileName}})) -gt 10 ]]; then exit 1; else exit 0; fi" },
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 2
+    }
+  ],
+  "acceptedResourceRoles": ["slave_public", "*"],
+  "constraints": [
+    ["hostname", "UNIQUE"],
+    ["hostname", "GROUP_BY"]
+  ]
+}

--- a/repo/packages/E/ecr-login/0/marathon.json.mustache
+++ b/repo/packages/E/ecr-login/0/marathon.json.mustache
@@ -7,7 +7,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "{{resource.assets.container.docker.latest}}",
+      "image": "{{resource.assets.container.docker.v1-0-0}}",
       "network": "HOST",
       "forcePullImage": false,
       "privileged": false

--- a/repo/packages/E/ecr-login/0/marathon.json.mustache
+++ b/repo/packages/E/ecr-login/0/marathon.json.mustache
@@ -1,5 +1,5 @@
 {
-  "id": "{{ecr-login.appId}}",
+  "id": "{{ecr-login.app_id}}",
   "cpus": {{ecr-login.cpus}},
   "mem": {{ecr-login.mem}},
   "instances": {{ecr-login.instances}},
@@ -11,36 +11,36 @@
       "network": "HOST",
       "forcePullImage": false,
       "privileged": false
-    }
+    },
+    "volumes": [
+      {
+        "hostPath": "{{ecr-login.host_directory}}",
+        "containerPath": "{{ecr-login.host_directory}}",
+        "mode": "RW"
+      }
+    ]
   },
   "env": {
-    "AWS_DEFAULT_REGION": "{{ecr-login.registryRegion}}",
-    "REGION": "{{ecr-login.registryRegion}}",
-    "REGISTRIES": "{{ecr-login.registryAccounts}}",
-    "FILE_LOCATION": "{{ecr-login.hostDirectory}}/{{ecr-login.dockercfgFileName}}",
-    "INTERVAL": "{{ecr-login.hostDirectory}}/{{ecr-login.refreshInterval}}",
-    {{#ecr-login.awsAccessKey}}
-    "AWS_ACCESS_KEY_ID": {{ecr-login.awsAccessKey}},
-    {{/ecr-login.awsAccessKey}}
-    {{#ecr-login.awsSecretAccessKey}}
-    "AWS_ACCESS_KEY_ID": {{ecr-login.awsSecretAccessKey}}
-    {{/ecr-login.awsSecretAccessKey}},
-    {{#ecr-login.awsSessionToken}}
-    "AWS_ACCESS_KEY_ID": {{ecr-login.awsSessionToken}}
-    {{/ecr-login.awsSessionToken}}
+    {{#ecr-login.aws_access_key}}
+      "AWS_ACCESS_KEY_ID": "{{ecr-login.aws_access_key}}",
+    {{/ecr-login.aws_access_key}}
+    {{#ecr-login.aws_secret_access_key}}
+      "AWS_SECRET_ACCESS_KEY": "{{ecr-login.aws_secret_access_key}}",
+    {{/ecr-login.aws_secret_access_key}}
+    {{#ecr-login.aws_session_token}}
+      "AWS_SESSION_TOKEN": "{{ecr-login.aws_session_token}}",
+    {{/ecr-login.aws_session_token}}
+    "AWS_DEFAULT_REGION": "{{ecr-login.registry_region}}",
+    "REGION": "{{ecr-login.registry_region}}",
+    "REGISTRIES": "{{ecr-login.registry_accounts}}",
+    "FILE_LOCATION": "{{ecr-login.host_directory}}/{{ecr-login.dockercfg_filename}}",
+    "INTERVAL": "{{ecr-login.refresh_interval}}"
   },
-  "volumes": [
-    {
-      "hostPath": "{{ecr-login.hostDirectory}}",
-      "containerPath": "{{ecr-login.hostDirectory}}",
-      "mode": "RW"
-    }
-  ],
   "healthChecks": [
     {
       "protocol": "COMMAND",
-      "command": { "value": "if [[ $(expr $(date +%s) - $(date +%s -r {{ecr-login.hostDirectory}}/{{ecr-login.dockercfgFileName}})) -gt 10 ]]; then exit 1; else exit 0; fi" },
-      "gracePeriodSeconds": 300,
+      "command": { "value": "if [[ $(expr $(date +%s) - $(date +%s -r {{ecr-login.host_directory}}/{{ecr-login.dockercfg_filename}})) -gt {{ecr-login.refresh_interval}} ]]; then exit 1; else exit 0; fi" },
+      "gracePeriodSeconds": 60,
       "intervalSeconds": 60,
       "timeoutSeconds": 20,
       "maxConsecutiveFailures": 2

--- a/repo/packages/E/ecr-login/0/package.json
+++ b/repo/packages/E/ecr-login/0/package.json
@@ -1,18 +1,12 @@
 {
-    "packagingVersion": "1.0",
+    "packagingVersion": "3.0",
     "description": "AWS ECR login utility",
     "framework": false,
-    "licenses": [
-        {
-            "name": "Simplified BSD license",
-            "url": "https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE"
-        }
-    ],
     "maintainer": "fuller@adobe.com",
     "name": "ecr-login",
     "postInstallNotes": "ECR login on DCOS successfully installed.\nYou can now begin pulling from this registry.",
-    "postUninstallNotes": "ECR login on DCOS successfully uninstalled.\n.",
-    "preInstallNotes": "Pass the AWS account number and region as package options.\nMake sure the Mesos agent's IAM role allows logging into the ECR specified.\nMarathon will make sure that the ECR login agent runs only once per slave.",
+    "postUninstallNotes": "ECR login on DCOS successfully uninstalled.\nDocker auths may still persist in your .dockercfg file.",
+    "preInstallNotes": "Pass the AWS account number and region as package options.\nMake sure the Mesos agent's IAM role (or the provided credentials) allows logging into the ECR specified.\nMarathon will make sure that the ECR login agent runs only once per slave.",
     "tags": [
         "ecr",
         "aws"

--- a/repo/packages/E/ecr-login/0/package.json
+++ b/repo/packages/E/ecr-login/0/package.json
@@ -1,0 +1,21 @@
+{
+    "packagingVersion": "1.0",
+    "description": "AWS ECR login utility",
+    "framework": false,
+    "licenses": [
+        {
+            "name": "Simplified BSD license",
+            "url": "https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE"
+        }
+    ],
+    "maintainer": "fuller@adobe.com",
+    "name": "ecr-login",
+    "postInstallNotes": "ECR login on DCOS successfully installed.\nYou can now begin pulling from this registry.",
+    "postUninstallNotes": "ECR login on DCOS successfully uninstalled.\n.",
+    "preInstallNotes": "Pass the AWS account number and region as package options.\nMake sure the Mesos agent's IAM role allows logging into the ECR specified.\nMarathon will make sure that the ECR login agent runs only once per slave.",
+    "tags": [
+        "ecr",
+        "aws"
+    ],
+    "version": "1.0.0"
+}

--- a/repo/packages/E/ecr-login/0/resource.json
+++ b/repo/packages/E/ecr-login/0/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "latest": "adobeplatform/dcos-ecr-login:latest"
+        "v1-0-0": "adobeplatform/aws-ecr-login:v1.0.0"
       }
     }
   },

--- a/repo/packages/E/ecr-login/0/resource.json
+++ b/repo/packages/E/ecr-login/0/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "latest": "adobeplatform/ecr-login:latest"
+        "latest": "adobeplatform/dcos-ecr-login:latest"
       }
     }
   },

--- a/repo/packages/E/ecr-login/0/resource.json
+++ b/repo/packages/E/ecr-login/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "latest": "adobeplatform/ecr-login:latest"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/af/AWS_Simple_Icons_Compute_ECS.svg/100px-AWS_Simple_Icons_Compute_ECS.svg.png",
+    "icon-medium": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/af/AWS_Simple_Icons_Compute_ECS.svg/500px-AWS_Simple_Icons_Compute_ECS.svg.png",
+    "icon-large": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/af/AWS_Simple_Icons_Compute_ECS.svg/2000px-AWS_Simple_Icons_Compute_ECS.svg.png"
+  }
+}


### PR DESCRIPTION
Some companies are using Amazon's EC2 Container Registry (ECR) for the storage of Docker containers in AWS. One challenge with ECR is that is requires an interaction between traditional AWS API calls and the Docker login commands to generate temporary `.dockercfg` credentials.

To use ECR, the Docker login credentials must first be obtained from AWS, then, rotated every 12 hours (slightly less than 12 hours to avoid login errors). This PR introduces a DC/OS package that handles these aspects.

The [container](https://hub.docker.com/r/adobeplatform/aws-ecr-login/) it uses will run continuously in the background using [a script](https://github.com/adobe-platform/aws-ecr-login/blob/master/ecr-login.sh) to refresh Docker credentials at the specified interval. It can be run on AWS instances, Azure, GCE, or on metal. In AWS, the preferred method is to use AWS IAM roles on the underlying instances. Elsewhere, the settings allow for the input of AWS access keys and secrets.

The `host_directory` and `dockercfg_filename` are used to provide the path for where the docker config file should be written on the host. The volume from `host_directory` is mounted into the container for the write. After this service is running, you can pass the docker config location to any other Marathon app config via `uris`. It will then use this file to download the private Docker image from ECR.

## Notes
* This uses the more recent `auths` version of Docker configs. If you are running Docker < 1.7, this will not work.
* On AWS, the region will be determined by the region in which the instance is located. If a different region is desired (or if not running on AWS) provide it via the `region` option.
* On AWS the agent IAM role is used to perform a Docker login. Optionally (on AWS; required elsewhere) AWS an access key and secret can be passed. Regardless of method, the permissions must allow: `ecr:GetAuthorizationToken`. If you also want to pull images, you will need: `ecr:BatchGetImage`, `ecr:GetDownloadUrlForLayer`, `ecr:BatchCheckLayerAvailability`.
* The `interval` option has a default of `21600` seconds (6 hours). The logins expire every 12 hours, so we recommend leaving it at the default to be safe.
* This service is designed to handle existing Docker configs and merge the `auths` section accordingly. This allows you to authenticate with multiple ECRs or other registries at the same time. You can pass multiple `registry_accounts` (separated with a space).
* If you are writing the Docker config file to a shared volume, this service only has to run on one agent. If you are writing to local files, it must be run on every agent that will pull from ECR.