### PR TITLE
add mariadb marathon package based on `bitnami/mariadb:10.1.14-r2`

### DIFF
--- a/repo/packages/M/mariadb/0/config.json
+++ b/repo/packages/M/mariadb/0/config.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "The name of the MariaDB service instance",
+          "type": "string",
+          "default": "mariadb"
+        }
+      }
+    },
+    "mariadb": {
+      "additionalProperties": false,
+      "description": "MariaDB service configuration properties",
+      "properties": {
+        "cpus": {
+          "description": "CPU shares to allocate to each MariaDB node.",
+          "type": "number",
+          "default": 1,
+          "minimum": 1
+        },
+        "mem": {
+          "description": "Memory to allocate to each MariaDB node.",
+          "type": "number",
+          "default": 1024.0,
+          "minimum": 1024.0
+        },
+        "bridge": {
+          "default": false,
+          "description": "Whether to use bridge networking mode for Docker container. By default, this is false and host mode networking is used.",
+          "type": "boolean"
+        },
+        "host_volume": {
+          "description": "The location of a volume on the host to be used for persisting MariaDB data. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/mariadb`). Note that this path must be the same on all DCOS agents.",
+          "type": "string",
+          "default": "/tmp"
+        },
+        "root_password": {
+          "description": "Specifies the password that will be set for the MariaDB root superuser account, required.",
+          "type": "string"
+        },
+        "database": {
+          "type": "object",
+          "description": "Optionally create a MariaDB database.",
+          "properties": {
+            "name": {
+              "description": "The name of a database to be created on image startup, optional.",
+              "type": "string"
+            },
+            "username": {
+              "description": "The username of a user to be created with superuser access to this database only, optional.",
+              "type": "string"
+            },
+            "password": {
+              "description": "The password for a user to be created with superuser access to this database only., optional.",
+              "type": "string"
+            }
+          }
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "bridge",
+        "host_volume"
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/M/mariadb/0/marathon.json.mustache
+++ b/repo/packages/M/mariadb/0/marathon.json.mustache
@@ -1,0 +1,73 @@
+{
+    "id": "{{service.name}}",
+    "cpus": {{mariadb.cpus}},
+    "mem": {{mariadb.mem}},
+    "instances": 1,
+    "env": {
+        {{#mariadb.database.name}}
+        "MARIADB_DATABASE": "{{mariadb.database.name}}",
+        {{#mariadb.database.username}}
+        "MARIADB_USER": "{{mariadb.database.username}}",
+        "MARIADB_PASSWORD": "{{mariadb.database.password}}",
+        {{/mariadb.database.username}}
+        {{/mariadb.database.name}}
+        "MARIADB_ROOT_PASSWORD": "{{mariadb.root_password}}"
+    },
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.mariadb-docker}}",
+            "forcePullImage": true,
+            {{#mariadb.bridge}}
+            "network": "BRIDGE",
+            "portMappings": [{
+                "containerPort": 3306,
+                "hostPort": 0,
+                "protocol": "tcp"
+            }]
+            {{/mariadb.bridge}}
+            {{^mariadb.bridge}}
+            "network": "HOST"
+            {{/mariadb.bridge}}
+        },
+        "volumes": [
+        {
+            "containerPath": "/bitnami/mariadb",
+            "hostPath": "{{mariadb.host_volume}}/{{service.name}}",
+            "mode": "RW"
+        }
+        ]
+    },
+    {{^mariadb.bridge}}
+    "portDefinitions": [
+    {
+            "port": 3306,
+            "protocol": "tcp",
+            "name": "mysql",
+            "labels": {}
+    }
+    ],
+    "requirePorts": true,
+    {{/mariadb.bridge}}
+    "healthChecks": [
+    {
+        "protocol": "TCP",
+        "portIndex": 0,
+        "gracePeriodSeconds": 300,
+        "intervalSeconds": 60,
+        "timeoutSeconds": 20,
+        "maxConsecutiveFailures": 3,
+        "ignoreHttp1xx": false
+    }
+    ],
+    "labels": {
+        "DCOS_SERVICE_NAME": "{{service.name}}",
+        "DCOS_SERVICE_SCHEME": "http",
+        "DCOS_SERVICE_PORT_INDEX": "0",
+        "MARATHON_SINGLE_INSTANCE_APP":"true"
+    },
+    "upgradeStrategy":{
+        "minimumHealthCapacity": 0,
+        "maximumOverCapacity": 0
+    }
+}

--- a/repo/packages/M/mariadb/0/package.json
+++ b/repo/packages/M/mariadb/0/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion": "2.0",
+  "name": "mariadb",
+  "version": "10.1.14",
+  "scm": "https://github.com/MariaDB/server.git",
+  "maintainer": "containers@bitnami.com",
+  "website": "https://mariadb.org",
+  "description": "MariaDB is one of the most popular database servers in the world. It’s made by the original developers of MySQL and guaranteed to stay open source. Notable users include Wikipedia, Facebook and Google. MariaDB is developed as open source software and as a relational database it provides an SQL interface for accessing data. The latest versions of MariaDB also include GIS and JSON features.",
+  "tags": ["database", "mysql", "mariadb", "sql"],
+  "preInstallNotes": "In order for MariaDB service to start successfully it requires atleast 1 CPU and 1024MB of RAM including ports. WARNING: MariaDB on DCOS is currently in ALPHA. There may be bugs, incomplete\nfeatures, incorrect documentation, or other discrepancies.\n\nIf you didn't provide a value for `host_volume` in the CLI,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n",
+  "postUninstallNotes": "MariaDB has been uninstalled. Note that any data persisted to a NFS share still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "GNU GENERAL PUBLIC LICENSE",
+      "url": "https://github.com/mariadb/mariadb-server/blob/5.7/COPYING"
+    }
+  ]
+}

--- a/repo/packages/M/mariadb/0/resource.json
+++ b/repo/packages/M/mariadb/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://cloud.githubusercontent.com/assets/410147/17726269/936fd07a-646f-11e6-8ffa-ff3d0a1b4b15.png",
+    "icon-medium": "https://cloud.githubusercontent.com/assets/410147/17726265/919cbaf6-646f-11e6-8f3c-114245c4b7f4.png",
+    "icon-large": "https://cloud.githubusercontent.com/assets/410147/17726266/919d81ca-646f-11e6-8c7c-7bc91c11d1f5.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "mariadb-docker": "bitnami/mariadb:10.1.14-r2"
+      }
+    }
+  }
+}


### PR DESCRIPTION
We (Bitnami) would like to contribute a marathon package for MariaDB which uses the [Bitnami MariaDB Docker](https://github.com/bitnami/bitnami-docker-mariadb) image.

The package is based on the MySQL package and has a similar configuration parameters.

Would love to hear your feedback.  Thanks.

/cc @rrikhy