### PR TITLE
add nginx package based on bitnami/nginx:1.10.1-r1

### DIFF
--- a/repo/packages/N/nginx/4/config.json
+++ b/repo/packages/N/nginx/4/config.json
@@ -56,12 +56,26 @@
           "type": "string"
         },
         "bridge": {
-          "default": false,
-          "description": "Whether to use BRIDGE networking mode for Docker container. By default, this is false and HOST mode networking is used.",
+          "default": true,
+          "description": "Whether to use BRIDGE networking mode for Docker container. By default, this is true and BRIDGE mode networking is used.",
           "type": "boolean"
+        },
+        "virtual-host": {
+          "description": "The virtual host address to configure for integration with Marathon-lb.",
+          "type": "string"
+        },
+        "https-redirect": {
+          "description": "Whether Marathon-lb should redirect HTTP traffic to HTTPS. This requires 'virtual-host' to be set. By default, this is false.",
+          "type": "boolean",
+          "default": false
         }
       },
-      "required": ["cpus", "mem", "instances", "name"],
+      "required": [
+        "cpus",
+        "mem",
+        "instances",
+        "name"
+      ],
       "type": "object"
     }
   },

--- a/repo/packages/N/nginx/4/config.json
+++ b/repo/packages/N/nginx/4/config.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "nginx": {
+      "properties": {
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each nginx instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 1024.0,
+          "description": "Memory (MB) to allocate to each nginx task.",
+          "minimum": 256.0,
+          "type": "number"
+        },
+        "minimumHealthCapacity": {
+          "default": 0.5,
+          "description": "Minimum health capacity.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "maximumOverCapacity": {
+          "default": 0.2,
+          "description": "Maximum over capacity.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "name": {
+          "default": "nginx",
+          "description": "Name for this nginx application",
+          "type": "string"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy nginx only on nodes with this role.",
+          "type": "string"
+        },
+        "contentDir": {
+          "description": "Path of directory, relative to sandbox, containing HTML code. Can NOT be combined with configUrl.",
+          "type": "string"
+        },
+        "contentUrl": {
+          "description": "URL of content that needs to be hosted. Can NOT be combined with configUrl.",
+          "type": "string"
+        },
+        "configUrl": {
+          "description": "URL to Nginx vhost configurations (e.g., load balancing, reverse proxy, etc). Can NOT be combined with contentUrl or contentDir.",
+          "type": "string"
+        },
+        "bridge": {
+          "default": false,
+          "description": "Whether to use BRIDGE networking mode for Docker container. By default, this is false and HOST mode networking is used.",
+          "type": "boolean"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/N/nginx/4/marathon.json.mustache
+++ b/repo/packages/N/nginx/4/marathon.json.mustache
@@ -50,6 +50,11 @@
     "{{nginx.role}}"
   ],
   "labels": {
+    {{#nginx.virtual-host}}
+    "HAPROXY_GROUP":"external",
+    "HAPROXY_0_VHOST":"{{nginx.virtual-host}}",
+    "HAPROXY_0_REDIRECT_TO_HTTPS": "{{nginx.https-redirect}}",
+    {{/nginx.virtual-host}}
     "DCOS_SERVICE_NAME": "{{nginx.name}}",
     "DCOS_SERVICE_SCHEME": "http",
     "DCOS_SERVICE_PORT_INDEX": "0"

--- a/repo/packages/N/nginx/4/marathon.json.mustache
+++ b/repo/packages/N/nginx/4/marathon.json.mustache
@@ -1,0 +1,57 @@
+{
+  "id": "/{{nginx.name}}",
+  "instances": {{nginx.instances}},
+  "cpus": {{nginx.cpus}},
+  "mem": {{nginx.mem}},
+  "maintainer": "containers@bitnami.com",
+{{#nginx.contentDir}}
+  "cmd": "cd /opt/bitnami/nginx && harpoon initialize nginx && rm -rf /opt/bitnami/nginx/html && ln -s /mnt/mesos/sandbox/{{nginx.contentDir}} /opt/bitnami/nginx/html && harpoon start --foreground nginx",
+{{/nginx.contentDir}}
+{{#nginx.configUrl}}
+  "cmd": "cd /opt/bitnami/nginx && harpoon initialize nginx && cp /mnt/mesos/sandbox/nginx/*.conf /bitnami/nginx/conf/vhosts/ && harpoon start --foreground nginx",
+{{/nginx.configUrl}}
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.nginx-docker}}",
+    {{#nginx.bridge}}
+      "network": "BRIDGE",
+      "portMappings": [
+        { "containerPort": 80, "hostPort": 0 },
+        { "containerPort": 443, "hostPort": 0 }
+      ]
+    {{/nginx.bridge}}
+    {{^nginx.bridge}}
+      "network": "HOST"
+    {{/nginx.bridge}}
+    }
+  },
+  "healthChecks": [
+    {
+      "protocol": "COMMAND",
+      "command": { "value": "harpoon status nginx | grep -q 'com.bitnami.nginx is running'"},
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3
+    }
+  ],
+{{#nginx.contentUrl}}
+  "uris":[
+    "{{nginx.contentUrl}}"
+  ],
+{{/nginx.contentUrl}}
+{{#nginx.configUrl}}
+  "uris":[
+    "{{nginx.configUrl}}"
+  ],
+{{/nginx.configUrl}}
+  "acceptedResourceRoles": [
+    "{{nginx.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{nginx.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/N/nginx/4/package.json
+++ b/repo/packages/N/nginx/4/package.json
@@ -1,6 +1,7 @@
 {
   "packagingVersion": "2.0",
   "name": "nginx",
+  "framework": false,
   "description": "nginx is a high performance HTTP and reverse proxy server.",
   "version": "1.10.1",
   "scm": "http://hg.nginx.org/nginx/",

--- a/repo/packages/N/nginx/4/package.json
+++ b/repo/packages/N/nginx/4/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion": "2.0",
+  "name": "nginx",
+  "description": "nginx is a high performance HTTP and reverse proxy server.",
+  "version": "1.10.1",
+  "scm": "http://hg.nginx.org/nginx/",
+  "maintainer": "containers@bitnami.com",
+  "tags": ["proxy", "web-server", "cache", "reverse-proxy"],
+  "preInstallNotes": "Preparing to install nginx.",
+  "postInstallNotes": "Nginx has been installed.",
+  "postUninstallNotes": "Nginx was uninstalled successfully.",
+  "licenses": [
+    {
+      "name": "BSD like",
+      "url": "http://nginx.org/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/N/nginx/4/resource.json
+++ b/repo/packages/N/nginx/4/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://pbs.twimg.com/profile_images/567774844322713600/tYoVju31.png",
+    "icon-medium": "https://pbs.twimg.com/profile_images/567774844322713600/tYoVju31.png",
+    "icon-large": "https://pbs.twimg.com/profile_images/567774844322713600/tYoVju31.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "nginx-docker": "bitnami/nginx:1.10.1-r1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
We would like to take over the maintenance of the Nginx package, using the [Bitnami Docker Image for NGINX](https://github.com/bitnami/bitnami-docker-nginx).

This update is backward compatible with the current NGINX package.

[Why Bitnami?](https://bitnami.com/learn_more#benefits)