### PR TITLE
Make local-universe HA

### DIFF
--- a/local/dcos-local-universe-http.service
+++ b/local/dcos-local-universe-http.service
@@ -8,4 +8,9 @@ StartLimitInterval=0
 RestartSec=15
 TimeoutStartSec=120
 TimeoutStopSec=15
+ExecStartPre=-/usr/bin/docker kill %n
+ExecStartPre=-/usr/bin/docker rm %n
 ExecStart=/usr/bin/docker run --rm --name %n -p 8082:80 mesosphere/universe nginx -g "daemon off;"
+
+[Install]
+WantedBy=multi-user.target

--- a/local/dcos-local-universe-registry.service
+++ b/local/dcos-local-universe-registry.service
@@ -8,4 +8,9 @@ StartLimitInterval=0
 RestartSec=15
 TimeoutStartSec=120
 TimeoutStopSec=15
+ExecStartPre=-/usr/bin/docker kill %n
+ExecStartPre=-/usr/bin/docker rm %n
 ExecStart=/usr/bin/docker run --rm --name %n -p 5000:5000 -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key mesosphere/universe registry serve /etc/docker/registry/config.yml
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
These two files are used there: https://docs.mesosphere.com/1.7/administration/installing/custom/deploying-a-local-dcos-universe/

It's not possible to enable units if they don't have the `[Install]` part. And not being enabled, they will never be started automatically after node failures. 

I've added the `ExecStartPre` lines to delete Docker artifacts after the previous start if any.