### PR TITLE
Added marathon-slack package

### DIFF
--- a/repo/packages/M/marathon-slack/0/config.json
+++ b/repo/packages/M/marathon-slack/0/config.json
@@ -1,0 +1,56 @@
+{
+  "properties": {
+    "marathon-slack": {
+      "description": "The marathon-slack for DC/OS settings",
+      "properties": {
+        "slack_webhook_url": {
+          "description": "The Slack Webhook URL to send the notifications to.",
+          "type": "string"
+        },
+        "slack_channel": {
+          "default": "#marathon",
+          "description": "Optional: The Slack channel to send the message to.",
+          "type": "string"
+        },
+        "event_types": {
+          "default": "deployment_info,deployment_success,deployment_failed",
+          "description": "Optional: Comma-separated list of event types to notify upon - eg. deployment_info,deployment_success,deployment_failed. See https://github.com/tobilg/marathon-slack#event-types",
+          "type": "string"
+        },
+        "log_level": {
+          "default": "info",
+          "description": "Optional: The log level for the log file output. Can be either error, debug or info.",
+          "type": "string"
+        },
+        "cpus": {
+          "default": 0.1,
+          "description": "CPU (shares) to allocate to each Sysdig Cloud agent task",
+          "maximum": 1.0,
+          "minimum": 0.1,
+          "type": "number"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of slack-notifier instances running on DC/OS",
+          "minimum": 1,
+          "maximum": 1,
+          "type": "integer"
+        },
+        "mem": {
+          "default": 128.0,
+          "description": "Memory (MB) to allocate to the slack-notifier task",
+          "minimum": 512.0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "slack_webhook_url"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "marathon-slack"
+  ],
+  "type": "object"
+}

--- a/repo/packages/M/marathon-slack/0/config.json
+++ b/repo/packages/M/marathon-slack/0/config.json
@@ -24,21 +24,21 @@
         },
         "cpus": {
           "default": 0.1,
-          "description": "CPU (shares) to allocate to each Sysdig Cloud agent task",
+          "description": "CPU (shares) to allocate to the marathon-slack task",
           "maximum": 1.0,
           "minimum": 0.1,
           "type": "number"
         },
         "instances": {
           "default": 1,
-          "description": "Number of slack-notifier instances running on DC/OS",
+          "description": "Number of marathon-slack instances running on DC/OS",
           "minimum": 1,
           "maximum": 1,
           "type": "integer"
         },
         "mem": {
           "default": 128.0,
-          "description": "Memory (MB) to allocate to the slack-notifier task",
+          "description": "Memory (MB) to allocate to the marathon-slack task",
           "minimum": 512.0,
           "type": "number"
         }

--- a/repo/packages/M/marathon-slack/0/marathon.json.mustache
+++ b/repo/packages/M/marathon-slack/0/marathon.json.mustache
@@ -1,0 +1,29 @@
+{
+    "id": "/marathon-slack",
+    "cpus": {{marathon-slack.cpus}},
+    "mem": {{marathon-slack.mem}},
+    "disk": 0,
+    "instances": {{marathon-slack.instances}},
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.marathon-slack}}",
+            "network": "HOST",
+            "privileged": false,
+            "parameters": [],
+            "forcePullImage": true
+        }
+    },
+    "env": {
+        {{#marathon-slack.slack_channel}}
+        "SLACK_CHANNEL": "{{marathon-slack.slack_channel}}",
+        {{/marathon-slack.slack_channel}}
+        {{#marathon-slack.event_types}}
+        "EVENT_TYPES": "{{marathon-slack.event_types}}",
+        {{/marathon-slack.event_types}}
+        {{#marathon-slack.log_level}}
+        "LOG_LEVEL": "{{marathon-slack.log_level}}",
+        {{/marathon-slack.log_level}}
+        "SLACK_WEBHOOK_URL": "{{marathon-slack.slack_webhook_url}}"
+    }
+}

--- a/repo/packages/M/marathon-slack/0/marathon.json.mustache
+++ b/repo/packages/M/marathon-slack/0/marathon.json.mustache
@@ -25,5 +25,8 @@
         "LOG_LEVEL": "{{marathon-slack.log_level}}",
         {{/marathon-slack.log_level}}
         "SLACK_WEBHOOK_URL": "{{marathon-slack.slack_webhook_url}}"
+    },
+    "labels":{
+        "MARATHON_SINGLE_INSTANCE_APP": "true"
     }
 }

--- a/repo/packages/M/marathon-slack/0/package.json
+++ b/repo/packages/M/marathon-slack/0/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion" : "1.7",
+  "name": "marathon-slack",
+  "version": "0.1.1",
+  "tags": ["slack", "notifier", "marathon", "eventbus", "events", "bot", "notifications"],
+  "maintainer": "tobilg@gmail.com",
+  "description": "Send selected Marathon event types to a Slack WebHook",
+  "scm": "https://github.com/tobilg/marathon-slack.git",
+  "website": "https://github.com/tobilg/marathon-slack",
+  "framework": false,
+  "preInstallNotes": "This will install marathon-slack... Send your Marathon events to Slack!",
+  "postInstallNotes": "Thanks for installing! Have fun sending your Marathon events to Slack.",
+  "postUninstallNotes": "marathon-slack was successfully unistalled.",
+  "licenses": [{
+    "name": "MIT",
+    "url": "https://github.com/tobilg/marathon-slack/blob/master/LICENSE"
+  }]
+}

--- a/repo/packages/M/marathon-slack/0/package.json
+++ b/repo/packages/M/marathon-slack/0/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "3.0",
   "minDcosReleaseVersion" : "1.7",
   "name": "marathon-slack",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "tags": ["slack", "notifier", "marathon", "eventbus", "events", "bot", "notifications"],
   "maintainer": "tobilg@gmail.com",
   "description": "Send selected Marathon event types to a Slack WebHook",

--- a/repo/packages/M/marathon-slack/0/package.json
+++ b/repo/packages/M/marathon-slack/0/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "3.0",
   "minDcosReleaseVersion" : "1.7",
   "name": "marathon-slack",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "tags": ["slack", "notifier", "marathon", "eventbus", "events", "bot", "notifications"],
   "maintainer": "tobilg@gmail.com",
   "description": "Send selected Marathon event types to a Slack WebHook",

--- a/repo/packages/M/marathon-slack/0/resource.json
+++ b/repo/packages/M/marathon-slack/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "marathon-slack": "tobilg/marathon-slack:0.1.1"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "http://www.sharelytics.de/assets/img/marathon-slack/marathon-slack_48.png",
+    "icon-medium": "http://www.sharelytics.de/assets/img/marathon-slack/marathon-slack_96.png",
+    "icon-large": "http://www.sharelytics.de/assets/img/marathon-slack/marathon-slack_256.png"
+  }
+}

--- a/repo/packages/M/marathon-slack/0/resource.json
+++ b/repo/packages/M/marathon-slack/0/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "marathon-slack": "tobilg/marathon-slack:0.1.2"
+        "marathon-slack": "tobilg/marathon-slack:0.1.3"
       }
     }
   },

--- a/repo/packages/M/marathon-slack/0/resource.json
+++ b/repo/packages/M/marathon-slack/0/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "marathon-slack": "tobilg/marathon-slack:0.1.1"
+        "marathon-slack": "tobilg/marathon-slack:0.1.2"
       }
     }
   },


### PR DESCRIPTION
This PR adds a package for the [marathon-slack](https://github.com/tobilg/marathon-slack) project. 

This enables the sending of (selected) Marathon Event Bus events to a Slack channel.