### PR TITLE
DCOS-9029: dcos-enterprise-cli bundle

### DIFF
--- a/repo/packages/D/dcos-enterprise-cli/0/package.json
+++ b/repo/packages/D/dcos-enterprise-cli/0/package.json
@@ -1,0 +1,9 @@
+{
+  "packagingVersion": "3.0",
+  "name": "dcos-enterprise-cli",
+  "version": "1.0.0",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.8",
+  "description": "Enterprise DC/OS CLI",
+  "tags": [ "mesosphere", "enterprise", "subcommand" ]
+}

--- a/repo/packages/D/dcos-enterprise-cli/0/resource.json
+++ b/repo/packages/D/dcos-enterprise-cli/0/resource.json
@@ -1,0 +1,30 @@
+{
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "666f9890e1c3db4349f472b2d0807bb94879f6a78c1445b354259fbc960ca061"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/darwin/x86-64/1.0.0/666f9890e1c3db4349f472b2d0807bb94879f6a78c1445b354259fbc960ca061/dcos-enterprise-cli"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "b453e0f6f5929109a4c961b2c2749d781e0be12c4d7caf830cb10372ffdbcd40"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/linux/x86-64/1.0.0/b453e0f6f5929109a4c961b2c2749d781e0be12c4d7caf830cb10372ffdbcd40/dcos-enterprise-cli"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces Enterprise CLI bundle.

Currently it only contains security related subcommand, which was removed in  https://github.com/mesosphere/universe/pull/601. 

The idea behind this PR is that we want to ship just one zip which contains multiple EE subcommands. All of them are ZIPed in 'bin/' folder before publishing to S3. TC build chains can be found here:
https://teamcity.mesosphere.io/project.html?projectId=ClosedSource_MesosphereEnterpriseDcOs_Cli&tab=projectOverview

Worth noting is that the URI of the published binary has changed to include SHAsum of the uploaded binary. The reason for that is that each build produces a bitwise different binary. I suspect this is related to time of the build/hostname/etc.... Instead of trying to come up with identical binaries on every build, we just freeze one particular shasum with universe's resource.json.

The version of the EE CLI binary is currently equal to version of the Security CLI. This will probably change as soon as we include more EE binaries.