### PR TITLE
add missing docker option to sysdigcloud

### DIFF
--- a/repo/packages/S/sysdigcloud/0/marathon.json.mustache
+++ b/repo/packages/S/sysdigcloud/0/marathon.json.mustache
@@ -19,6 +19,9 @@
             "parameters": [
                 {
                     "key": "name", "value": "sysdig-agent"
+                },
+                {
+                    "key": "pid", "value": "host"
                 }
             ]
         },


### PR DESCRIPTION
adding missing docker option