### PR TITLE
Update Jenkins Version and Add JENKINS_OPTS

### DIFF
--- a/repo/packages/J/jenkins/13/config.json
+++ b/repo/packages/J/jenkins/13/config.json
@@ -1,0 +1,127 @@
+{
+    "type": "object",
+    "properties": {
+        "service": {
+            "description": "Configuration properties for the Jenkins service for DC/OS.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the service to display in the DC/OS dashboard.",
+                    "type": "string",
+                    "default": "jenkins"
+                },
+                "cpus": {
+                    "description": "CPU shares to allocate to each Jenkins master.",
+                    "type": "number",
+                    "default": 1.0,
+                    "minimum": 0.1
+                },
+                "mem": {
+                    "description": "Memory (in MB) to allocate to each Jenkins master.",
+                    "type": "number",
+                    "default": 2048.0,
+                    "minimum": 2048.0
+                }
+            }
+        },
+        "storage": {
+            "description": "Storage-related configuration properties for Jenkins on DC/OS.",
+            "type": "object",
+            "properties": {
+                "host-volume": {
+                    "description": "The location of a volume on the host to be used for persisting Jenkins configuration and build data. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/jenkins`). Note that this path must be the same on all DC/OS agents.",
+                    "type": "string",
+                    "default": "/tmp"
+                },
+                "pinned-hostname": {
+                    "description": "An optional DC/OS agent hostname to run this Jenkins instance on (e.g. 10.0.0.1).",
+                    "type" : "string"
+                }
+            }
+        },
+        "networking": {
+            "description": "Networking-related configuration properties for Jenkins on DC/OS.",
+            "type": "object",
+            "properties": {
+                "known-hosts": {
+                    "description": "A space-separated list of hosts used to populate the SSH known hosts file on the Jenkins master.",
+                    "type": "string",
+                    "default": "github.com"
+                },
+                "virtual-host": {
+                    "description": "The virtual host address to configure for integration with Marathon-lb.",
+                    "type": "string"
+                },
+                "https-redirect": {
+                    "description": "Whether Marathon-lb should redirect HTTP traffic to HTTPS. This requires 'virtual-host' to be set. By default, this is false.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "root-url": {
+                    "description": "The web address of the Jenkins installation (e.g. http://jenkins.example.com). This is used by Jenkins to refer to itself when creating links in emails, chat notifications, etc.",
+                    "type": "string"
+                }
+            }
+        },
+        "roles": {
+            "description": "Role configuration properties for Jenkins on DC/OS.",
+            "type": "object",
+            "properties": {
+                "jenkins-master-role": {
+                    "description": "The accepted resource roles that the Jenkins master itself runs as using Marathon. By default, this will deploy to any agents with the * role. For example, to deploy to a public DC/OS agent, set this to 'slave_public'.",
+                    "type": "string",
+                    "default": "*"
+                },
+                "jenkins-agent-role": {
+                    "description": "The role passed to the internal Jenkins configuration that denotes which resources to launch Jenkins agents on.",
+                    "type": "string",
+                    "default": "*"
+                  }
+              }
+          },
+        "security": {
+            "description": "Security configuration properties for Jenkins on DC/OS.",
+            "type": "object",
+            "properties": {
+                "strict-mode": {
+                    "description": "Enabled if Enterprise DC/OS is provisioned using the 'strict' security mode flag. When enabled, tasks run as the user specified below.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "strict-mode-user": {
+                    "description": "In strict mode, tasks will run as this user. The 'strict' security mode does not permit running tasks as root. By default, the user 'nobody' is used. Ensure that this user exists on each of the agents in your DC/OS cluster.",
+                    "type": "string",
+                    "default": "nobody"
+                }
+            }
+        },
+        "advanced": {
+            "description": "Advanced configuration properties for the Jenkins service. Under normal circumstances, you shouldn't need to modify these values.",
+            "type": "object",
+            "properties": {
+                "mesos-master": {
+                    "description": "URL of this cluster's Mesos master.",
+                    "type": "string",
+                    "default": "zk://leader.mesos:2181/mesos"
+                },
+                "jvm-opts": {
+                    "description": "Optional arguments to pass to the JVM.",
+                    "type": "string",
+                    "default": "-Xms1024m -Xmx1024m"
+                },
+                "jenkins-opts": {
+                    "description": "Optional arguments to pass to Jenkins.",
+                    "type": "string"
+                },
+                "docker-image": {
+                    "description": "The Docker image to use for the Jenkins service. By default, this package will use the Jenkins image in the Mesosphere organization on Docker Hub, which you must be authenticated against. Otherwise, specify the host, image, and tag for the Jenkins image on your private Docker Registry.",
+                    "type": "string"
+                },
+                "docker-credentials-uri": {
+                    "description": "An optional URI to be fetched and extracted that contains docker credentials (e.g. file:///etc/docker/docker.tar.gz).",
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/J/jenkins/13/marathon.json.mustache
+++ b/repo/packages/J/jenkins/13/marathon.json.mustache
@@ -1,0 +1,83 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "instances": 1,
+  "env": {
+      "JENKINS_AGENT_ROLE": "{{roles.jenkins-agent-role}}",
+      "JENKINS_AGENT_USER": "{{#security.strict-mode}}{{security.strict-mode-user}}{{/security.strict-mode}}{{^security.strict-mode}}root{{/security.strict-mode}}",
+      "JENKINS_FRAMEWORK_NAME": "{{service.name}}",
+      "JENKINS_CONTEXT": "/service/{{service.name}}",
+      "JENKINS_MESOS_MASTER": "{{advanced.mesos-master}}",
+      {{#networking.root-url}}
+      "JENKINS_ROOT_URL": "{{networking.root-url}}",
+      {{/networking.root-url}}
+      "JVM_OPTS": "{{advanced.jvm-opts}}",
+      "JENKINS_OPTS": "{{advanced.jenkins-opts}}",
+      "LD_LIBRARY_PATH": "/opt/mesosphere/lib",
+      "SSH_KNOWN_HOSTS": "{{networking.known-hosts}}"
+  },
+  "ports": [0, 0],
+  "container": {
+       "type": "DOCKER",
+       "docker": {
+       {{#advanced.docker-image}}
+           "image": "{{advanced.docker-image}}",
+       {{/advanced.docker-image}}
+       {{^advanced.docker-image}}
+           "image": "{{resource.assets.container.docker.jenkins-201-274}}",
+       {{/advanced.docker-image}}
+           "network" : "HOST"
+       },
+       "volumes": [
+           {
+               "containerPath": "/var/jenkins_home",
+               "hostPath": "{{storage.host-volume}}/{{service.name}}",
+               "mode": "RW"
+           },
+           {
+               "containerPath": "/opt/mesosphere",
+               "hostPath": "/opt/mesosphere",
+               "mode": "RO"
+           }
+       ]
+   },
+   {{#advanced.docker-credentials-uri}}
+   "fetch": [
+      {
+          "uri": "{{advanced.docker-credentials-uri}}",
+          "executable": false,
+          "extract": true
+      }
+   ],{{/advanced.docker-credentials-uri}}
+   "acceptedResourceRoles": [ "{{roles.jenkins-master-role}}" ],
+   "healthChecks": [
+    {
+      "path": "/service/{{service.name}}",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "gracePeriodSeconds": 30,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3
+    }
+  ],
+  "labels": {
+    {{#networking.virtual-host}}
+    "HAPROXY_GROUP":"external",
+    "HAPROXY_0_VHOST":"{{networking.virtual-host}}",
+    "HAPROXY_0_REDIRECT_TO_HTTPS": "{{networking.https-redirect}}",
+    {{/networking.virtual-host}}
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }{{#storage.pinned-hostname}},
+  "constraints": [["hostname", "CLUSTER", "{{storage.pinned-hostname}}"]]
+  {{/storage.pinned-hostname}}
+}

--- a/repo/packages/J/jenkins/13/package.json
+++ b/repo/packages/J/jenkins/13/package.json
@@ -1,0 +1,21 @@
+{
+  "packagingVersion": "2.0",
+  "name": "jenkins",
+  "version": "2.0.1-2.7.4",
+  "scm": "https://github.com/mesosphere/jenkins-dcos.git",
+  "maintainer": "support@mesosphere.io",
+  "website": "https://jenkins.io",
+  "framework": true,
+  "description": "Jenkins is an award-winning, cross-platform, continuous integration and continuous delivery application that increases your productivity. Use Jenkins to build and test your software projects continuously making it easier for developers to integrate changes to the project, and making it easier for users to obtain a fresh build. It also allows you to continuously deliver your software by providing powerful ways to define your build pipelines and integrating with a large number of testing and deployment technologies.",
+  "tags": ["continuous-integration", "ci", "jenkins"],
+  "preInstallNotes": "WARNING: If you didn't provide a value for `host-volume` in the CLI,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n",
+  "postInstallNotes": "Jenkins has been installed.",
+  "postUninstallNotes": "Jenkins has been uninstalled. Note that any data persisted to a NFS share still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/mesosphere/jenkins-dcos/blob/master/LICENSE"
+    }
+  ],
+  "selected": true
+}

--- a/repo/packages/J/jenkins/13/resource.json
+++ b/repo/packages/J/jenkins/13/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-jenkins-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-jenkins-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-jenkins-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "jenkins-201-272": "mesosphere/jenkins:2.0.1-2.7.4"
+      }
+    }
+  }
+}

--- a/repo/packages/J/jenkins/13/resource.json
+++ b/repo/packages/J/jenkins/13/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "jenkins-201-272": "mesosphere/jenkins:2.0.1-2.7.4"
+        "jenkins-201-274": "mesosphere/jenkins:2.0.1-2.7.4"
       }
     }
   }


### PR DESCRIPTION
Update Jenkins to 2.7.4 LTS and a handful of plugins. This version also adds the GitLab plugin.

Add the new JENKINS_OPTS parameter to the package configuration.