### PR TITLE
Updated dcos-enterprise-cli package resource.json file

### DIFF
--- a/repo/packages/D/dcos-enterprise-cli/3/resource.json
+++ b/repo/packages/D/dcos-enterprise-cli/3/resource.json
@@ -1,4 +1,7 @@
 {
+    "assets": {
+    },
+
     "cli": {
         "binaries": {
             "darwin": {


### PR DESCRIPTION
resource.json file for dcos-enterprise-cli package is missing "assets":  section which is causing failure of offline-universe.py. 

ERROR BELOW 
root@centos72 universe]# ./scripts/local-universe.py --repository ./repo/packages --include="dcos-enterprise-cli"
Start docker registry.
40adf950bd232b45292f5196b3f70c188a62c3d4f130130281a476b5fe4ead32
Stopping docker registry.
registry
Traceback (most recent call last):
File "./scripts/local-universe.py", line 314, in <module>
sys.exit(main())
File "./scripts/local-universe.py", line 104, in main
args.selected)):
File "/usr/lib64/python3.4/concurrent/futures/_base.py", line 549, in result_iterator
yield future.result()
File "/usr/lib64/python3.4/concurrent/futures/_base.py", line 395, in result
return self.__get_result()
File "/usr/lib64/python3.4/concurrent/futures/_base.py", line 354, in __get_result
raise self._exception
File "/usr/lib64/python3.4/concurrent/futures/thread.py", line 54, in run
result = self.fn(*self.args, **self.kwargs)
File "./scripts/local-universe.py", line 84, in handle_package
repo_artifacts)
File "./scripts/local-universe.py", line 273, in prepare_repository
if 'container' in resource["assets"]:
KeyError: 'assets'
[root@centos72 universe]#

Error results from a missing 'assets': section in resource.json