### PR TITLE
Upgrade Riak packaging

### DIFF
--- a/repo/packages/R/riak/1/command.json
+++ b/repo/packages/R/riak/1/command.json
@@ -1,6 +1,0 @@
-{
-  "pip": [
-    "git+https://github.com/basho-labs/riak-mesos-tools.git@riak-mesos-v1.1.x#egg=riak_mesos",
-    "git+https://github.com/basho-labs/riak-mesos-dcos-shims@0.0.1"
-  ]
-}

--- a/repo/packages/R/riak/1/command.json
+++ b/repo/packages/R/riak/1/command.json
@@ -1,0 +1,6 @@
+{
+  "pip": [
+    "git+https://github.com/basho-labs/riak-mesos-tools.git@riak-mesos-v1.1.x#egg=riak_mesos",
+    "git+https://github.com/basho-labs/riak-mesos-dcos-shims@0.0.1"
+  ]
+}

--- a/repo/packages/R/riak/1/config.json
+++ b/repo/packages/R/riak/1/config.json
@@ -40,21 +40,6 @@
                     "description": "Framework Role.",
                     "default": "riak"
                 },
-                "auth-principal": {
-                    "type": "string",
-                    "description": "Mesos authentication principal.",
-                    "default": ""
-                },
-                "auth-provider": {
-                    "type": "string",
-                    "description": "Mesos authentication provider.",
-                    "default": ""
-                },
-                "auth-secret-file": {
-                    "type": "string",
-                    "description": "Mesos authentication secret file.",
-                    "default": ""
-                },
                 "instances": {
                     "type": "number",
                     "description": "Number of framework instances",
@@ -188,7 +173,6 @@
                 "master",
                 "zk",
                 "user",
-                "auth-principal",
                 "instances",
                 "healthcheck-grace-period-seconds",
                 "healthcheck-interval-seconds",

--- a/repo/packages/R/riak/1/config.json
+++ b/repo/packages/R/riak/1/config.json
@@ -28,7 +28,7 @@
                 "zk": {
                     "type": "string",
                     "description": "Zookeeper address. Specify in the format host:port.",
-                    "default": "leader.mesos:2181"
+                    "default": "zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181"
                 },
                 "user": {
                     "type": "string",

--- a/repo/packages/R/riak/1/config.json
+++ b/repo/packages/R/riak/1/config.json
@@ -3,7 +3,7 @@
     "properties": {
         "riak": {
             "type": "object",
-            "description": "Riak Mesos Framework specific properties",
+            "description": "Configuration properties for the Riak service for DC/OS.",
             "properties": {
                 "framework-name": {
                     "type": "string",

--- a/repo/packages/R/riak/1/config.json
+++ b/repo/packages/R/riak/1/config.json
@@ -104,16 +104,16 @@
                 },
                 "scheduler": {
                     "type": "object",
-                    "description": "Requirements for Riak Mesos Scheduler",
+                    "description": "Requirements for Riak DC/OS Scheduler",
                     "properties": {
                         "cpus": {
                             "type": "number",
-                            "description": "Riak Mesos Scheduler CPU requirements",
+                            "description": "Riak DC/OS Scheduler CPU requirements",
                             "default": 0.5
                         },
                         "mem": {
                             "type": "number",
-                            "description": "Riak Mesos Scheduler Memory requirements",
+                            "description": "Riak DC/OS Scheduler Memory requirements",
                             "default": 2048.0
                         },
                         "constraints": {
@@ -125,16 +125,16 @@
                 },
                 "executor": {
                     "type": "object",
-                    "description": "Requirements for Riak Mesos Executor",
+                    "description": "Requirements for Riak DC/OS Executor",
                     "properties": {
                         "cpus": {
                             "type": "number",
-                            "description": "Riak Mesos Executor CPU requirements",
+                            "description": "Riak DC/OS Executor CPU requirements",
                             "default": 0.1
                         },
                         "mem": {
                             "type": "number",
-                            "description": "Riak Mesos Executor Memory requirements",
+                            "description": "Riak DC/OS Executor Memory requirements",
                             "default": 512.0
                         }
                     }
@@ -162,7 +162,7 @@
                 },
                 "director": {
                     "type": "object",
-                    "description": "Requirements for Riak Mesos Director",
+                    "description": "Requirements for Riak DC/OS Director",
                     "properties": {
                         "use-public": {
                             "type": "boolean",
@@ -171,7 +171,7 @@
                         },
                         "cpus": {
                             "type": "number",
-                            "description": "Riak Mesos Director CPU requirements",
+                            "description": "Riak DC/OS Director CPU requirements",
                             "default": 0.5
                         },
                         "mem": {

--- a/repo/packages/R/riak/1/config.json
+++ b/repo/packages/R/riak/1/config.json
@@ -1,0 +1,204 @@
+{
+    "type": "object",
+    "properties": {
+        "riak": {
+            "type": "object",
+            "description": "Riak Mesos Framework specific properties",
+            "properties": {
+                "framework-name": {
+                    "type": "string",
+                    "description": "Framework Instance Name.",
+                    "default": "riak"
+                },
+                "hostname": {
+                    "default": "riak.marathon.mesos",
+                    "type": "string",
+                    "description": "Framework HTTP API hostname."
+                },
+                "marathon": {
+                    "type": "string",
+                    "description": "The Marathon URL.",
+                    "default": "marathon.mesos:8080"
+                },
+                "master": {
+                    "type": "string",
+                    "description": "The URL of the Mesos master.",
+                    "default": "leader.mesos:5050"
+                },
+                "zk": {
+                    "type": "string",
+                    "description": "Zookeeper address. Specify in the format host:port.",
+                    "default": "leader.mesos:2181"
+                },
+                "user": {
+                    "type": "string",
+                    "description": "Framework User.",
+                    "default": "root"
+                },
+                "role": {
+                    "type": "string",
+                    "description": "Framework Role.",
+                    "default": "riak"
+                },
+                "auth-principal": {
+                    "type": "string",
+                    "description": "Mesos authentication principal.",
+                    "default": ""
+                },
+                "auth-provider": {
+                    "type": "string",
+                    "description": "Mesos authentication provider.",
+                    "default": ""
+                },
+                "auth-secret-file": {
+                    "type": "string",
+                    "description": "Mesos authentication secret file.",
+                    "default": ""
+                },
+                "instances": {
+                    "type": "number",
+                    "description": "Number of framework instances",
+                    "default": 1
+                },
+                "healthcheck-grace-period-seconds": {
+                    "type": "number",
+                    "description": "Memory requirements",
+                    "default": 300
+                },
+                "healthcheck-interval-seconds": {
+                    "type": "number",
+                    "description": "Memory requirements",
+                    "default": 60
+                },
+                "healthcheck-timeout-seconds": {
+                    "type": "number",
+                    "description": "Memory requirements",
+                    "default": 20
+                },
+                "healthcheck-max-consecutive-failures": {
+                    "type": "number",
+                    "description": "Memory requirements",
+                    "default": 5
+                },
+                "constraints": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "string",
+                                "enum": ["UNIQUE", "CLUSTER", "GROUP_BY", "LIKE", "UNLIKE"]
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "minItems": 2,
+                        "additionalItems": false
+                    },
+                    "description": "Marathon constraints for the framework/scheduler instance. Valid constraint operators are one of UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE.",
+                    "default": []
+                },
+                "scheduler": {
+                    "type": "object",
+                    "description": "Requirements for Riak Mesos Scheduler",
+                    "properties": {
+                        "cpus": {
+                            "type": "number",
+                            "description": "Riak Mesos Scheduler CPU requirements",
+                            "default": 0.5
+                        },
+                        "mem": {
+                            "type": "number",
+                            "description": "Riak Mesos Scheduler Memory requirements",
+                            "default": 2048.0
+                        },
+                        "constraints": {
+                            "type": "string",
+                            "default": "[[\"hostname\", \"UNIQUE\"]]",
+                            "description": "Scheduler constraints for Riak node tasks. Valid constraint operators are one of UNIQUE, CLUSTER, GROUP_BY, LIKE, UNLIKE."
+                        }
+                    }
+                },
+                "executor": {
+                    "type": "object",
+                    "description": "Requirements for Riak Mesos Executor",
+                    "properties": {
+                        "cpus": {
+                            "type": "number",
+                            "description": "Riak Mesos Executor CPU requirements",
+                            "default": 0.1
+                        },
+                        "mem": {
+                            "type": "number",
+                            "description": "Riak Mesos Executor Memory requirements",
+                            "default": 512.0
+                        }
+                    }
+                },
+                "node": {
+                    "type": "object",
+                    "description": "Requirements for Riak",
+                    "properties": {
+                        "cpus": {
+                            "type": "number",
+                            "description": "Riak CPU requirements",
+                            "default": 8.0
+                        },
+                        "mem": {
+                            "type": "number",
+                            "description": "Riak Memory requirements",
+                            "default": 16000.0
+                        },
+                        "disk": {
+                            "type": "number",
+                            "description": "Riak Disk requirements",
+                            "default": 200000.0
+                        }
+                    }
+                },
+                "director": {
+                    "type": "object",
+                    "description": "Requirements for Riak Mesos Director",
+                    "properties": {
+                        "use-public": {
+                            "type": "boolean",
+                            "description": "When true, only deploys director on public agents.",
+                            "default": false
+                        },
+                        "cpus": {
+                            "type": "number",
+                            "description": "Riak Mesos Director CPU requirements",
+                            "default": 0.5
+                        },
+                        "mem": {
+                            "type": "number",
+                            "description": "Riak Director Memory requirements",
+                            "default": 1024.0
+                        }
+                    }
+                }
+            },
+            "required": [
+                "framework-name",
+                "marathon",
+                "master",
+                "zk",
+                "user",
+                "auth-principal",
+                "instances",
+                "healthcheck-grace-period-seconds",
+                "healthcheck-interval-seconds",
+                "healthcheck-timeout-seconds",
+                "healthcheck-max-consecutive-failures",
+                "scheduler",
+                "executor",
+                "node",
+                "director"
+            ]
+        }
+    }
+}

--- a/repo/packages/R/riak/1/marathon.json.mustache
+++ b/repo/packages/R/riak/1/marathon.json.mustache
@@ -5,7 +5,6 @@
     "cpus": {{riak.scheduler.cpus}},
     "mem": {{riak.scheduler.mem}},
     "ports":[ 0 ],
-    {{! Generated field }}
     "fetch": [{"extract": false, "uri": "{{resource.assets.uris.riak-kv-2-2}}"}, {"extract": false, "uri": "{{resource.assets.uris.explorer}}"}, {"extract": false, "uri": "{{resource.assets.uris.director}}"}, {"extract": false, "uri": "{{resource.assets.uris.riak-ts-1-4}}"}, {"extract": true, "uri": "{{resource.assets.uris.scheduler}}"}, {"extract": false, "uri": "{{resource.assets.uris.executor}}"}, {"extract": false, "uri": "{{resource.assets.uris.patches}}"}],
     "cmd":"./riak_mesos_scheduler/bin/ermf-scheduler",
     {{#riak.constraints}}"constraints": {{{riak.constraints}}},{{/riak.constraints}}
@@ -16,7 +15,6 @@
         ,"RIAK_MESOS_USER": "{{riak.user}}"
         ,"RIAK_MESOS_DIRECTOR_CPUS": "{{riak.director.cpus}}"
         ,"RIAK_MESOS_DIRECTOR_MEM": "{{riak.director.mem}}"
-        {{! Generated field }}
         ,"RIAK_MESOS_RESOURCE_URLS": "{\"riak-kv-2-2\": \"{{resource.assets.uris.riak-kv-2-2}}\",\"explorer\": \"{{resource.assets.uris.explorer}}\",\"director\": \"{{resource.assets.uris.director}}\",\"riak-ts-1-4\": \"{{resource.assets.uris.riak-ts-1-4}}\",\"scheduler\": \"{{resource.assets.uris.scheduler}}\",\"executor\": \"{{resource.assets.uris.executor}}\",\"patches\": \"{{resource.assets.uris.patches}}\"}"
         {{#riak.director.use-public}},"RIAK_MESOS_DIRECTOR_PUBLIC": "{{riak.director.use-public}}"{{/riak.director.use-public}}
         {{#riak.scheduler.constraints}},"RIAK_MESOS_CONSTRAINTS": "{{riak.scheduler.constraints}}"{{/riak.scheduler.constraints}}

--- a/repo/packages/R/riak/1/marathon.json.mustache
+++ b/repo/packages/R/riak/1/marathon.json.mustache
@@ -4,7 +4,7 @@
     "cpus": {{riak.scheduler.cpus}},
     "mem": {{riak.scheduler.mem}},
     "ports":[ 0 ],
-    "fetch": [{"extract": false, "uri": "{{resource.assets.uris.riak-kv-2-2}}"}, {"extract": false, "uri": "{{resource.assets.uris.explorer}}"}, {"extract": false, "uri": "{{resource.assets.uris.director}}"}, {"extract": false, "uri": "{{resource.assets.uris.riak-ts-1-4}}"}, {"extract": true, "uri": "{{resource.assets.uris.scheduler}}"}, {"extract": false, "uri": "{{resource.assets.uris.executor}}"}, {"extract": false, "uri": "{{resource.assets.uris.patches}}"}],
+    "fetch": [{"extract": false, "uri": "{{resource.assets.uris.riak-kv-2-2}}"}, {"extract": false, "uri": "{{resource.assets.uris.explorer}}"}, {"extract": false, "uri": "{{resource.assets.uris.director}}"}, {"extract": false, "uri": "{{resource.assets.uris.riak-ts-1-5}}"}, {"extract": true, "uri": "{{resource.assets.uris.scheduler}}"}, {"extract": false, "uri": "{{resource.assets.uris.executor}}"}, {"extract": false, "uri": "{{resource.assets.uris.patches}}"}],
     "cmd":"./riak_mesos_scheduler/bin/ermf-scheduler",
     {{#riak.constraints}}"constraints": {{{riak.constraints}}},{{/riak.constraints}}
     "env": {
@@ -14,7 +14,7 @@
         ,"RIAK_MESOS_USER": "{{riak.user}}"
         ,"RIAK_MESOS_DIRECTOR_CPUS": "{{riak.director.cpus}}"
         ,"RIAK_MESOS_DIRECTOR_MEM": "{{riak.director.mem}}"
-        ,"RIAK_MESOS_RESOURCE_URLS": "{\"riak-kv-2-2\": \"{{resource.assets.uris.riak-kv-2-2}}\",\"explorer\": \"{{resource.assets.uris.explorer}}\",\"director\": \"{{resource.assets.uris.director}}\",\"riak-ts-1-4\": \"{{resource.assets.uris.riak-ts-1-4}}\",\"scheduler\": \"{{resource.assets.uris.scheduler}}\",\"executor\": \"{{resource.assets.uris.executor}}\",\"patches\": \"{{resource.assets.uris.patches}}\"}"
+        ,"RIAK_MESOS_RESOURCE_URLS": "{\"riak-kv-2-2\": \"{{resource.assets.uris.riak-kv-2-2}}\",\"explorer\": \"{{resource.assets.uris.explorer}}\",\"director\": \"{{resource.assets.uris.director}}\",\"riak-ts-1-5\": \"{{resource.assets.uris.riak-ts-1-5}}\",\"scheduler\": \"{{resource.assets.uris.scheduler}}\",\"executor\": \"{{resource.assets.uris.executor}}\",\"patches\": \"{{resource.assets.uris.patches}}\"}"
         {{#riak.director.use-public}},"RIAK_MESOS_DIRECTOR_PUBLIC": "{{riak.director.use-public}}"{{/riak.director.use-public}}
         {{#riak.scheduler.constraints}},"RIAK_MESOS_CONSTRAINTS": "{{riak.scheduler.constraints}}"{{/riak.scheduler.constraints}}
         {{#riak.auth-principal}},"RIAK_MESOS_PRINCIPAL": "{{riak.auth-principal}}"{{/riak.auth-principal}}

--- a/repo/packages/R/riak/1/marathon.json.mustache
+++ b/repo/packages/R/riak/1/marathon.json.mustache
@@ -1,4 +1,3 @@
-{{! Do not edit. Generated from marathon.json.mustache.tpl }}
 {
     "id":"{{riak.framework-name}}",
     "instances": {{riak.instances}},

--- a/repo/packages/R/riak/1/marathon.json.mustache
+++ b/repo/packages/R/riak/1/marathon.json.mustache
@@ -1,0 +1,50 @@
+{{! Do not edit. Generated from marathon.json.mustache.tpl }}
+{
+    "id":"{{riak.framework-name}}",
+    "instances": {{riak.instances}},
+    "cpus": {{riak.scheduler.cpus}},
+    "mem": {{riak.scheduler.mem}},
+    "ports":[ 0 ],
+    {{! Generated field }}
+    "fetch": [{"extract": false, "uri": "{{resource.assets.uris.riak-kv-2-2}}"}, {"extract": false, "uri": "{{resource.assets.uris.explorer}}"}, {"extract": false, "uri": "{{resource.assets.uris.director}}"}, {"extract": false, "uri": "{{resource.assets.uris.riak-ts-1-4}}"}, {"extract": true, "uri": "{{resource.assets.uris.scheduler}}"}, {"extract": false, "uri": "{{resource.assets.uris.executor}}"}, {"extract": false, "uri": "{{resource.assets.uris.patches}}"}],
+    "cmd":"./riak_mesos_scheduler/bin/ermf-scheduler",
+    {{#riak.constraints}}"constraints": {{{riak.constraints}}},{{/riak.constraints}}
+    "env": {
+        "RIAK_MESOS_NAME": "{{riak.framework-name}}"
+        ,"RIAK_MESOS_ZK": "{{riak.zk}}"
+        ,"RIAK_MESOS_MASTER": "{{riak.master}}"
+        ,"RIAK_MESOS_USER": "{{riak.user}}"
+        ,"RIAK_MESOS_DIRECTOR_CPUS": "{{riak.director.cpus}}"
+        ,"RIAK_MESOS_DIRECTOR_MEM": "{{riak.director.mem}}"
+        {{! Generated field }}
+        ,"RIAK_MESOS_RESOURCE_URLS": "{\"riak-kv-2-2\": \"{{resource.assets.uris.riak-kv-2-2}}\",\"explorer\": \"{{resource.assets.uris.explorer}}\",\"director\": \"{{resource.assets.uris.director}}\",\"riak-ts-1-4\": \"{{resource.assets.uris.riak-ts-1-4}}\",\"scheduler\": \"{{resource.assets.uris.scheduler}}\",\"executor\": \"{{resource.assets.uris.executor}}\",\"patches\": \"{{resource.assets.uris.patches}}\"}"
+        {{#riak.director.use-public}},"RIAK_MESOS_DIRECTOR_PUBLIC": "{{riak.director.use-public}}"{{/riak.director.use-public}}
+        {{#riak.scheduler.constraints}},"RIAK_MESOS_CONSTRAINTS": "{{riak.scheduler.constraints}}"{{/riak.scheduler.constraints}}
+        {{#riak.auth-principal}},"RIAK_MESOS_PRINCIPAL": "{{riak.auth-principal}}"{{/riak.auth-principal}}
+        {{#riak.auth-provider}},"RIAK_MESOS_PROVIDER": "{{riak.auth-provider}}"{{/riak.auth-provider}}
+        {{#riak.auth-secret-file}},"RIAK_MESOS_SECRET_FILE": "{{riak.auth-secret-file}}"{{/riak.auth-secret-file}}
+        {{#riak.role}},"RIAK_MESOS_ROLE": "{{riak.role}}"{{/riak.role}}
+        {{#riak.ip}},"RIAK_MESOS_IP": "{{riak.ip}}"{{/riak.ip}}
+        {{#riak.hostname}},"RIAK_MESOS_HOSTNAME": "{{riak.hostname}}"{{/riak.hostname}}
+        {{#riak.failover-timeout}},"RIAK_MESOS_FAILOVER_TIMEOUT": "{{riak.failover-timeout}}"{{/riak.failover-timeout}}
+        {{#riak.node.cpus}},"RIAK_MESOS_NODE_CPUS": "{{riak.node.cpus}}"{{/riak.node.cpus}}
+        {{#riak.node.mem}},"RIAK_MESOS_NODE_MEM": "{{riak.node.mem}}"{{/riak.node.mem}}
+        {{#riak.node.disk}},"RIAK_MESOS_NODE_DISK": "{{riak.node.disk}}"{{/riak.node.disk}}
+        {{#riak.executor.cpus}},"RIAK_MESOS_EXECUTOR_CPUS": "{{riak.executor.cpus}}"{{/riak.executor.cpus}}
+        {{#riak.executor.mem}},"RIAK_MESOS_EXECUTOR_MEM": "{{riak.executor.mem}}"{{/riak.executor.mem}}
+    },
+    "healthChecks": [
+    {
+      "path": "/healthcheck",
+      "portIndex": 0,
+      "protocol": "HTTP",
+      "gracePeriodSeconds": {{riak.healthcheck-grace-period-seconds}},
+      "intervalSeconds": {{riak.healthcheck-interval-seconds}},
+      "timeoutSeconds": {{riak.healthcheck-timeout-seconds}},
+      "maxConsecutiveFailures": {{riak.healthcheck-max-consecutive-failures}},
+      "ignoreHttp1xx": false
+    }],
+    "labels": {
+        "DCOS_PACKAGE_FRAMEWORK_NAME": "{{riak.framework-name}}"
+    }
+}

--- a/repo/packages/R/riak/1/package.json
+++ b/repo/packages/R/riak/1/package.json
@@ -10,7 +10,7 @@
   "website": "http://basho-labs.github.io/riak-mesos/",
   "postInstallNotes": "Thank you for installing Riak on Mesos. Visit https://github.com/basho-labs/riak-mesos for usage information.",
   "preInstallNotes": "The Riak framework should have at least 16GB of RAM and 8.0 CPUs to perform successfully. Documentation: https://github.com/dcos/examples/tree/master/1.8/riak",
-  "postUninstallNotes": "The Mesos Riak Framework has been uninstalled, .",
+  "postUninstallNotes": "The Mesos Riak Framework has been uninstalled.",
   "licenses": [
     {
       "name": "Apache License Version 2.0",

--- a/repo/packages/R/riak/1/package.json
+++ b/repo/packages/R/riak/1/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "3.0",
   "minDcosReleaseVersion": "1.8",
   "name": "riak",
-  "version": "2.0.0rc2",
+  "version": "2.0.0",
   "framework": true,
   "tags": ["basho", "framework", "database", "riak", "riak-kv", "riak-ts"],
   "maintainer": "help@basho.com",

--- a/repo/packages/R/riak/1/package.json
+++ b/repo/packages/R/riak/1/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "riak",
-  "version": "2.0.0-rc2",
+  "version": "2.0.0rc2",
   "framework": true,
   "tags": ["basho", "framework", "database", "riak", "riak-kv", "riak-ts"],
   "maintainer": "help@basho.com",

--- a/repo/packages/R/riak/1/package.json
+++ b/repo/packages/R/riak/1/package.json
@@ -9,7 +9,7 @@
   "scm": "https://github.com/basho-labs/riak-mesos.git",
   "website": "http://basho-labs.github.io/riak-mesos/",
   "postInstallNotes": "Thank you for installing Riak on Mesos. Visit https://github.com/basho-labs/riak-mesos for usage information.",
-  "preInstallNotes": "The Riak framework should have at least 1GB of RAM and 0.5 CPUs to perform successfully.",
+  "preInstallNotes": "The Riak framework should have at least 16GB of RAM and 8.0 CPUs to perform successfully. Documentation: https://github.com/dcos/examples/tree/master/1.8/riak",
   "postUninstallNotes": "The Mesos Riak Framework has been uninstalled, .",
   "licenses": [
     {

--- a/repo/packages/R/riak/1/package.json
+++ b/repo/packages/R/riak/1/package.json
@@ -1,5 +1,6 @@
 {
   "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.8",
   "name": "riak",
   "version": "2.0.0rc2",
   "framework": true,

--- a/repo/packages/R/riak/1/package.json
+++ b/repo/packages/R/riak/1/package.json
@@ -9,9 +9,9 @@
   "description": "A distributed NoSQL key-value data store that offers high availability, fault tolerance, operational simplicity, and scalability.",
   "scm": "https://github.com/basho-labs/riak-mesos.git",
   "website": "http://basho-labs.github.io/riak-mesos/",
-  "postInstallNotes": "Thank you for installing Riak on Mesos. Visit https://github.com/basho-labs/riak-mesos for usage information.",
-  "preInstallNotes": "The Riak framework should have at least 16GB of RAM and 8.0 CPUs to perform successfully. Documentation: https://github.com/dcos/examples/tree/master/1.8/riak",
-  "postUninstallNotes": "The Mesos Riak Framework has been uninstalled.",
+  "postInstallNotes": "Thank you for installing Riak on DC/OS.\nPlease run `dcos riak framework wait-for-service [--timeout <secs>]` until the Framework has fully started.\nVisit https://github.com/basho-labs/riak-mesos for usage information.",
+  "preInstallNotes": "The Riak framework recommends at least 16GB of RAM and 8.0 CPUs per node to perform successfully.\nDocumentation: https://github.com/dcos/examples/tree/master/1.8/riak",
+  "postUninstallNotes": "The DC/OS Riak Framework has been uninstalled.",
   "licenses": [
     {
       "name": "Apache License Version 2.0",

--- a/repo/packages/R/riak/1/package.json
+++ b/repo/packages/R/riak/1/package.json
@@ -1,5 +1,5 @@
 {
-  "packagingVersion": "2.0",
+  "packagingVersion": "3.0",
   "name": "riak",
   "version": "2.0.0-rc2",
   "framework": true,

--- a/repo/packages/R/riak/1/package.json
+++ b/repo/packages/R/riak/1/package.json
@@ -1,0 +1,20 @@
+{
+  "packagingVersion": "2.0",
+  "name": "riak",
+  "version": "2.0.0-rc2",
+  "framework": true,
+  "tags": ["basho", "framework", "database", "riak", "riak-kv", "riak-ts"],
+  "maintainer": "help@basho.com",
+  "description": "A distributed NoSQL key-value data store that offers high availability, fault tolerance, operational simplicity, and scalability.",
+  "scm": "https://github.com/basho-labs/riak-mesos.git",
+  "website": "http://basho-labs.github.io/riak-mesos/",
+  "postInstallNotes": "Thank you for installing Riak on Mesos. Visit https://github.com/basho-labs/riak-mesos for usage information.",
+  "preInstallNotes": "The Riak framework should have at least 1GB of RAM and 0.5 CPUs to perform successfully.",
+  "postUninstallNotes": "The Mesos Riak Framework has been uninstalled, .",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/basho-labs/riak-mesos/blob/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/R/riak/1/resource.json
+++ b/repo/packages/R/riak/1/resource.json
@@ -26,7 +26,7 @@
             {"algo": "sha256", "value": "1bb661733ad2898f6714f4d8b7065d89a1f2afe1720f77f9552a3f7d6851daae"}
           ],
           "kind": "executable",
-          "url":"https://github.com/basho-labs/riak-mesos-tools/releases/download/2.0.0-rc4/dcos-riak-darwin"
+          "url":"https://github.com/basho-labs/riak-mesos-tools/releases/download/2.0.0/dcos-riak-darwin"
         }
       },
       "linux": {
@@ -35,7 +35,7 @@
             {"algo": "sha256", "value": "15120f78025df04a7ee954823757dff49249abe18b775652444274aa20e93408"}
           ],
           "kind": "executable",
-          "url": "https://github.com/basho-labs/riak-mesos-tools/releases/download/2.0.0-rc4/dcos-riak-linux"
+          "url": "https://github.com/basho-labs/riak-mesos-tools/releases/download/2.0.0/dcos-riak-linux"
         }
       }
     }

--- a/repo/packages/R/riak/1/resource.json
+++ b/repo/packages/R/riak/1/resource.json
@@ -17,5 +17,18 @@
       "riak-kv-2-2": "https://github.com/basho-labs/riak-mesos/releases/download/2.0.0-rc1/riak-2.2.0-centos-7.tar.gz",
       "riak-ts-1-4": "https://github.com/basho-labs/riak-mesos/releases/download/2.0.0-rc1/riak_ts-1.4.0-centos-7.tar.gz"
     }
+  },
+  "cli":{
+    "binaries": {
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {"algo": "sha256", "value":"371475b592e959f0948e0b311f6a8789f8e7cdfc11e072563449e53aaa988fd9"}
+          ],
+          "kind": "executable",
+          "url": "https://github.com/basho-labs/riak-mesos-tools/releases/download/2.0.0-rc3/dcos-riak-2.0.0rc2-linux-x64"
+        }
+      }
+    }
   }
 }

--- a/repo/packages/R/riak/1/resource.json
+++ b/repo/packages/R/riak/1/resource.json
@@ -23,7 +23,7 @@
       "linux": {
         "x86-64": {
           "contentHash": [
-            {"algo": "sha256", "value":"371475b592e959f0948e0b311f6a8789f8e7cdfc11e072563449e53aaa988fd9"}
+            {"algo": "sha256", "value":"15120f78025df04a7ee954823757dff49249abe18b775652444274aa20e93408"}
           ],
           "kind": "executable",
           "url": "https://github.com/basho-labs/riak-mesos-tools/releases/download/2.0.0-rc3/dcos-riak-2.0.0rc2-linux-x64"

--- a/repo/packages/R/riak/1/resource.json
+++ b/repo/packages/R/riak/1/resource.json
@@ -20,13 +20,22 @@
   },
   "cli":{
     "binaries": {
+      "darwin":{
+        "x86-64":{
+          "contentHash":[
+            {"algo": "sha256", "value": "1bb661733ad2898f6714f4d8b7065d89a1f2afe1720f77f9552a3f7d6851daae"}
+          ],
+          "kind": "executable",
+          "url":"https://github.com/basho-labs/riak-mesos-tools/releases/download/2.0.0-rc4/dcos-riak-darwin"
+        }
+      },
       "linux": {
         "x86-64": {
           "contentHash": [
-            {"algo": "sha256", "value":"15120f78025df04a7ee954823757dff49249abe18b775652444274aa20e93408"}
+            {"algo": "sha256", "value": "15120f78025df04a7ee954823757dff49249abe18b775652444274aa20e93408"}
           ],
           "kind": "executable",
-          "url": "https://github.com/basho-labs/riak-mesos-tools/releases/download/2.0.0-rc3/dcos-riak-2.0.0rc2-linux-x64"
+          "url": "https://github.com/basho-labs/riak-mesos-tools/releases/download/2.0.0-rc4/dcos-riak-linux"
         }
       }
     }

--- a/repo/packages/R/riak/1/resource.json
+++ b/repo/packages/R/riak/1/resource.json
@@ -9,26 +9,13 @@
   },
   "assets": {
     "uris": {
-      "scheduler": "https://github.com/basho-labs/riak-mesos-scheduler/releases/download/2.0.2/riak_mesos_scheduler-2.0.2-mesos-1.0.0-centos-7.tar.gz",
+      "scheduler": "https://github.com/basho-labs/riak-mesos-scheduler/releases/download/2.0.3/riak_mesos_scheduler-2.0.3-mesos-1.0.0-centos-7.tar.gz",
       "executor": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.7.1/riak_mesos_executor-1.7.1-mesos-1.0.0-centos-7.tar.gz",
       "patches": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.7.1/riak_erlpmd_patches-rel-1.7.1-mesos-1.0.0-centos-7.tar.gz",
-      "explorer": "https://github.com/basho-labs/riak_explorer/releases/download/1.3.0/riak_explorer-1.3.0.relpatch-centos-7.tar.gz",
+      "explorer": "https://github.com/basho-labs/riak_explorer/releases/download/1.4.1/riak_explorer-1.4.1.relpatch-centos-7.tar.gz",
       "director": "https://github.com/basho-labs/riak-mesos-director/releases/download/1.0.1/riak_mesos_director-1.0.1-centos-7.tar.gz",
-      "riak-kv-2-2": "https://github.com/basho-labs/riak-mesos/releases/download/2.0.0-rc1/riak-2.2.0-centos-7.tar.gz",
-      "riak-ts-1-4": "https://github.com/basho-labs/riak-mesos/releases/download/2.0.0-rc1/riak_ts-1.4.0-centos-7.tar.gz"
-    }
-  },
-  "cli":{
-    "binaries": {
-      "linux": {
-        "x86-64": {
-          "contentHash": [
-            {"algo": "sha256", "value":"371475b592e959f0948e0b311f6a8789f8e7cdfc11e072563449e53aaa988fd9"}
-          ],
-          "kind": "executable",
-          "url": "https://github.com/basho-labs/riak-mesos-tools/releases/download/2.0.0-rc3/dcos-riak-2.0.0rc2-linux-x64"
-        }
-      }
+      "riak-kv-2-2": "https://github.com/basho-labs/riak-mesos/releases/download/2.0.0-rc4/riak-2.2.0-centos-7.tar.gz",
+      "riak-ts-1-5": "https://github.com/basho-labs/riak-mesos/releases/download/2.0.0-rc4/riak_ts-1.5.1-centos-7.tar.gz"
     }
   }
 }

--- a/repo/packages/R/riak/1/resource.json
+++ b/repo/packages/R/riak/1/resource.json
@@ -17,5 +17,18 @@
       "riak-kv-2-2": "https://github.com/basho-labs/riak-mesos/releases/download/2.0.0-rc4/riak-2.2.0-centos-7.tar.gz",
       "riak-ts-1-5": "https://github.com/basho-labs/riak-mesos/releases/download/2.0.0-rc4/riak_ts-1.5.1-centos-7.tar.gz"
     }
+  },
+  "cli":{
+    "binaries": {
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {"algo": "sha256", "value":"371475b592e959f0948e0b311f6a8789f8e7cdfc11e072563449e53aaa988fd9"}
+          ],
+          "kind": "executable",
+          "url": "https://github.com/basho-labs/riak-mesos-tools/releases/download/2.0.0-rc3/dcos-riak-2.0.0rc2-linux-x64"
+        }
+      }
+    }
   }
 }

--- a/repo/packages/R/riak/1/resource.json
+++ b/repo/packages/R/riak/1/resource.json
@@ -1,0 +1,21 @@
+{
+  "images": {
+    "icon-small": "http://riak-tools.s3.amazonaws.com/riak-mesos/riak-mesos-small.png",
+    "icon-medium": "http://riak-tools.s3.amazonaws.com/riak-mesos/riak-mesos-medium.png",
+    "icon-large": "http://riak-tools.s3.amazonaws.com/riak-mesos/riak-mesos-large.png",
+    "screenshots": [
+      "http://riak-tools.s3.amazonaws.com/riak-mesos/riak-mesos-screenshot.png"
+    ]
+  },
+  "assets": {
+    "uris": {
+      "scheduler": "https://github.com/basho-labs/riak-mesos-scheduler/releases/download/2.0.2/riak_mesos_scheduler-2.0.2-mesos-1.0.0-centos-7.tar.gz",
+      "executor": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.7.1/riak_mesos_executor-1.7.1-mesos-1.0.0-centos-7.tar.gz",
+      "patches": "https://github.com/basho-labs/riak-mesos-executor/releases/download/1.7.1/riak_erlpmd_patches-rel-1.7.1-mesos-1.0.0-centos-7.tar.gz",
+      "explorer": "https://github.com/basho-labs/riak_explorer/releases/download/1.3.0/riak_explorer-1.3.0.relpatch-centos-7.tar.gz",
+      "director": "https://github.com/basho-labs/riak-mesos-director/releases/download/1.0.1/riak_mesos_director-1.0.1-centos-7.tar.gz",
+      "riak-kv-2-2": "https://github.com/basho-labs/riak-mesos/releases/download/2.0.0-rc1/riak-2.2.0-centos-7.tar.gz",
+      "riak-ts-1-4": "https://github.com/basho-labs/riak-mesos/releases/download/2.0.0-rc1/riak_ts-1.4.0-centos-7.tar.gz"
+    }
+  }
+}


### PR DESCRIPTION
Remove old Riak package, replace with Riak KV and TS variants, using:
- Riak KV 2.2.0
- Riak TS 1.5.1
