### PR TITLE
dcos-enterprise-cli: bump Darwin build of 1.0.3 release (DCOS-9804)

### DIFF
--- a/repo/packages/D/dcos-enterprise-cli/4/package.json
+++ b/repo/packages/D/dcos-enterprise-cli/4/package.json
@@ -1,0 +1,9 @@
+{
+  "packagingVersion": "3.0",
+  "name": "dcos-enterprise-cli",
+  "version": "1.0.3",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.8",
+  "description": "Enterprise DC/OS CLI",
+  "tags": [ "mesosphere", "enterprise", "subcommand" ]
+}

--- a/repo/packages/D/dcos-enterprise-cli/4/resource.json
+++ b/repo/packages/D/dcos-enterprise-cli/4/resource.json
@@ -1,0 +1,33 @@
+{
+    "assets": {
+    },
+
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "c2b565dc19c4f4e5146238d8e2f7dffb8a579b7d7433b6a337e690ad1598d2b6"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/darwin/x86-64/1.0.3/c2b565dc19c4f4e5146238d8e2f7dffb8a579b7d7433b6a337e690ad1598d2b6/dcos-enterprise-cli"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "14f1155ecfff8ac003340a6551bacbb50802436123b868159b3b6f76356824bb"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/linux/x86-64/1.0.3/14f1155ecfff8ac003340a6551bacbb50802436123b868159b3b6f76356824bb/dcos-enterprise-cli"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pulls in a fixed Darwin build for the 1.0.3 release of dcos-enterprise-cli.

For background, cf https://github.com/pyinstaller/pyinstaller/issues/1978#issuecomment-249184644.

https://mesosphere.atlassian.net/browse/DCOS-9804