### PR TITLE
Mysql + mysql admin

### DIFF
--- a/repo/packages/M/mysql-admin/0/config.json
+++ b/repo/packages/M/mysql-admin/0/config.json
@@ -31,7 +31,7 @@
                 "defaultdb": {
                     "description": "Default database. Defaults to 'defaultb'.",
                     "type": "string",
-                    "default": "defaultb"
+                    "default": "defaultdb"
                 }
             },
             "required": [

--- a/repo/packages/M/mysql-admin/0/config.json
+++ b/repo/packages/M/mysql-admin/0/config.json
@@ -1,0 +1,80 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service":{
+            "type":"object",
+            "description": "DC/OS service configuration properties",
+            "properties":{
+                "name" : {
+                    "description":"Name of this service instance.",
+                    "type":"string",
+                    "default":"mysql-admin"
+                }
+            }
+        },
+        "mysql-admin":{
+            "type": "object",
+            "description": "mysql-admin service configuration properties",
+            "properties": {
+                "cpus": {
+                    "description": "CPU shares to allocate to this mysql-admin instance.",
+                    "type": "number",
+                    "default": 0.2,
+                    "minimum": 0.2
+                },
+                "mem": {
+                    "description": "Memory to allocate to this mysql-admin instance.",
+                    "type": "number",
+                    "default": 256.0,
+                    "minimum": 256.0
+                },
+                "defaultdb": {
+                    "description": "Default database. Defaults to 'defaultb'.",
+                    "type": "string",
+                    "default": "defaultb"
+                }
+            },
+            "required": [
+                "cpus",
+                "mem"
+            ]
+        },
+        "networking":{
+            "type": "object",
+            "description": "MySQL admin networking configuration properties",
+            "properties": {
+                "mysql_location":{
+                    "description": "The name of the DC/OS mysql instance to connect to.",
+                    "type": "string",
+                    "default": "mysql"
+                },
+                "mysql_host_port":{
+                    "description": "The port where the mysql instance is listening on. Defaults to 3306",
+                    "type": "number",
+                    "default": 3306
+                },
+                "external_access": {
+                    "type": "object",
+                    "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+                    "properties": {    
+                        "enable": {
+                            "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB. Defaults to false.",
+                            "type": "boolean",
+                            "default": false                    
+                        },
+                        "external_port": {
+                            "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+                            "type": "number",
+                            "default": 13307
+                        },
+                        "virtual_host": {
+                            "description": "For external access, Virtual Host URL to be used in the external load balancer.",
+                            "type": "string",
+                            "default": "mysql-admin.example.org"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/M/mysql-admin/0/marathon.json.mustache
+++ b/repo/packages/M/mysql-admin/0/marathon.json.mustache
@@ -1,0 +1,51 @@
+{
+    "id": "{{service.name}}",
+    "cpus": {{mysql-admin.cpus}},
+    "mem": {{mysql-admin.mem}},
+    "instances": 1,
+    "env": {
+        "PMA_HOST": "{{networking.mysql_location}}.marathon.l4lb.thisdcos.directory",
+        "PMA_PORT": "{{networking.mysql_host_port}}"
+    },
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.mysql-admin-docker}}",
+            "forcePullImage": false,
+            "network": "BRIDGE",
+            "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 0,
+                {{#networking.external_access.enable}}
+                "servicePort": {{networking.external_access.external_port}},
+                {{/networking.external_access.enable}}
+                "protocol": "tcp"
+            }
+            ]
+        }
+    },
+    "healthChecks": [
+        {
+            "protocol": "HTTP",
+            "path": "/",
+            "portIndex": 0,
+
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ],
+    "labels": {
+        "DCOS_PACKAGE_VERSION": "0.1",
+        "DCOS_SERVICE_NAME": "{{service.name}}",
+        "DCOS_SERVICE_SCHEME": "http",
+        "DCOS_SERVICE_PORT_INDEX": "0",
+        {{#networking.external_access.enable}}
+        "HAPROXY_GROUP": "external",
+        "HAPROXY_0_VHOST": "{{networking.external_access.virtual_host}}",
+        {{/networking.external_access.enable}}        
+        "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+    }
+}

--- a/repo/packages/M/mysql-admin/0/package.json
+++ b/repo/packages/M/mysql-admin/0/package.json
@@ -1,0 +1,23 @@
+{
+  "packagingVersion": "3.0",
+  "name": "mysql-admin",
+  "version": "0.1",
+  "scm": "https://github.com/phpmyadmin/docker",
+  "maintainer": "support@mesosphere.io",
+  "website": "https://www.phpmyadmin.net/",
+  "description": "phpMyAdmin is a free software tool written in PHP, intended to handle the administration of MySQL over the Web. phpMyAdmin supports a wide range of operations on MySQL and MariaDB.\n\nThis DC/OS package is ready to be used alongside the DC/OS `mysql` package. Other MySQL servers may work, but haven't been tested.",
+  "tags": [
+    "mysql",
+    "database",
+    "admin"
+    ],
+  "preInstallNotes": "MySQL Admin requires at least 0.2 CPU and 256MB of RAM.\n\nWARNING: MySQL Admin on DCOS is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nThis package will automatically connect to an existing DC/OS `mysql` package through an automated Virtual IP.\n\nThis package is accessible through the DC/OS `Services` tab. If the `external_access`is enabled on installation, it will also create an entry in the DC/OS external load balancer for accessing the UI from outside the cluster, by default in port `13306`. Access the UI at `http://your_DCOS_URL/services/mysql-admin` or at `http://your_public_node_ip:13306` if `external_access` is enabled",
+  "postInstallNotes": "MySQL Admin has been installed.\n\nYou can now access the UI at `http://your_DCOS_URL/services/mysql-admin` or at `http://your_public_node_ip:13306` if you selected `external_access` on installation.\n\nDC/OS MySQL default Login: `admin`\nDefault password: `password`",
+  "postUninstallNotes": "MySQL Admin has been uninstalled.",
+  "licenses": [
+    {
+      "name": "GNU GPL License",
+      "url": "https://raw.githubusercontent.com/phpmyadmin/docker/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/M/mysql-admin/0/resource.json
+++ b/repo/packages/M/mysql-admin/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "http://enitedinternational.com/img/icons/icon/mysql-icon.png",
+    "icon-medium": "http://www.ebexsoft.com/images/icons/mysql.jpg",
+    "icon-large": "http://michaelglesenkamp.com/images/icons/icon-mysql.jpg"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "mysql-admin-docker": "phpmyadmin/phpmyadmin:4.6.4-1"
+      }
+    }
+  }
+}

--- a/repo/packages/M/mysql/4/config.json
+++ b/repo/packages/M/mysql/4/config.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "Name of this service instance",
+          "type": "string",
+          "default": "mysql"
+        }
+      }
+    },
+    "mysql": {
+      "type": "object",
+      "description": "MySQL service configuration properties",
+      "properties": {
+        "cpus": {
+          "description": "CPU shares to allocate to each MySQL node.",
+          "type": "number",
+          "default": 0.3,
+          "minimum": 0.3
+        },
+        "mem": {
+          "description": "Memory to allocate to each MySQL node.",
+          "type": "number",
+          "default": 1024.0,
+          "minimum": 1024.0
+        }
+      },
+      "required": [
+        "cpus",
+        "mem"
+      ]
+    },
+    "database": {
+      "type": "object",
+      "description": "MySQL database configuration properties",
+      "properties":{
+        "create_new": {
+          "description": "Optionally create a new MySQL database.",
+          "type": "boolean",
+          "default": true
+        },
+        "name": {
+          "description": "The name of a database to be created on startup.",
+          "type": "string",
+          "default": "defaultdb"
+        },
+        "username": {
+          "description": "The username of a user to be created with superuser access to this database only.",
+          "type": "string",
+          "default": "admin"
+        },
+        "password": {
+          "description": "The password for a user to be created with superuser access to this database only.",
+          "type": "string",
+          "default": "password"
+        },
+        "root_password": {
+          "description": "Specifies the password that will be set for the MySQL root superuser account.",
+          "type": "string",
+          "default": "root"
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "description": "MySQL storage configuration properties",
+      "properties":{    
+        "host_volume": {
+          "description": "The location of a volume on the host to be used for persisting MySQL data. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/mysql`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents.",
+          "type": "string",
+          "default": "/tmp"
+        },
+        "persistence": {
+          "type": "object",
+          "description": "Enable persistent storage.",
+          "properties": {    
+            "enable": {
+              "description": "Enable or disable persistent storage.",
+              "type": "boolean",
+              "default": false                    
+            },
+            "volume_size": {
+              "description": "If a new volume is to be created, this controls its size in MBs. Defaults to 64MBs",
+              "type": "number",
+              "default": 256
+            }
+          }
+        }
+      }
+    },
+    "networking": {
+      "type": "object",
+      "description": "MySQL networking configuration properties",
+      "properties": {    
+        "bridge": {
+          "default": false,
+          "description": "Whether to use bridge networking mode for Docker container. By default, this is false and host mode networking is used.",
+          "type": "boolean"
+        },
+        "port": {
+          "description": "Port number to be used for clear communication internally to the cluster.",
+          "type": "number",
+          "default": 3306
+        },
+        "external_access": {
+          "type": "object",
+          "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+            "properties": {    
+              "enable": {
+                "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB. Defaults to FALSE.",
+                "type": "boolean",
+                "default": false                    
+              },
+              "external_port": {
+                "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+                "type": "number",
+                "default": 13306
+              }
+            }
+          }
+      }      
+    }
+  }
+}

--- a/repo/packages/M/mysql/4/config.json
+++ b/repo/packages/M/mysql/4/config.json
@@ -38,11 +38,6 @@
       "type": "object",
       "description": "MySQL database configuration properties",
       "properties":{
-        "create_new": {
-          "description": "Optionally create a new MySQL database.",
-          "type": "boolean",
-          "default": true
-        },
         "name": {
           "description": "The name of a database to be created on startup.",
           "type": "string",

--- a/repo/packages/M/mysql/4/config.json
+++ b/repo/packages/M/mysql/4/config.json
@@ -91,11 +91,6 @@
       "type": "object",
       "description": "MySQL networking configuration properties",
       "properties": {    
-        "bridge": {
-          "default": false,
-          "description": "Whether to use bridge networking mode for Docker container. By default, this is false and host mode networking is used.",
-          "type": "boolean"
-        },
         "port": {
           "description": "Port number to be used for clear communication internally to the cluster. Currently unused and fixed to be 3306.",
           "type": "number",

--- a/repo/packages/M/mysql/4/config.json
+++ b/repo/packages/M/mysql/4/config.json
@@ -25,8 +25,8 @@
         "mem": {
           "description": "Memory to allocate to each MySQL node.",
           "type": "number",
-          "default": 1024.0,
-          "minimum": 1024.0
+          "default": 512.0,
+          "minimum": 512.0
         }
       },
       "required": [
@@ -97,7 +97,7 @@
           "type": "boolean"
         },
         "port": {
-          "description": "Port number to be used for clear communication internally to the cluster.",
+          "description": "Port number to be used for clear communication internally to the cluster. Currently unused and fixed to be 3306.",
           "type": "number",
           "default": 3306
         },

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -17,7 +17,7 @@
       {{^storage.persistence.enable}}
       "hostPath": "{{storage.host_volume}}/{{service.name}}",
       {{/storage.persistence.enable}}
-      {{#storage.persistence.enable}}          
+      {{#storage.persistence.enable}}
       "persistent": {
         "size": {{storage.persistence.volume_size}}
       },

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -27,8 +27,6 @@
         }
         ],
         "docker": {
-            "image": "{{resource.assets.container.docker.mysql-docker}}",
-            "forcePullImage": true,
             {{#networking.bridge}}
             "network": "BRIDGE",
             "portMappings": [{
@@ -42,12 +40,12 @@
                 "labels": {
                     "VIP_0": "/{{service.name}}:{{networking.port}}"
                 }
-            }]
+            }],
             {{/networking.bridge}}
             {{^networking.bridge}}
-            "network": "HOST"
+            "network": "HOST",
             {{/networking.bridge}}
-
+            "image": "{{resource.assets.container.docker.mysql-docker}}"
         }
     },
     {{^networking.bridge}}

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -45,7 +45,6 @@
     "healthChecks": [{
         "protocol": "TCP",
         "portIndex": 0,
-        "port": 3306,
         "gracePeriodSeconds": 300,
         "intervalSeconds": 60,
         "timeoutSeconds": 20,

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -43,9 +43,6 @@
     "labels": {
         "DCOS_PACKAGE_VERSION": "0.2",
         "DCOS_SERVICE_NAME": "{{service.name}}",
-        {{#networking.external_access.enable}}
-        "HAPROXY_GROUP": "external",
-        {{/networking.external_access.enable}},
         "DCOS_PACKAGE_IS_FRAMEWORK": "false"
     }
 }

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -13,15 +13,8 @@
     "container": {
         "type": "DOCKER",
         "volumes": [{
-            "containerPath": "var",
-            {{^storage.persistence.enable}}
-            "hostPath": "{{storage.host_volume}}/{{service.name}}",
-            {{/storage.persistence.enable}}
-            {{#storage.persistence.enable}}
-            "persistent": {
-                "size": {{storage.persistence.volume_size}}
-            },
-            {{/storage.persistence.enable}}           
+            "containerPath": "/var/lib/mysql",
+            "hostPath": "{{storage.host_volume}}/{{service.name}}",    
             "mode": "RW"
         }],
         "docker": {
@@ -31,9 +24,6 @@
             "portMappings": [{
                 "containerPort": 3306,
                 "hostPort": 0,
-                {{#networking.external_access.enable}}
-                "servicePort": {{networking.external_access.external_port}},
-                {{/networking.external_access.enable}}                
                 "protocol": "tcp",
                 "name": "{{service.name}}",
                 "labels": {

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -1,51 +1,51 @@
 {
-    "id": "{{service.name}}",
-    "cpus": {{mysql.cpus}},
-    "mem": {{mysql.mem}},
-    "instances": 1,
-    "env": {
-        "MYSQL_DATABASE": "{{database.name}}",
-        "MYSQL_USER": "{{database.username}}",
-        "MYSQL_PASSWORD": "{{database.password}}",
-        "MYSQL_ROOT_PASSWORD": "{{database.root_password}}",
-        "MYSQL_CONTEXT": "/service/{{service.name}}"
-    },
-    "container": {
-        "type": "DOCKER",
-        "volumes": [{
-            "containerPath": "/var/lib/mysql",
-            "hostPath": "{{storage.host_volume}}/{{service.name}}",    
-            "mode": "RW"
-        }],
-        "docker": {
-            "image": "{{resource.assets.container.docker.mysql-docker}}",
-            "forcePullImage": false,
-            "network": "BRIDGE",
-            "portMappings": [{
-                "containerPort": 3306,
-                "hostPort": 0,
-                "protocol": "tcp",
-                "name": "{{service.name}}",
-                "labels": {
-                    "VIP_0": "/{{service.name}}:{{networking.port}}"
-                }
-            }]
-        }
-    },
-    "healthChecks": [{
-        "protocol": "TCP",
-        "gracePeriodSeconds": 300,
-        "intervalSeconds": 60,
-        "timeoutSeconds": 20,
-        "maxConsecutiveFailures": 3,
-        "portIndex": 0
+  "id": "{{service.name}}",
+  "cpus": {{mysql.cpus}},
+  "mem": {{mysql.mem}},
+  "instances": 1,
+  "env": {
+    "MYSQL_DATABASE": "{{database.name}}",
+    "MYSQL_USER": "{{database.username}}",
+    "MYSQL_PASSWORD": "{{database.password}}",
+    "MYSQL_ROOT_PASSWORD": "{{database.root_password}}",
+    "MYSQL_CONTEXT": "/service/{{service.name}}"
+  },
+  "container": {
+    "type": "DOCKER",
+    "volumes": [{
+      "containerPath": "/var/lib/mysql",
+      "hostPath": "{{storage.host_volume}}/{{service.name}}",    
+      "mode": "RW"
     }],
-    "labels": {
-        "DCOS_PACKAGE_VERSION": "0.2",
-        "DCOS_SERVICE_NAME": "{{service.name}}",
-        {{#networking.external_access.enable}}
-        "HAPROXY_GROUP": "external",
-        {{/networking.external_access.enable}},
-        "DCOS_PACKAGE_IS_FRAMEWORK": "false"
-    }
+      "docker": {
+        "image": "{{resource.assets.container.docker.mysql-docker}}",
+        "forcePullImage": false,
+        "network": "BRIDGE",
+        "portMappings": [{
+          "containerPort": 3306,
+          "hostPort": 0,
+          "protocol": "tcp",
+          "name": "{{service.name}}",
+          "labels": {
+            "VIP_0": "/{{service.name}}:{{networking.port}}"
+          }
+        }]
+      }
+  },
+  "healthChecks": [{
+    "protocol": "TCP",
+    "gracePeriodSeconds": 300,
+    "intervalSeconds": 60,
+    "timeoutSeconds": 20,
+    "maxConsecutiveFailures": 3,
+    "portIndex": 0
+  }],
+  "labels": {
+    "DCOS_PACKAGE_VERSION": "0.2",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    {{#networking.external_access.enable}}
+    "HAPROXY_GROUP": "external",
+    {{/networking.external_access.enable}},
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  }
 }

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -43,6 +43,9 @@
     "labels": {
         "DCOS_PACKAGE_VERSION": "0.2",
         "DCOS_SERVICE_NAME": "{{service.name}}",
+        {{#networking.external_access.enable}}
+        "HAPROXY_GROUP": "external",
+        {{/networking.external_access.enable}},
         "DCOS_PACKAGE_IS_FRAMEWORK": "false"
     }
 }

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -24,12 +24,12 @@
       {{/storage.persistence.enable}}
       "mode": "RW"
     }],
-      "docker": {
-        "image": "{{resource.assets.container.docker.mysql-docker}}",
-        "forcePullImage": false,
-        "network": "BRIDGE",
-        "portMappings": [{
-          "containerPort": 3306,
+    "docker": {
+      "image": "{{resource.assets.container.docker.mysql-docker}}",
+      "forcePullImage": false,
+      "network": "BRIDGE",
+      "portMappings": [{
+        "containerPort": 3306,
           "hostPort": 0,
           {{#networking.external_access.enable}}
           "servicePort": {{networking.external_access.external_port}},
@@ -39,8 +39,8 @@
           "labels": {
             "VIP_0": "/{{service.name}}:{{networking.port}}"
           }
-        }]
-      }
+      }]
+    }
   },
   "healthChecks": [{
     "protocol": "TCP",

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -1,0 +1,93 @@
+{
+    "id": "{{service.name}}",
+    "cpus": {{mysql.cpus}},
+    "mem": {{mysql.mem}},
+    "instances": 1,
+    "env": {
+        "MYSQL_DATABASE": "{{database.name}}",
+        "MYSQL_USER": "{{database.username}}",
+        "MYSQL_PASSWORD": "{{database.password}}",
+        "MYSQL_ROOT_PASSWORD": "{{database.root_password}}",
+        "MYSQL_CONTEXT": "/service/{{service.name}}"
+    },
+    "container": {
+        "type": "DOCKER",
+        "volumes": [
+        {
+            "containerPath": "/var/lib/mysql",
+            {{^storage.persistence.enable}}
+            "hostPath": "{{storage.host_volume}}/{{service.name}}",
+            {{/storage.persistence.enable}}
+            {{#storage.persistence.enable}}
+            "persistent": {
+                "size": {{storage.persistence.volume_size}}
+            },
+            {{/storage.persistence.enable}}           
+            "mode": "RW"
+        }
+        ],
+        "docker": {
+            "image": "{{resource.assets.container.docker.mysql-docker}}",
+            "forcePullImage": true,
+            {{#networking.bridge}}
+            "network": "BRIDGE",
+            "portMappings": [{
+                "containerPort": 3306,
+                "hostPort": 0,
+                {{#networking.external_access.enable}}
+                "servicePort": {{networking.external_access.external_port}},
+                {{/networking.external_access.enable}}                
+                "protocol": "tcp",
+                "name": "{{service.name}}",
+                "labels": {
+                    "VIP_0": "/{{service.name}}:{{networking.port}}"
+                }
+            }]
+            {{/networking.bridge}}
+            {{^networking.bridge}}
+            "network": "HOST"
+            {{/networking.bridge}}
+
+        }
+    },
+    {{^networking.bridge}}
+    "portDefinitions": [
+    {
+            "port": 3306,
+            "protocol": "tcp",
+            "name": "mysql",
+            "labels": {
+                "VIP_0": "/{{service.name}}:{{networking.port}}"
+                }
+    }
+    ],
+    "requirePorts": true,
+    {{/networking.bridge}}
+    "healthChecks": [
+    {
+        "protocol": "TCP",
+        {{#networking.bridge}}
+        "portIndex": 0,
+        {{/networking.bridge}}
+        {{^networking.bridge}}
+        "port": 3306
+        {{/networking.bridge}}
+        "gracePeriodSeconds": 300,
+        "intervalSeconds": 60,
+        "timeoutSeconds": 20,
+        "maxConsecutiveFailures": 3
+    }
+    ],
+    "labels": {
+        "DCOS_PACKAGE_VERSION": "0.2",
+        "DCOS_SERVICE_NAME": "{{service.name}}",
+        {{#networking.external_access.enable}}
+        "HAPROXY_GROUP": "external",
+        {{/networking.external_access.enable}},
+        "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+    },
+    "upgradeStrategy":{
+        "minimumHealthCapacity": 0,
+        "maximumOverCapacity": 0
+    }
+}

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -14,7 +14,13 @@
     "type": "DOCKER",
     "volumes": [{
       "containerPath": "/var/lib/mysql",
-      "hostPath": "{{storage.host_volume}}/{{service.name}}",    
+      {{^storage.persistence.enable}}
+      "hostPath": "{{storage.host_volume}}/{{service.name}}",
+      {{/storage.persistence.enable}}
+      {{#storage.persistence.enable}}          
+      "persistent": {
+        "size": {{storage.persistence.volume_size}}
+      },
       "mode": "RW"
     }],
       "docker": {
@@ -24,6 +30,9 @@
         "portMappings": [{
           "containerPort": 3306,
           "hostPort": 0,
+          {{#networking.external_access.enable}}
+          "servicePort": {{networking.external_access.external_port}},
+          {{/networking.external_access.enable}}
           "protocol": "tcp",
           "name": "{{service.name}}",
           "labels": {

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -12,8 +12,7 @@
     },
     "container": {
         "type": "DOCKER",
-        "volumes": [
-        {
+        "volumes": [{
             "containerPath": "/var/lib/mysql",
             {{^storage.persistence.enable}}
             "hostPath": "{{storage.host_volume}}/{{service.name}}",
@@ -24,10 +23,10 @@
             },
             {{/storage.persistence.enable}}           
             "mode": "RW"
-        }
-        ],
+        }],
         "docker": {
-            {{#networking.bridge}}
+            "image": "{{resource.assets.container.docker.mysql-docker}}",
+            "forcePullImage": false,
             "network": "BRIDGE",
             "portMappings": [{
                 "containerPort": 3306,
@@ -40,42 +39,18 @@
                 "labels": {
                     "VIP_0": "/{{service.name}}:{{networking.port}}"
                 }
-            }],
-            {{/networking.bridge}}
-            {{^networking.bridge}}
-            "network": "HOST",
-            {{/networking.bridge}}
-            "image": "{{resource.assets.container.docker.mysql-docker}}"
+            }]
         }
     },
-    {{^networking.bridge}}
-    "portDefinitions": [
-    {
-            "port": 3306,
-            "protocol": "tcp",
-            "name": "mysql",
-            "labels": {
-                "VIP_0": "/{{service.name}}:{{networking.port}}"
-                }
-    }
-    ],
-    "requirePorts": true,
-    {{/networking.bridge}}
-    "healthChecks": [
-    {
+    "healthChecks": [{
         "protocol": "TCP",
-        {{#networking.bridge}}
         "portIndex": 0,
-        {{/networking.bridge}}
-        {{^networking.bridge}}
         "port": 3306
-        {{/networking.bridge}}
         "gracePeriodSeconds": 300,
         "intervalSeconds": 60,
         "timeoutSeconds": 20,
         "maxConsecutiveFailures": 3
-    }
-    ],
+    }],
     "labels": {
         "DCOS_PACKAGE_VERSION": "0.2",
         "DCOS_SERVICE_NAME": "{{service.name}}",

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -13,7 +13,7 @@
     "container": {
         "type": "DOCKER",
         "volumes": [{
-            "containerPath": "/var/lib/mysql",
+            "containerPath": "var",
             {{^storage.persistence.enable}}
             "hostPath": "{{storage.host_volume}}/{{service.name}}",
             {{/storage.persistence.enable}}
@@ -44,11 +44,11 @@
     },
     "healthChecks": [{
         "protocol": "TCP",
-        "portIndex": 0,
         "gracePeriodSeconds": 300,
         "intervalSeconds": 60,
         "timeoutSeconds": 20,
-        "maxConsecutiveFailures": 3
+        "maxConsecutiveFailures": 3,
+        "portIndex": 0
     }],
     "labels": {
         "DCOS_PACKAGE_VERSION": "0.2",
@@ -57,9 +57,5 @@
         "HAPROXY_GROUP": "external",
         {{/networking.external_access.enable}},
         "DCOS_PACKAGE_IS_FRAMEWORK": "false"
-    },
-    "upgradeStrategy":{
-        "minimumHealthCapacity": 0,
-        "maximumOverCapacity": 0
     }
 }

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -45,7 +45,7 @@
     "healthChecks": [{
         "protocol": "TCP",
         "portIndex": 0,
-        "port": 3306
+        "port": 3306,
         "gracePeriodSeconds": 300,
         "intervalSeconds": 60,
         "timeoutSeconds": 20,

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -21,6 +21,7 @@
       "persistent": {
         "size": {{storage.persistence.volume_size}}
       },
+      {{/storage.persistence.enable}}
       "mode": "RW"
     }],
       "docker": {

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -45,7 +45,7 @@
     "DCOS_SERVICE_NAME": "{{service.name}}",
     {{#networking.external_access.enable}}
     "HAPROXY_GROUP": "external",
-    {{/networking.external_access.enable}},
+    {{/networking.external_access.enable}}
     "DCOS_PACKAGE_IS_FRAMEWORK": "false"
   }
 }

--- a/repo/packages/M/mysql/4/marathon.json.mustache
+++ b/repo/packages/M/mysql/4/marathon.json.mustache
@@ -13,7 +13,7 @@
   "container": {
     "type": "DOCKER",
     "volumes": [{
-      "containerPath": "/var/lib/mysql",
+      "containerPath": "var",
       {{^storage.persistence.enable}}
       "hostPath": "{{storage.host_volume}}/{{service.name}}",
       {{/storage.persistence.enable}}

--- a/repo/packages/M/mysql/4/package.json
+++ b/repo/packages/M/mysql/4/package.json
@@ -1,0 +1,20 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.7",
+  "name": "mysql",
+  "version": "0.2",
+  "scm": "https://github.com/mysql/mysql-server.git",
+  "maintainer": "support@mesosphere.io",
+  "website": "https://mysql-ci.org",
+  "description": "MySQL is the world's most popular open source database. With its proven performance, reliability and ease-of-use, MySQL has become the leading database choice for web-based applications, covering the entire range from personal projects and websites, via e-commerce and information services, all the way to high profile web properties including Facebook, Twitter, YouTube, Yahoo! and many more.",
+  "tags": ["database", "mysql", "sql"],
+  "preInstallNotes": "In order for MySQL service to start successfully it requires atleast 0.3 CPU and 512MB of RAM. WARNING: MySQL on DCOS is currently EXPERIMENTAL. There may be bugs, incomplete\nfeatures, incorrect documentation, or other discrepancies.\n\nIf you didn't provide a value for `host_volume` in the CLI,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\nThis package can create local persistent volumes for the database files to survive across restarts or failures. The parameter `host_volume` controls the path in the host in which these volumes will be created, which can be an NFS-mounted share. This path defaults to /tmp, so if you didn't provide a value for `host_volume` when installing the package,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n\nThis DC/OS MySQL package creates a named Virtual IP for other services in the cluster to access the service in the format `mysql.marathon.l4lb.thisdcos.directory:3306` (where `mysql` would be the package instance name used for installation).\nIf the `external_access` installation option is selected, it also creates an entry in the External Load Balancer for accessing the service from outside of the cluster on port `13306` by default.\n\n You can administer this service easily installing the DC/OS `mysql-admin` package.",
+  "postInstallNotes": "MySQL has been installed.\n Default Login `admin`\nDefault password: `password`",
+  "postUninstallNotes": "MySQL has been uninstalled. Note that any data persisted to a NFS share still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "GNU GENERAL PUBLIC LICENSE",
+      "url": "https://github.com/mysql/mysql-server/blob/5.7/COPYING"
+    }
+  ]
+}

--- a/repo/packages/M/mysql/4/resource.json
+++ b/repo/packages/M/mysql/4/resource.json
@@ -1,8 +1,8 @@
 {
   "images": {
-    "icon-small": "http://www.icon100.com/up/3792/48/mysql.png",
-    "icon-medium": "http://www.icon100.com/up/3792/96/mysql.png",
-    "icon-large": "http://www.icon100.com/up/3792/256/mysql.png"
+    "icon-small": "http://www.coretechnologies.com/images/mysql-logo-48x48.png",
+    "icon-medium": "http://www.ebexsoft.com/images/icons/mysql.jpg",
+    "icon-large": "http://michaelglesenkamp.com/images/icons/icon-mysql.jpg"
   },
   "assets": {
     "container": {

--- a/repo/packages/M/mysql/4/resource.json
+++ b/repo/packages/M/mysql/4/resource.json
@@ -1,6 +1,6 @@
 {
   "images": {
-    "icon-small": "http://www.coretechnologies.com/images/mysql-logo-48x48.png",
+    "icon-small": "http://enitedinternational.com/img/icons/icon/mysql-icon.png",
     "icon-medium": "http://www.ebexsoft.com/images/icons/mysql.jpg",
     "icon-large": "http://michaelglesenkamp.com/images/icons/icon-mysql.jpg"
   },

--- a/repo/packages/M/mysql/4/resource.json
+++ b/repo/packages/M/mysql/4/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "http://www.icon100.com/up/3792/48/mysql.png",
+    "icon-medium": "http://www.icon100.com/up/3792/96/mysql.png",
+    "icon-large": "http://www.icon100.com/up/3792/256/mysql.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "mysql-docker": "mysql:5.7.12"
+      }
+    }
+  }
+}


### PR DESCRIPTION
#- removed the option for bridge/host networking (todo: bring it back and add to other similar packages)
- added persistent storage section and capabilities
- added external connectivity section and capabilities
- added MySQL-admin based on phpmyadmin
- change container path in mounted volume to "var" to avoid issues with using "/"
- MySQL will always create a new database, user and password with default values