### PR TITLE
Define ElasticSearch version through a config parameter

### DIFF
--- a/repo/packages/E/elasticsearch/1/config.json
+++ b/repo/packages/E/elasticsearch/1/config.json
@@ -42,6 +42,11 @@
           "description":"Forces docker to re-pull the image.",
           "type":"boolean"
         },
+        "docker-image":{
+          "default":"elasticsearch:latest",
+          "description":"The elasticsearch docker image to use",
+          "type":"string"
+        },
         "executor":{
           "properties":{
             "ram":{

--- a/repo/packages/E/elasticsearch/1/marathon.json.mustache
+++ b/repo/packages/E/elasticsearch/1/marathon.json.mustache
@@ -32,7 +32,8 @@
     {{/elasticsearch.executor.settings-location}}
 
     "--executorForcePullImage", "{{elasticsearch.force-pull-image}}",
-    "--executorName", "{{elasticsearch.executor.name}}"
+    "--executorName", "{{elasticsearch.executor.name}}",
+    "--elasticsearchDockerImage", "{{elasticsearch.docker-image}}"
   ],
   "env": {
     "JAVA_OPTS": "{{elasticsearch.scheduler.java-heap}}"


### PR DESCRIPTION
Currently the ElasticSearch framework is installing the latest ElasticSearch docker image so you can't use a previous version of ElasticSearch.

This PR includes the changes to allow the user to define the docker image he wants the executors to use. A new field will be included within the DC/OS Universe advanced installation to allow the user to set a different version of Elasticsearch.