### PR TITLE
mysql improvement set inc. host mode

### DIFF
--- a/repo/packages/M/mysql-admin/1/config.json
+++ b/repo/packages/M/mysql-admin/1/config.json
@@ -1,0 +1,80 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service":{
+            "type":"object",
+            "description": "DC/OS service configuration properties",
+            "properties":{
+                "name" : {
+                    "description":"Name of this service instance.",
+                    "type":"string",
+                    "default":"mysql-admin"
+                }
+            }
+        },
+        "mysql-admin":{
+            "type": "object",
+            "description": "mysql-admin service configuration properties",
+            "properties": {
+                "cpus": {
+                    "description": "CPU shares to allocate to each service instance.",
+                    "type": "number",
+                    "default": 0.2,
+                    "minimum": 0.2
+                },
+                "mem": {
+                    "description":  "Memory to allocate to each service instance.",
+                    "type": "number",
+                    "default": 256.0,
+                    "minimum": 256.0
+                },
+                "defaultdb": {
+                    "description": "Default database. Defaults to 'defaultb'.",
+                    "type": "string",
+                    "default": "defaultdb"
+                }
+            },
+            "required": [
+                "cpus",
+                "mem"
+            ]
+        },
+        "networking":{
+            "type": "object",
+            "description": "MySQL admin networking configuration properties",
+            "properties": {
+                "mysql_location":{
+                    "description": "The name of the DC/OS mysql instance to connect to.",
+                    "type": "string",
+                    "default": "mysql"
+                },
+                "mysql_host_port":{
+                    "description": "The port where the mysql instance is listening on.",
+                    "type": "number",
+                    "default": 3306
+                },
+                "external_access": {
+                    "type": "object",
+                    "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+                    "properties": {    
+                        "enable": {
+                            "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB. Defaults to false.",
+                            "type": "boolean",
+                            "default": false                    
+                        },
+                        "external_access_port": {
+                            "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+                            "type": "number",
+                            "default": 13307
+                        },
+                        "virtual_host": {
+                            "description": "For external access, Virtual Host URL to be used in the external load balancer.",
+                            "type": "string",
+                            "default": "mysql-admin.example.org"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/M/mysql-admin/1/marathon.json.mustache
+++ b/repo/packages/M/mysql-admin/1/marathon.json.mustache
@@ -1,0 +1,51 @@
+{
+    "id": "{{service.name}}",
+    "cpus": {{mysql-admin.cpus}},
+    "mem": {{mysql-admin.mem}},
+    "instances": 1,
+    "env": {
+        "PMA_HOST": "{{networking.mysql_location}}.marathon.l4lb.thisdcos.directory",
+        "PMA_PORT": "{{networking.mysql_host_port}}"
+    },
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.mysql-admin-docker}}",
+            "forcePullImage": false,
+            "network": "BRIDGE",
+            "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 0,
+                {{#networking.external_access.enable}}
+                "servicePort": {{networking.external_access.external_access_port}},
+                {{/networking.external_access.enable}}
+                "protocol": "tcp"
+            }
+            ]
+        }
+    },
+    "healthChecks": [
+        {
+            "protocol": "HTTP",
+            "path": "/",
+            "portIndex": 0,
+
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ],
+    "labels": {
+        "DCOS_PACKAGE_VERSION": "4.6.4-0.2",
+        "DCOS_SERVICE_NAME": "{{service.name}}",
+        "DCOS_SERVICE_SCHEME": "http",
+        "DCOS_SERVICE_PORT_INDEX": "0",
+        {{#networking.external_access.enable}}
+        "HAPROXY_GROUP": "external",
+        "HAPROXY_0_VHOST": "{{networking.external_access.virtual_host}}",
+        {{/networking.external_access.enable}}        
+        "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+    }
+}

--- a/repo/packages/M/mysql-admin/1/package.json
+++ b/repo/packages/M/mysql-admin/1/package.json
@@ -1,0 +1,23 @@
+{
+  "packagingVersion": "3.0",
+  "name": "mysql-admin",
+  "version": "4.6.4-0.2",
+  "scm": "https://github.com/phpmyadmin/docker",
+  "maintainer": "support@mesosphere.io",
+  "website": "https://www.phpmyadmin.net/",
+  "description": "phpMyAdmin is a free software tool written in PHP, intended to handle the administration of MySQL over the Web. phpMyAdmin supports a wide range of operations on MySQL and MariaDB.\n\nThis DC/OS package is ready to be used alongside the DC/OS `mysql` package. Other MySQL servers may work, but haven't been tested.",
+  "tags": [
+    "mysql",
+    "database",
+    "admin"
+    ],
+  "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\n```Advanced Installation options notes```\n\nnetworking / *external_access*: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / *external_access_port*: port to be used in Marathon-LB for accessing the service.",
+  "postInstallNotes": "Service installed.\n\nIt is recommended to access this service through the endpoint created in Marathon-LB.\n\nDefault login: `admin`/`password`.",
+  "postInstallNotes": "Service installed.\n\nIt is recommended to access this service through the endpoint created in Marathon-LB.\n\nDefault login: `admin`/`password`.\n\nDefault database `defaultdb`",
+  "licenses": [
+    {
+      "name": "GNU GPL License",
+      "url": "https://raw.githubusercontent.com/phpmyadmin/docker/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/M/mysql-admin/1/resource.json
+++ b/repo/packages/M/mysql-admin/1/resource.json
@@ -1,0 +1,19 @@
+{
+  "images": {
+    "icon-small": "http://enitedinternational.com/img/icons/icon/mysql-icon.png",
+    "icon-medium": "http://www.ebexsoft.com/images/icons/mysql.jpg",
+    "icon-large": "http://michaelglesenkamp.com/images/icons/icon-mysql.jpg",
+   "screenshots": [
+     "https://upload.wikimedia.org/wikipedia/commons/6/66/PhpMyAdmin_screenshot_new.png",
+     "http://i1-linux.softpedia-static.com/screenshots/phpMyAdmin_2.png",
+     "https://www.phpmyadmin.net/static/images/screenshots/monitor.png"
+   ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "mysql-admin-docker": "phpmyadmin/phpmyadmin:4.6.4-1"
+      }
+    }
+  }
+}

--- a/repo/packages/M/mysql-admin/2/config.json
+++ b/repo/packages/M/mysql-admin/2/config.json
@@ -1,0 +1,80 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service":{
+            "type":"object",
+            "description": "DC/OS service configuration properties",
+            "properties":{
+                "name" : {
+                    "description":"Name of this service instance.",
+                    "type":"string",
+                    "default":"mysql-admin"
+                }
+            }
+        },
+        "mysql-admin":{
+            "type": "object",
+            "description": "mysql-admin service configuration properties",
+            "properties": {
+                "cpus": {
+                    "description": "CPU shares to allocate to each service instance.",
+                    "type": "number",
+                    "default": 0.2,
+                    "minimum": 0.2
+                },
+                "mem": {
+                    "description":  "Memory to allocate to each service instance.",
+                    "type": "number",
+                    "default": 256.0,
+                    "minimum": 256.0
+                },
+                "defaultdb": {
+                    "description": "Default database. Defaults to 'defaultb'.",
+                    "type": "string",
+                    "default": "defaultdb"
+                }
+            },
+            "required": [
+                "cpus",
+                "mem"
+            ]
+        },
+        "networking":{
+            "type": "object",
+            "description": "MySQL admin networking configuration properties",
+            "properties": {
+                "mysql_location":{
+                    "description": "The name of the DC/OS mysql instance to connect to.",
+                    "type": "string",
+                    "default": "mysql"
+                },
+                "mysql_host_port":{
+                    "description": "The port where the mysql instance is listening on.",
+                    "type": "number",
+                    "default": 3306
+                },
+                "external_access": {
+                    "type": "object",
+                    "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+                    "properties": {    
+                        "enable": {
+                            "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB. Defaults to false.",
+                            "type": "boolean",
+                            "default": false                    
+                        },
+                        "external_access_port": {
+                            "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+                            "type": "number",
+                            "default": 13307
+                        },
+                        "virtual_host": {
+                            "description": "For external access, Virtual Host URL to be used in the external load balancer.",
+                            "type": "string",
+                            "default": "mysql-admin.example.org"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/M/mysql-admin/2/marathon.json.mustache
+++ b/repo/packages/M/mysql-admin/2/marathon.json.mustache
@@ -1,0 +1,51 @@
+{
+    "id": "{{service.name}}",
+    "cpus": {{mysql-admin.cpus}},
+    "mem": {{mysql-admin.mem}},
+    "instances": 1,
+    "env": {
+        "PMA_HOST": "{{networking.mysql_location}}.marathon.l4lb.thisdcos.directory",
+        "PMA_PORT": "{{networking.mysql_host_port}}"
+    },
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.mysql-admin-docker}}",
+            "forcePullImage": false,
+            "network": "BRIDGE",
+            "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 0,
+                {{#networking.external_access.enable}}
+                "servicePort": {{networking.external_access.external_access_port}},
+                {{/networking.external_access.enable}}
+                "protocol": "tcp"
+            }
+            ]
+        }
+    },
+    "healthChecks": [
+        {
+            "protocol": "HTTP",
+            "path": "/",
+            "portIndex": 0,
+
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ],
+    "labels": {
+        "DCOS_PACKAGE_VERSION": "4.6.4-0.2",
+        "DCOS_SERVICE_NAME": "{{service.name}}",
+        "DCOS_SERVICE_SCHEME": "http",
+        "DCOS_SERVICE_PORT_INDEX": "0",
+        {{#networking.external_access.enable}}
+        "HAPROXY_GROUP": "external",
+        "HAPROXY_0_VHOST": "{{networking.external_access.virtual_host}}",
+        {{/networking.external_access.enable}}        
+        "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+    }
+}

--- a/repo/packages/M/mysql-admin/2/marathon.json.mustache
+++ b/repo/packages/M/mysql-admin/2/marathon.json.mustache
@@ -38,7 +38,7 @@
         }
     ],
     "labels": {
-        "DCOS_PACKAGE_VERSION": "4.6.4-0.2",
+        "DCOS_PACKAGE_VERSION": "4.6.4-0.3",
         "DCOS_SERVICE_NAME": "{{service.name}}",
         "DCOS_SERVICE_SCHEME": "http",
         "DCOS_SERVICE_PORT_INDEX": "0",

--- a/repo/packages/M/mysql-admin/2/package.json
+++ b/repo/packages/M/mysql-admin/2/package.json
@@ -1,0 +1,23 @@
+{
+  "packagingVersion": "3.0",
+  "name": "mysql-admin",
+  "version": "4.6.4-0.2",
+  "scm": "https://github.com/phpmyadmin/docker",
+  "maintainer": "support@mesosphere.io",
+  "website": "https://www.phpmyadmin.net/",
+  "description": "phpMyAdmin is a free software tool written in PHP, intended to handle the administration of MySQL over the Web. phpMyAdmin supports a wide range of operations on MySQL and MariaDB.\n\nThis DC/OS package is ready to be used alongside the DC/OS `mysql` package. Other MySQL servers may work, but haven't been tested.",
+  "tags": [
+    "mysql",
+    "database",
+    "admin"
+    ],
+  "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\n```Advanced Installation options notes```\n\nnetworking / *external_access*: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / *external_access_port*: port to be used in Marathon-LB for accessing the service.",
+  "postInstallNotes": "Service installed.\n\nIt is recommended to access this service through the endpoint created in Marathon-LB.\n\nDefault login: `admin`/`password`.",
+  "postInstallNotes": "Service installed.\n\nIt is recommended to access this service through the endpoint created in Marathon-LB.\n\nDefault login: `admin`/`password`.\n\nDefault database `defaultdb`",
+  "licenses": [
+    {
+      "name": "GNU GPL License",
+      "url": "https://raw.githubusercontent.com/phpmyadmin/docker/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/M/mysql-admin/2/package.json
+++ b/repo/packages/M/mysql-admin/2/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "mysql-admin",
-  "version": "4.6.4-0.2",
+  "version": "4.6.4-0.3",
   "scm": "https://github.com/phpmyadmin/docker",
   "maintainer": "support@mesosphere.io",
   "website": "https://www.phpmyadmin.net/",

--- a/repo/packages/M/mysql-admin/2/resource.json
+++ b/repo/packages/M/mysql-admin/2/resource.json
@@ -1,0 +1,19 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/mysql/assets/mysql-admin-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/mysql/assets/mysql-admin-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/mysql/assets/mysql-admin-large.png",
+   "screenshots": [
+     "https://upload.wikimedia.org/wikipedia/commons/6/66/PhpMyAdmin_screenshot_new.png",
+     "http://i1-linux.softpedia-static.com/screenshots/phpMyAdmin_2.png",
+     "https://www.phpmyadmin.net/static/images/screenshots/monitor.png"
+   ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "mysql-admin-docker": "phpmyadmin/phpmyadmin:4.6.4-1"
+      }
+    }
+  }
+}

--- a/repo/packages/M/mysql-admin/2/resource.json
+++ b/repo/packages/M/mysql-admin/2/resource.json
@@ -1,8 +1,8 @@
 {
   "images": {
-    "icon-small": "https://downloads.mesosphere.com/mysql/assets/mysql-admin-small.png",
-    "icon-medium": "https://downloads.mesosphere.com/mysql/assets/mysql-admin-medium.png",
-    "icon-large": "https://downloads.mesosphere.com/mysql/assets/mysql-admin-large.png",
+    "icon-small": "https://downloads.mesosphere.com/mysql-admin/assets/mysql-admin-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/mysql-admin/assets/mysql-admin-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/mysql-admin/assets/mysql-admin-large.png",
    "screenshots": [
      "https://upload.wikimedia.org/wikipedia/commons/6/66/PhpMyAdmin_screenshot_new.png",
      "http://i1-linux.softpedia-static.com/screenshots/phpMyAdmin_2.png",

--- a/repo/packages/M/mysql/5/config.json
+++ b/repo/packages/M/mysql/5/config.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "Name of this service instance",
+          "type": "string",
+          "default": "mysql"
+        }
+      }
+    },
+    "mysql": {
+      "type": "object",
+      "description": "MySQL service configuration properties",
+      "properties": {
+        "cpus": {
+          "description": "CPU shares to allocate to each service instance.",
+          "type": "number",
+          "default": 0.3,
+          "minimum": 0.3
+        },
+        "mem": {
+          "description":  "Memory to allocate to each service instance.",
+          "type": "number",
+          "default": 512.0,
+          "minimum": 512.0
+        }
+      },
+      "required": [
+        "cpus",
+        "mem"
+      ]
+    },
+    "database": {
+      "type": "object",
+      "description": "MySQL database configuration properties",
+      "properties":{
+        "name": {
+          "description": "The name of a database to be created on startup.",
+          "type": "string",
+          "default": "defaultdb"
+        },
+        "username": {
+          "description": "The username of a user to be created with superuser access to this database only.",
+          "type": "string",
+          "default": "admin"
+        },
+        "password": {
+          "description": "The password for a user to be created with superuser access to this database only.",
+          "type": "string",
+          "default": "password"
+        },
+        "root_password": {
+          "description": "Specifies the password that will be set for the MySQL root superuser account.",
+          "type": "string",
+          "default": "root"
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "description": "MySQL storage configuration properties",
+      "properties":{    
+        "persistence": {
+          "type": "object",
+          "description": "Enable persistent storage.",
+          "properties": {    
+            "enable": {
+              "description": "Enable or disable persistent storage.",
+              "type": "boolean",
+              "default": false                    
+            },
+            "volume_size": {
+              "description": "If a new volume is to be created, this controls its size in MBs.",
+              "type": "number",
+              "default": 256
+            }
+          }
+        },
+        "host_volume": {
+          "description": "If using non-persistent volumes (local volumes), this sets the location of a volume on the host to be used for the service. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/service_name`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents. NOTE: if you don't change the default /tmp value, YOUR DATA WILL NOT BE SAVED IN ANY WAY.",
+          "type": "string",
+          "default": "/tmp"
+        }
+      }
+    },
+    "networking": {
+      "type": "object",
+      "description": "MySQL networking configuration properties",
+      "properties": {    
+        "port": {
+          "description": "Port number to be used for clear communication internally to the cluster. Currently unused and fixed to be 3306.",
+          "type": "number",
+          "default": 3306
+        },  
+        "host_mode": {
+            "description": "Enable or disable host networking mode. NOTE: this requires the default port to be available on the target host. This also forces to have a single instance per node.",
+            "type": "boolean",
+            "default": false                    
+        },
+        "external_access": {
+          "type": "object",
+          "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+            "properties": {    
+              "enable": {
+                "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+                "type": "boolean",
+                "default": false                    
+              },
+              "external_access_port": {
+                "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+                "type": "number",
+                "default": 13306
+              }
+            }
+          }
+      }      
+    }
+  }
+}

--- a/repo/packages/M/mysql/5/marathon.json.mustache
+++ b/repo/packages/M/mysql/5/marathon.json.mustache
@@ -1,0 +1,91 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{mysql.cpus}},
+  "mem": {{mysql.mem}},
+  "instances": 1,
+  "env": {
+    "MYSQL_DATABASE": "{{database.name}}",
+    "MYSQL_USER": "{{database.username}}",
+    "MYSQL_PASSWORD": "{{database.password}}",
+    "MYSQL_ROOT_PASSWORD": "{{database.root_password}}",
+    "MYSQL_CONTEXT": "/service/{{service.name}}"
+  },
+  "container": {
+    "type": "DOCKER",
+    "volumes": [{
+      "containerPath": "var",
+      {{^storage.persistence.enable}}
+      "hostPath": "{{storage.host_volume}}/{{service.name}}",
+      {{/storage.persistence.enable}}
+      {{#storage.persistence.enable}}
+      "persistent": {
+        "size": {{storage.persistence.volume_size}}
+      },
+      {{/storage.persistence.enable}}
+      "mode": "RW"
+    }],
+    "docker": {
+      "image": "{{resource.assets.container.docker.mysql-docker}}",
+      {{#networking.host_mode}}
+      "network": "HOST",
+      {{/networking.host_mode}}            
+      {{^networking.host_mode}}
+      "network": "BRIDGE",
+      "portMappings": [{
+        "containerPort": 3306,
+        "hostPort": 0,
+        {{#networking.external_access.enable}}
+        "servicePort": {{networking.external_access.external_access_port}},
+        {{/networking.external_access.enable}}
+        "protocol": "tcp",
+        "name": "{{service.name}}",
+        "labels": {
+          "VIP_0": "/{{service.name}}:{{networking.port}}"
+        }
+      }],
+      {{/networking.host_mode}}
+      "forcePullImage": false
+    }
+  },
+  {{#networking.host_mode}}
+  "portDefinitions": [{
+      "protocol": "tcp",
+      "port": 3306,
+      "name": "{{service.name}}",
+      {{#networking.external_access.enable}}
+      "servicePort": {{networking.external_access.external_access_port}},
+      {{/networking.external_access.enable}}
+      "labels": {
+        "VIP_0": "/{{service.name}}:{{networking.port}}"
+      }
+  }],
+  "requirePorts": true,
+  "constraints": [["hostname", "UNIQUE"]],
+  {{/networking.host_mode}}
+  "healthChecks": [{
+    "protocol": "TCP",
+    {{#networking.host_mode}}
+    "port": 3306,
+    {{/networking.host_mode}}
+    {{^networking.host_mode}}
+    "portIndex": 0,
+    {{/networking.host_mode}}    
+    "gracePeriodSeconds": 300,
+    "intervalSeconds": 60,
+    "timeoutSeconds": 20,
+    "maxConsecutiveFailures": 3
+  }],
+  "labels": {
+    "DCOS_PACKAGE_VERSION": "5.7.12-0.3",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    {{#networking.external_access.enable}}
+    "HAPROXY_GROUP": "external",
+    {{/networking.external_access.enable}}
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/M/mysql/5/package.json
+++ b/repo/packages/M/mysql/5/package.json
@@ -1,0 +1,20 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.7",
+  "name": "mysql",
+  "version": "5.7.12-0.3",
+  "scm": "https://github.com/mysql/mysql-server.git",
+  "maintainer": "support@mesosphere.io",
+  "website": "https://mysql-ci.org",
+  "description": "MySQL is the world's most popular open source database. With its proven performance, reliability and ease-of-use, MySQL has become the leading database choice for web-based applications, covering the entire range from personal projects and websites, via e-commerce and information services, all the way to high profile web properties including Facebook, Twitter, YouTube, Yahoo! and many more.",
+  "tags": ["database", "mysql", "sql"],
+  "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\n```Advanced Installation options notes```\n\nstorage / *persistence*: create local persistent volumes for internal storage files to survive across restarts or failures.\n\nstorage / *host_volume*:  if persistence is not selected, this package can use a local volume in the host for storage, like a local directory or an NFS mount. The parameter *host_volume* controls the path in the host in which these volumes will be created, which MUST be the same on all nodes of the cluster.\n\nNOTE: If you didn't select persistence in the storage section, or provided a valid value for *host_volume* on installation,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n\nnetworking / *port*: This DC/OS service can be accessed from any other application through a NAMED VIP in the format *`service_name.marathon.l4lb.thisdcos.directory:port`*. Check status of the VIP in the *Network* tab of the DC/OS Dashboard (Enterprise DC/OS only).\n\nnetworking / *external_access*: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / *external_access_port*: port to be used in Marathon-LB for accessing the service.",
+ "postInstallNotes": "Service installed.\n\nDefault login: `admin`/`password`.",
+ "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "GNU GENERAL PUBLIC LICENSE",
+      "url": "https://github.com/mysql/mysql-server/blob/5.7/COPYING"
+    }
+  ]
+}

--- a/repo/packages/M/mysql/5/resource.json
+++ b/repo/packages/M/mysql/5/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "http://enitedinternational.com/img/icons/icon/mysql-icon.png",
+    "icon-medium": "http://www.ebexsoft.com/images/icons/mysql.jpg",
+    "icon-large": "http://michaelglesenkamp.com/images/icons/icon-mysql.jpg"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "mysql-docker": "mysql:5.7.12"
+      }
+    }
+  }
+}

--- a/repo/packages/M/mysql/6/config.json
+++ b/repo/packages/M/mysql/6/config.json
@@ -1,0 +1,149 @@
+{
+	"$schema": "http://json-schema.org/schema#",
+	"properties": {
+		"service": {
+			"type": "object",
+			"description": "DC/OS service configuration properties",
+			"properties": {
+				"name": {
+					"description": "Name of this service instance",
+					"type": "string",
+					"default": "mysql"
+				}
+			}
+		},
+		"mysql": {
+			"type": "object",
+			"description": "MySQL service configuration properties",
+			"properties": {
+				"cpus": {
+					"description": "CPU shares to allocate to each service instance.",
+					"type": "number",
+					"default": 0.3,
+					"minimum": 0.3
+				},
+				"mem": {
+					"description":  "Memory to allocate to each service instance.",
+					"type": "number",
+					"default": 512.0,
+					"minimum": 512.0
+				}
+			},
+			"required": [
+				"cpus",
+				"mem"
+			]
+		},
+		"database": {
+			"type": "object",
+			"description": "MySQL database configuration properties",
+			"properties":{
+				"name": {
+					"description": "The name of a database to be created on startup.",
+					"type": "string",
+					"default": "defaultdb"
+				},
+				"username": {
+					"description": "The username of a user to be created with superuser access to this database only.",
+					"type": "string",
+					"default": "admin"
+				},
+				"password": {
+					"description": "The password for a user to be created with superuser access to this database only.",
+					"type": "string",
+					"default": "password"
+				},
+				"root_password": {
+					"description": "Specifies the password that will be set for the MySQL root superuser account.",
+					"type": "string",
+					"default": "root"
+				}
+			}
+		},
+		"storage": {
+			"type": "object",
+			"description": "MySQL storage configuration properties",
+			"properties":{    
+				"persistence": {
+					"type": "object",
+					"description": "Enable persistent storage.",
+					"properties": {    
+						"enable": {
+							"description": "Enable or disable persistent storage.",
+							"type": "boolean",
+							"default": false                    
+						},
+						"volume_size": {
+							"description": "If a new volume is to be created, this controls its size in MBs.",
+							"type": "number",
+							"default": 256
+						},
+						"external": {
+							"type": "object",
+							"description": "External persistent storage properties",
+								"properties":{   
+									"enable": {
+										"description": "Enable or disable external persistent storage. Please note that for these to work, your DC/OS cluster MUST have been installed with the right options in `config.yaml`. Also, please note this requires a working  configuration file for the driver (e.g. `rexray.yaml`).",
+										"type": "boolean",
+										"default": false                    
+									},
+									"volume_name": {
+										"description": "Name that your volume driver uses to look up your volume. When your task is staged on an agent, the volume driver queries the storage service for a volume with this name. If one does not exist, it is created implicitly. Otherwise, the existing volume is reused.",
+										"type": "string",
+										"default": "mysql"
+									},
+									"provider": {
+										"description": "Provider of the external persistent volume.",
+										"type": "string",
+										"default": "dvdi"
+									},
+									"driver": {
+										"description": "Volume driver to use for storage. If you are running Marathon on DC/OS, this value is probably rexray.",
+										"type": "string",
+										"default": "rexray"
+									}
+								}
+						}
+					}
+				},
+				"host_volume": {
+					"description": "If using non-persistent volumes (local volumes), this sets the location of a volume on the host to be used for the service. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/service_name`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents. NOTE: if you don't change the default /tmp value, YOUR DATA WILL NOT BE SAVED IN ANY WAY.",
+					"type": "string",
+					"default": "/tmp"
+				}
+			}
+		},
+		"networking": {
+			"type": "object",
+			"description": "MySQL networking configuration properties",
+			"properties": {    
+				"port": {
+					"description": "Port number to be used for clear communication internally to the cluster. Currently unused and fixed to be 3306.",
+					"type": "number",
+					"default": 3306
+				},  
+				"host_mode": {
+						"description": "Enable or disable host networking mode. NOTE: this requires the default port to be available on the target host. This also forces to have a single instance per node.",
+						"type": "boolean",
+						"default": false                    
+				},
+				"external_access": {
+					"type": "object",
+					"description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+						"properties": {    
+							"enable": {
+								"description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+								"type": "boolean",
+								"default": false                    
+							},
+							"external_access_port": {
+								"description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+								"type": "number",
+								"default": 13306
+							}
+						}
+					}
+			}      
+		}
+	}
+}

--- a/repo/packages/M/mysql/6/config.json
+++ b/repo/packages/M/mysql/6/config.json
@@ -63,7 +63,12 @@
 		"storage": {
 			"type": "object",
 			"description": "MySQL storage configuration properties",
-			"properties":{    
+			"properties":{
+				"host_volume": {
+					"description": "If using non-persistent volumes (local volumes), this sets the location of a volume on the host to be used for the service. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/service_name`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents. NOTE: if you don't change the default /tmp value, YOUR DATA WILL NOT BE SAVED IN ANY WAY.",
+					"type": "string",
+					"default": "/tmp"
+				},    
 				"persistence": {
 					"type": "object",
 					"description": "Enable persistent storage.",
@@ -105,11 +110,6 @@
 								}
 						}
 					}
-				},
-				"host_volume": {
-					"description": "If using non-persistent volumes (local volumes), this sets the location of a volume on the host to be used for the service. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/service_name`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents. NOTE: if you don't change the default /tmp value, YOUR DATA WILL NOT BE SAVED IN ANY WAY.",
-					"type": "string",
-					"default": "/tmp"
 				}
 			}
 		},

--- a/repo/packages/M/mysql/6/config.json
+++ b/repo/packages/M/mysql/6/config.json
@@ -74,7 +74,7 @@
 							"default": false                    
 						},
 						"volume_size": {
-							"description": "If a new volume is to be created, this controls its size in MBs.",
+							"description": "If a new local volume is to be created, this controls its size in MBs.",
 							"type": "number",
 							"default": 256
 						},
@@ -83,22 +83,22 @@
 							"description": "External persistent storage properties",
 								"properties":{   
 									"enable": {
-										"description": "Enable or disable external persistent storage. Please note that for these to work, your DC/OS cluster MUST have been installed with the right options in `config.yaml`. Also, please note this requires a working  configuration file for the driver (e.g. `rexray.yaml`).",
+										"description": "Enable or disable external persistent storage. The `persistence` option must also be selected. Please note that for these to work, your DC/OS cluster MUST have been installed with the right options in `config.yaml`. Also, please note this requires a working  configuration file for the driver (e.g. `rexray.yaml`).",
 										"type": "boolean",
 										"default": false                    
 									},
 									"volume_name": {
-										"description": "Name that your volume driver uses to look up your volume. When your task is staged on an agent, the volume driver queries the storage service for a volume with this name. If one does not exist, it is created implicitly. Otherwise, the existing volume is reused.",
+										"description": "Name that your volume driver uses to look up your external volume. When your task is staged on an agent, the volume driver queries the storage service for a volume with this name. If one does not exist, it is created implicitly. Otherwise, the existing volume is reused.",
 										"type": "string",
 										"default": "mysql"
 									},
 									"provider": {
-										"description": "Provider of the external persistent volume.",
+										"description": "Provider of the external persistent volume. The default value should be correct for most use cases.",
 										"type": "string",
 										"default": "dvdi"
 									},
 									"driver": {
-										"description": "Volume driver to use for storage. If you are running Marathon on DC/OS, this value is probably rexray.",
+										"description": "Volume driver to use for storage. The default value should be correct for most use cases.",
 										"type": "string",
 										"default": "rexray"
 									}

--- a/repo/packages/M/mysql/6/config.json
+++ b/repo/packages/M/mysql/6/config.json
@@ -74,7 +74,7 @@
 							"default": false                    
 						},
 						"volume_size": {
-							"description": "If a new local volume is to be created, this controls its size in MBs.",
+							"description": "If a new volume is to be created, this controls its size in MBs.",
 							"type": "number",
 							"default": 256
 						},

--- a/repo/packages/M/mysql/6/marathon.json.mustache
+++ b/repo/packages/M/mysql/6/marathon.json.mustache
@@ -1,0 +1,102 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{mysql.cpus}},
+  "mem": {{mysql.mem}},
+  "instances": 1,
+  "env": {
+    "MYSQL_DATABASE": "{{database.name}}",
+    "MYSQL_USER": "{{database.username}}",
+    "MYSQL_PASSWORD": "{{database.password}}",
+    "MYSQL_ROOT_PASSWORD": "{{database.root_password}}",
+    "MYSQL_CONTEXT": "/service/{{service.name}}"
+  },
+  "container": {
+    "type": "DOCKER",
+    "volumes": [{
+      "containerPath": "var",
+      {{^storage.persistence.enable}}
+      "hostPath": "{{storage.host_volume}}/{{service.name}}",
+      {{/storage.persistence.enable}}
+      {{#storage.persistence.enable}}
+      {{^storage.persistence.external.enable}}
+      "persistent": {
+        "size": {{storage.persistence.volume_size}}
+      },
+      {{/storage.persistence.external.enable}}
+      {{#storage.persistence.external.enable}}
+      "external": {
+        "name": "{{storage.persistence.external.volume_name}}",
+        "provider": "{{storage.persistence.external.provider}}",
+        "options": {
+          "dvdi/driver": "{{storage.persistence.external.driver}}"
+        },
+      {{/storage.persistence.external.enable}}
+      }
+      {{/storage.persistence.enable}}
+      "mode": "RW"
+    }],
+    "docker": {
+      "image": "{{resource.assets.container.docker.mysql-docker}}",
+      {{#networking.host_mode}}
+      "network": "HOST",
+      {{/networking.host_mode}}            
+      {{^networking.host_mode}}
+      "network": "BRIDGE",
+      "portMappings": [{
+        "containerPort": 3306,
+        "hostPort": 0,
+        {{#networking.external_access.enable}}
+        "servicePort": {{networking.external_access.external_access_port}},
+        {{/networking.external_access.enable}}
+        "protocol": "tcp",
+        "name": "{{service.name}}",
+        "labels": {
+          "VIP_0": "/{{service.name}}:{{networking.port}}"
+        }
+      }],
+      {{/networking.host_mode}}
+      "forcePullImage": false
+    }
+  },
+  {{#networking.host_mode}}
+  "portDefinitions": [{
+      "protocol": "tcp",
+      "port": 3306,
+      "name": "{{service.name}}",
+      {{#networking.external_access.enable}}
+      "servicePort": {{networking.external_access.external_access_port}},
+      {{/networking.external_access.enable}}
+      "labels": {
+        "VIP_0": "/{{service.name}}:{{networking.port}}"
+      }
+  }],
+  "requirePorts": true,
+  "constraints": [["hostname", "UNIQUE"]],
+  {{/networking.host_mode}}
+  "healthChecks": [{
+    "protocol": "TCP",
+    {{#networking.host_mode}}
+    "port": 3306,
+    {{/networking.host_mode}}
+    {{^networking.host_mode}}
+    "portIndex": 0,
+    {{/networking.host_mode}}    
+    "gracePeriodSeconds": 300,
+    "intervalSeconds": 60,
+    "timeoutSeconds": 20,
+    "maxConsecutiveFailures": 3
+  }],
+  "labels": {
+    "DCOS_PACKAGE_VERSION": "5.7.12-0.3",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    {{#networking.external_access.enable}}
+    "HAPROXY_GROUP": "external",
+    {{/networking.external_access.enable}}
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/M/mysql/6/marathon.json.mustache
+++ b/repo/packages/M/mysql/6/marathon.json.mustache
@@ -27,6 +27,7 @@
       "external": {
         "name": "{{storage.persistence.external.volume_name}}",
         "provider": "{{storage.persistence.external.provider}}",
+        "size": {{storage.persistence.volume_size}},
         "options": {
           "dvdi/driver": "{{storage.persistence.external.driver}}"
         }

--- a/repo/packages/M/mysql/6/marathon.json.mustache
+++ b/repo/packages/M/mysql/6/marathon.json.mustache
@@ -27,7 +27,6 @@
       "external": {
         "name": "{{storage.persistence.external.volume_name}}",
         "provider": "{{storage.persistence.external.provider}}",
-        "size": {{storage.persistence.volume_size}},
         "options": { "dvdi/driver": "{{storage.persistence.external.driver}}" }
       },
       {{/storage.persistence.external.enable}}

--- a/repo/packages/M/mysql/6/marathon.json.mustache
+++ b/repo/packages/M/mysql/6/marathon.json.mustache
@@ -87,7 +87,7 @@
     "maxConsecutiveFailures": 3
   }],
   "labels": {
-    "DCOS_PACKAGE_VERSION": "5.7.12-0.3",
+    "DCOS_PACKAGE_VERSION": "5.7.12-0.4",
     "DCOS_SERVICE_NAME": "{{service.name}}",
     "MARATHON_SINGLE_INSTANCE_APP": "true",
     {{#networking.external_access.enable}}

--- a/repo/packages/M/mysql/6/marathon.json.mustache
+++ b/repo/packages/M/mysql/6/marathon.json.mustache
@@ -13,6 +13,7 @@
   "container": {
     "type": "DOCKER",
     "volumes": [{
+      "containerPath": "var",
       {{^storage.persistence.enable}}
       "hostPath": "{{storage.host_volume}}/{{service.name}}",
       {{/storage.persistence.enable}}
@@ -28,10 +29,8 @@
         "provider": "{{storage.persistence.external.provider}}",
         "options": {
           "dvdi/driver": "{{storage.persistence.external.driver}}"
-        },
+      },
       {{/storage.persistence.external.enable}}
-      "containerPath": "var"
-      }
       {{/storage.persistence.enable}}
       "mode": "RW"
     }],

--- a/repo/packages/M/mysql/6/marathon.json.mustache
+++ b/repo/packages/M/mysql/6/marathon.json.mustache
@@ -29,6 +29,7 @@
         "provider": "{{storage.persistence.external.provider}}",
         "options": {
           "dvdi/driver": "{{storage.persistence.external.driver}}"
+        }
       },
       {{/storage.persistence.external.enable}}
       {{/storage.persistence.enable}}

--- a/repo/packages/M/mysql/6/marathon.json.mustache
+++ b/repo/packages/M/mysql/6/marathon.json.mustache
@@ -28,9 +28,7 @@
         "name": "{{storage.persistence.external.volume_name}}",
         "provider": "{{storage.persistence.external.provider}}",
         "size": {{storage.persistence.volume_size}},
-        "options": {
-          "dvdi/driver": "{{storage.persistence.external.driver}}"
-        }
+        "options": { "dvdi/driver": "{{storage.persistence.external.driver}}" }
       },
       {{/storage.persistence.external.enable}}
       {{/storage.persistence.enable}}

--- a/repo/packages/M/mysql/6/marathon.json.mustache
+++ b/repo/packages/M/mysql/6/marathon.json.mustache
@@ -13,17 +13,19 @@
   "container": {
     "type": "DOCKER",
     "volumes": [{
-      "containerPath": "var",
       {{^storage.persistence.enable}}
+      "containerPath": "var",
       "hostPath": "{{storage.host_volume}}/{{service.name}}",
       {{/storage.persistence.enable}}
       {{#storage.persistence.enable}}
       {{^storage.persistence.external.enable}}
+      "containerPath": "var",
       "persistent": {
         "size": {{storage.persistence.volume_size}}
       },
       {{/storage.persistence.external.enable}}
       {{#storage.persistence.external.enable}}
+      "containerPath": "/var/lib/mysql",
       "external": {
         "name": "{{storage.persistence.external.volume_name}}",
         "provider": "{{storage.persistence.external.provider}}",

--- a/repo/packages/M/mysql/6/marathon.json.mustache
+++ b/repo/packages/M/mysql/6/marathon.json.mustache
@@ -13,7 +13,6 @@
   "container": {
     "type": "DOCKER",
     "volumes": [{
-      "containerPath": "var",
       {{^storage.persistence.enable}}
       "hostPath": "{{storage.host_volume}}/{{service.name}}",
       {{/storage.persistence.enable}}
@@ -31,6 +30,7 @@
           "dvdi/driver": "{{storage.persistence.external.driver}}"
         },
       {{/storage.persistence.external.enable}}
+      "containerPath": "var"
       }
       {{/storage.persistence.enable}}
       "mode": "RW"

--- a/repo/packages/M/mysql/6/package.json
+++ b/repo/packages/M/mysql/6/package.json
@@ -1,0 +1,20 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.7",
+  "name": "mysql",
+  "version": "5.7.12-0.3",
+  "scm": "https://github.com/mysql/mysql-server.git",
+  "maintainer": "support@mesosphere.io",
+  "website": "https://mysql-ci.org",
+  "description": "MySQL is the world's most popular open source database. With its proven performance, reliability and ease-of-use, MySQL has become the leading database choice for web-based applications, covering the entire range from personal projects and websites, via e-commerce and information services, all the way to high profile web properties including Facebook, Twitter, YouTube, Yahoo! and many more.",
+  "tags": ["database", "mysql", "sql"],
+  "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\n```Advanced Installation options notes```\n\nstorage / *persistence*: create local persistent volumes for internal storage files to survive across restarts or failures.\n\nstorage / persistence / *external*: create external persistent volumes. This allows to use an external storage system such as Amazon EBS, OpenStack Cinder, EMC Isilon, EMC ScaleIO, EMC XtremIO, EMC VMAX and Google Compute Engine persistent storage. *NOTE*: To use external volumes with DC/OS, you MUST enable them during CLI or Advanced installation.\n\nstorage / *host_volume*:  if persistence is not selected, this package can use a local volume in the host for storage, like a local directory or an NFS mount. The parameter *host_volume* controls the path in the host in which these volumes will be created, which MUST be the same on all nodes of the cluster.\n\nNOTE: If you didn't select persistence in the storage section, or provided a valid value for *host_volume* on installation,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n\nnetworking / *port*: This DC/OS service can be accessed from any other application through a NAMED VIP in the format *`service_name.marathon.l4lb.thisdcos.directory:port`*. Check status of the VIP in the *Network* tab of the DC/OS Dashboard (Enterprise DC/OS only).\n\nnetworking / *external_access*: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / *external_access_port*: port to be used in Marathon-LB for accessing the service.",
+ "postInstallNotes": "Service installed.\n\nDefault login: `admin`/`password`.",
+ "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "GNU GENERAL PUBLIC LICENSE",
+      "url": "https://github.com/mysql/mysql-server/blob/5.7/COPYING"
+    }
+  ]
+}

--- a/repo/packages/M/mysql/6/package.json
+++ b/repo/packages/M/mysql/6/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "3.0",
   "minDcosReleaseVersion": "1.7",
   "name": "mysql",
-  "version": "5.7.12-0.3",
+  "version": "5.7.12-0.4",
   "scm": "https://github.com/mysql/mysql-server.git",
   "maintainer": "support@mesosphere.io",
   "website": "https://mysql-ci.org",

--- a/repo/packages/M/mysql/6/resource.json
+++ b/repo/packages/M/mysql/6/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "http://enitedinternational.com/img/icons/icon/mysql-icon.png",
+    "icon-medium": "http://www.ebexsoft.com/images/icons/mysql.jpg",
+    "icon-large": "http://michaelglesenkamp.com/images/icons/icon-mysql.jpg"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "mysql-docker": "mysql:5.7.12"
+      }
+    }
+  }
+}

--- a/repo/packages/M/mysql/6/resource.json
+++ b/repo/packages/M/mysql/6/resource.json
@@ -1,8 +1,8 @@
 {
   "images": {
-    "icon-small": "http://enitedinternational.com/img/icons/icon/mysql-icon.png",
-    "icon-medium": "http://www.ebexsoft.com/images/icons/mysql.jpg",
-    "icon-large": "http://michaelglesenkamp.com/images/icons/icon-mysql.jpg"
+    "icon-small": "https://downloads.mesosphere.com/mysql/assets/mysql-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/mysql/assets/mysql-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/mysql/assets/mysql-large.png"
   },
   "assets": {
     "container": {


### PR DESCRIPTION
* correct install Notes and improve info about configurable parameters
* fix scm links where appropriate
* add screenshots in the admin apps
* add note recommending to use endpoint in marathon-LB vs admin router to remove load from AR when possible
* remove configurable "instances" qty - fix to 1
* add "MARATHON_SINGLE_INSTANCE_APP": "true",
* add "upgradeStrategy" (0/0) for single instance apps
* remove "defaults" comments - defaults are obvious when configuring
* use coherent variable names across apps
* use standard default credentials where appropriate: "admin" "password"
* remove "version" from config.json
* move persistent storage to top of description, host_volume to bottom
* fix descriptions of cpus and mem for homogeneity and clarity
* add HOST mode for performance
* ports are only configurable only in bridge option - most dockers don't listen to $PORT0
* add "requirePorts" if host mode
* add HOSTNAME: UNIQUE if host mode
* change version format to $SOFTWAREVERSION-PACKAGEVERSION
e.g. mysql version 6.5.2, package version 0.2 gives
6.5.2-0.2
* bump package minor version