### PR TITLE
Openldap + openldap-admin: add host mode and set of documentation and formatting improvements

### DIFF
--- a/repo/packages/O/openldap-admin/3/config.json
+++ b/repo/packages/O/openldap-admin/3/config.json
@@ -1,0 +1,75 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service":{
+            "type":"object",
+            "description": "DC/OS service configuration properties",
+            "properties":{
+                "name" : {
+                    "description":"Name of this service instance.",
+                    "type":"string",
+                    "default":"openldap-admin"
+                }
+            }
+        },
+        "openldap-admin":{
+            "type": "object",
+            "description": "OpenLDAP-admin service configuration properties",
+            "properties": {
+                "cpus": {
+                    "description": "CPU shares to allocate to each OpenLDAP node.",
+                    "type": "number",
+                    "default": 0.2,
+                    "minimum": 0.1
+                },
+                "mem": {
+                    "description": "Memory to allocate to each OpenLDAP node.",
+                    "type": "number",
+                    "default": 256.0,
+                    "minimum": 128.0
+                }
+            },
+            "required": [
+                "cpus",
+                "mem"
+            ]
+        },
+        "networking":{
+            "type": "object",
+            "description": "OpenLDAP-admin networking configuration properties",
+            "properties": {
+                "ldap_location":{
+                    "description": "The name of the DC/OS OpenLDAP instance to connect to.",
+                    "type": "string",
+                    "default": "openldap"
+                },
+                "ldap_port":{
+                    "description": "The port where the DC/OS OpenLDAP instance is listening on.",
+                    "type": "number",
+                    "default": 389
+                },
+                "external_access": {
+                    "type": "object",
+                    "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+                    "properties": {    
+                        "enable": {
+                            "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+                            "type": "boolean",
+                            "default": false                    
+                        },
+                        "external_access_port": {
+                            "description": "Port number to be used in the external Marathon-LB load balancer",
+                            "type": "number",
+                            "default": 11389
+                        },
+                        "virtual_host":{
+                            "description": "Virtual Host URL to be used in the external Marathon-LB load balancer.",
+                            "type": "string",
+                            "default": "phpldapadmin.example.org"
+                        }
+                    }
+                }    
+            }
+        }
+    }
+}

--- a/repo/packages/O/openldap-admin/3/marathon.json.mustache
+++ b/repo/packages/O/openldap-admin/3/marathon.json.mustache
@@ -1,0 +1,50 @@
+{
+    "id": "{{service.name}}",
+    "cpus": {{openldap-admin.cpus}},
+    "mem": {{openldap-admin.mem}},
+    "instances": 1,
+    "env": {
+        "LDAP_SERVER_HOST": "{{networking.ldap_location}}.marathon.l4lb.thisdcos.directory",
+        "LDAP_SERVER_PORT": "{{networking.ldap_port}}"
+    },
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.openldap-admin-docker}}",
+            "forcePullImage": false,
+            "network": "BRIDGE",
+            "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 0,
+                {{#networking.external_access.enable}}
+                "servicePort": {{networking.external_access.external_port}},
+                {{/networking.external_access.enable}}
+                "protocol": "tcp"
+            }
+            ]
+        }
+    },
+    "healthChecks": [
+        {
+            "protocol": "HTTP",
+            "path": "/",
+            "portIndex": 0,    
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ],
+    "labels": {
+        "DCOS_PACKAGE_VERSION": "1.2.2-0.4",
+        "DCOS_SERVICE_NAME": "{{service.name}}",
+        "DCOS_SERVICE_SCHEME": "http",
+        "DCOS_SERVICE_PORT_INDEX": "0",
+        {{#networking.external_access.enable}}
+        "HAPROXY_GROUP": "external",
+        "HAPROXY_0_VHOST": "{{networking.external_access.virtual_host}}",
+        {{/networking.external_access.enable}}
+        "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+    }
+}

--- a/repo/packages/O/openldap-admin/3/package.json
+++ b/repo/packages/O/openldap-admin/3/package.json
@@ -1,0 +1,21 @@
+{
+  "packagingVersion": "3.0",
+  "name": "openldap-admin",
+  "version": "1.2.2-0.4",
+  "scm": "https://github.com/dinkel/docker-phpldapadmin",
+  "maintainer": "support@mesosphere.io",
+  "website": "http://phpldapadmin.sourceforge.net/wiki/index.php/Main_Page",
+  "description": "phpLDAPadmin is a web-based LDAP client. It provides easy, anywhere-accessible, multi-language administration for your LDAP server.\n\nThis DC/OS package is ready to be used alongside the DC/OS `openldap` package. Other LDAP servers may work, but haven't been tested.",
+  "tags": [
+    "ldap",
+    "directory"
+    ],
+  "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\n```Advanced Installation options notes```\n\nnetworking / *external_access*: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / *external_access_port*: port to be used in Marathon-LB for accessing the service.",
+  "postInstallNotes": "Service installed.\n\nIt is recommended to access this service through the endpoint created in Marathon-LB.\n\nDefault login: `cn=admin,dc=example,dc=org`/`password`.",
+  "licenses": [
+    {
+      "name": "MIT License",
+      "url": "https://opensource.org/licenses/MIT"
+    }
+  ]
+}

--- a/repo/packages/O/openldap-admin/3/resource.json
+++ b/repo/packages/O/openldap-admin/3/resource.json
@@ -1,0 +1,19 @@
+{
+  "images": {
+    "icon-small": "https://a.fsdn.com/allura/p/ldapnis2rfc2307bis/icon",
+    "icon-medium": "https://cdn6.aptoide.com/imgs/6/6/f/66f13d86b96187885e665f5634df7bfa.png",
+    "icon-large": "http://tecdistro.com/wp-content/uploads/2016/02/ldap.png",
+   "screenshots": [
+     "http://i1-scripts.softpedia-static.com/screenshots/phpLDAPadmin-14484.png",
+     "https://a.fsdn.com/con/app/proj/phpldapadmin/screenshots/303927.jpg",
+     "http://i1-linux.softpedia-static.com/screenshots/phpLDAPadmin_2.png"
+    ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "openldap-admin-docker": "dinkel/phpldapadmin:latest"
+      }
+    }
+  }
+}

--- a/repo/packages/O/openldap-admin/4/config.json
+++ b/repo/packages/O/openldap-admin/4/config.json
@@ -1,0 +1,75 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service":{
+            "type":"object",
+            "description": "DC/OS service configuration properties",
+            "properties":{
+                "name" : {
+                    "description":"Name of this service instance.",
+                    "type":"string",
+                    "default":"openldap-admin"
+                }
+            }
+        },
+        "openldap-admin":{
+            "type": "object",
+            "description": "OpenLDAP-admin service configuration properties",
+            "properties": {
+                "cpus": {
+                    "description": "CPU shares to allocate to each OpenLDAP node.",
+                    "type": "number",
+                    "default": 0.2,
+                    "minimum": 0.1
+                },
+                "mem": {
+                    "description": "Memory to allocate to each OpenLDAP node.",
+                    "type": "number",
+                    "default": 256.0,
+                    "minimum": 128.0
+                }
+            },
+            "required": [
+                "cpus",
+                "mem"
+            ]
+        },
+        "networking":{
+            "type": "object",
+            "description": "OpenLDAP-admin networking configuration properties",
+            "properties": {
+                "ldap_location":{
+                    "description": "The name of the DC/OS OpenLDAP instance to connect to.",
+                    "type": "string",
+                    "default": "openldap"
+                },
+                "ldap_port":{
+                    "description": "The port where the DC/OS OpenLDAP instance is listening on.",
+                    "type": "number",
+                    "default": 389
+                },
+                "external_access": {
+                    "type": "object",
+                    "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+                    "properties": {    
+                        "enable": {
+                            "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+                            "type": "boolean",
+                            "default": false                    
+                        },
+                        "external_access_port": {
+                            "description": "Port number to be used in the external Marathon-LB load balancer",
+                            "type": "number",
+                            "default": 11389
+                        },
+                        "virtual_host":{
+                            "description": "Virtual Host URL to be used in the external Marathon-LB load balancer.",
+                            "type": "string",
+                            "default": "phpldapadmin.example.org"
+                        }
+                    }
+                }    
+            }
+        }
+    }
+}

--- a/repo/packages/O/openldap-admin/4/marathon.json.mustache
+++ b/repo/packages/O/openldap-admin/4/marathon.json.mustache
@@ -37,7 +37,7 @@
         }
     ],
     "labels": {
-        "DCOS_PACKAGE_VERSION": "1.2.2-0.4",
+        "DCOS_PACKAGE_VERSION": "1.2.2-0.5",
         "DCOS_SERVICE_NAME": "{{service.name}}",
         "DCOS_SERVICE_SCHEME": "http",
         "DCOS_SERVICE_PORT_INDEX": "0",

--- a/repo/packages/O/openldap-admin/4/marathon.json.mustache
+++ b/repo/packages/O/openldap-admin/4/marathon.json.mustache
@@ -1,0 +1,50 @@
+{
+    "id": "{{service.name}}",
+    "cpus": {{openldap-admin.cpus}},
+    "mem": {{openldap-admin.mem}},
+    "instances": 1,
+    "env": {
+        "LDAP_SERVER_HOST": "{{networking.ldap_location}}.marathon.l4lb.thisdcos.directory",
+        "LDAP_SERVER_PORT": "{{networking.ldap_port}}"
+    },
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.openldap-admin-docker}}",
+            "forcePullImage": false,
+            "network": "BRIDGE",
+            "portMappings": [
+            {
+                "containerPort": 80,
+                "hostPort": 0,
+                {{#networking.external_access.enable}}
+                "servicePort": {{networking.external_access.external_port}},
+                {{/networking.external_access.enable}}
+                "protocol": "tcp"
+            }
+            ]
+        }
+    },
+    "healthChecks": [
+        {
+            "protocol": "HTTP",
+            "path": "/",
+            "portIndex": 0,    
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ],
+    "labels": {
+        "DCOS_PACKAGE_VERSION": "1.2.2-0.4",
+        "DCOS_SERVICE_NAME": "{{service.name}}",
+        "DCOS_SERVICE_SCHEME": "http",
+        "DCOS_SERVICE_PORT_INDEX": "0",
+        {{#networking.external_access.enable}}
+        "HAPROXY_GROUP": "external",
+        "HAPROXY_0_VHOST": "{{networking.external_access.virtual_host}}",
+        {{/networking.external_access.enable}}
+        "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+    }
+}

--- a/repo/packages/O/openldap-admin/4/package.json
+++ b/repo/packages/O/openldap-admin/4/package.json
@@ -1,0 +1,21 @@
+{
+  "packagingVersion": "3.0",
+  "name": "openldap-admin",
+  "version": "1.2.2-0.4",
+  "scm": "https://github.com/dinkel/docker-phpldapadmin",
+  "maintainer": "support@mesosphere.io",
+  "website": "http://phpldapadmin.sourceforge.net/wiki/index.php/Main_Page",
+  "description": "phpLDAPadmin is a web-based LDAP client. It provides easy, anywhere-accessible, multi-language administration for your LDAP server.\n\nThis DC/OS package is ready to be used alongside the DC/OS `openldap` package. Other LDAP servers may work, but haven't been tested.",
+  "tags": [
+    "ldap",
+    "directory"
+    ],
+  "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\n```Advanced Installation options notes```\n\nnetworking / *external_access*: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / *external_access_port*: port to be used in Marathon-LB for accessing the service.",
+  "postInstallNotes": "Service installed.\n\nIt is recommended to access this service through the endpoint created in Marathon-LB.\n\nDefault login: `cn=admin,dc=example,dc=org`/`password`.",
+  "licenses": [
+    {
+      "name": "MIT License",
+      "url": "https://opensource.org/licenses/MIT"
+    }
+  ]
+}

--- a/repo/packages/O/openldap-admin/4/package.json
+++ b/repo/packages/O/openldap-admin/4/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "openldap-admin",
-  "version": "1.2.2-0.4",
+  "version": "1.2.2-0.5",
   "scm": "https://github.com/dinkel/docker-phpldapadmin",
   "maintainer": "support@mesosphere.io",
   "website": "http://phpldapadmin.sourceforge.net/wiki/index.php/Main_Page",

--- a/repo/packages/O/openldap-admin/4/resource.json
+++ b/repo/packages/O/openldap-admin/4/resource.json
@@ -1,0 +1,19 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/openldap-admin/assets/openldap-admin-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/openldap-admin/assets/openldap-admin-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/openldap-admin/assets/openldap-admin-larges.png",
+   "screenshots": [
+     "http://i1-scripts.softpedia-static.com/screenshots/phpLDAPadmin-14484.png",
+     "https://a.fsdn.com/con/app/proj/phpldapadmin/screenshots/303927.jpg",
+     "http://i1-linux.softpedia-static.com/screenshots/phpLDAPadmin_2.png"
+    ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "openldap-admin-docker": "dinkel/phpldapadmin:latest"
+      }
+    }
+  }
+}

--- a/repo/packages/O/openldap-admin/4/resource.json
+++ b/repo/packages/O/openldap-admin/4/resource.json
@@ -1,8 +1,8 @@
 {
   "images": {
-    "icon-small": "https://downloads.mesosphere.com/openldap-admin/assets/openldap-admin-small.png",
-    "icon-medium": "https://downloads.mesosphere.com/openldap-admin/assets/openldap-admin-medium.png",
-    "icon-large": "https://downloads.mesosphere.com/openldap-admin/assets/openldap-admin-larges.png",
+    "icon-small": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-openldap-admin-small.png",
+    "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-openldap-admin-medium.png",
+    "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-openldap-admin-large.png",
    "screenshots": [
      "http://i1-scripts.softpedia-static.com/screenshots/phpLDAPadmin-14484.png",
      "https://a.fsdn.com/con/app/proj/phpldapadmin/screenshots/303927.jpg",

--- a/repo/packages/O/openldap/3/config.json
+++ b/repo/packages/O/openldap/3/config.json
@@ -1,0 +1,141 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service":{
+            "type":"object",
+            "description": "DC/OS service configuration properties",
+            "properties":{
+                "name" : {
+                    "description":"Name of this service instance.",
+                    "type":"string",
+                    "default":"openldap"
+                }
+            }
+        },
+        "openldap":{
+            "type": "object",
+            "description": "OpenLDAP service configuration properties",
+            "properties": {
+                "cpus": {
+                    "description": "CPU shares to allocate to each service instance.",
+                    "type": "number",
+                    "default": 0.3,
+                    "minimum": 0.3
+                },
+                "mem": {
+                    "description": "Memory to allocate to each service instance.",
+                    "type": "number",
+                    "default": 256.0,
+                    "minimum": 128.0
+                }
+            },
+            "required": [
+                "cpus",
+                "mem"
+            ]
+        },
+        "database": {
+            "type": "object",
+            "description": "OpenLDAP database configuration properties",
+            "properties":{
+                "admin_password":{
+                    "description": "Administrator password.",
+                    "type": "string",
+                    "default": "password"
+                },
+                "domain":{
+                    "description": "LDAP domain.",
+                    "type": "string",
+                    "default": "example.org"
+                },
+                "organization":{
+                    "description": "Organization name.",
+                    "type": "string",
+                    "default": "example"
+                },
+                "config_password":{
+                    "description": "Allows password protected access to the dn=config branch. This helps to reconfigure the server without interruption.",
+                    "type": "string",
+                    "default": "password"
+                },
+                "additional_schemas":{
+                    "description": "Loads additional schemas provided in the slapd package.",
+                    "type": "string"
+                },
+                "additional_modules":{
+                    "description": "Comma-separated list of modules to load.",
+                    "type": "string"
+                },
+                "force_reconfigure":{
+                    "description": "Reconfigure the service after the image has been initialized.",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "storage": {
+            "type": "object",
+            "description": "OpenLDAP storage configuration properties",
+            "properties":{  
+                "persistence": {
+                    "type": "object",
+                    "description": "Enable persistent storage.",
+                    "properties": {    
+                       "enable": {
+                            "description": "Enable or disable data persistence.",
+                            "type": "boolean",
+                            "default": false                    
+                        },
+                        "ldap_volume_size": {
+                            "description": "Size in MBs of the volume to be created for the LDAP database",
+                            "type": "number",
+                            "default": 256
+                        },
+                        "slapd_volume_size": {
+                            "description": "Size in MBs of the volume to be created for internal storage of the SLAPD daemon.",
+                            "type": "number",
+                            "default": 64
+                        }
+                    }
+                },            
+                "host_volume": {
+                    "description": "If using non-persistent volumes (local volumes), this sets the location of a volume on the host to be used for the service. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/service_name`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents. NOTE: if you don't change the default /tmp value, YOUR DATA WILL NOT BE SAVED IN ANY WAY.",
+                    "type": "string",
+                    "default": "/tmp"
+                }
+            }
+        },
+        "networking": {
+            "type": "object",
+            "description": "OpenLDAP networking configuration properties",
+            "properties": {    
+                "port": {
+                    "description": "Port number to be used for clear communication internally to the cluster.",
+                    "type": "number",
+                    "default": 389
+                },
+                "host_mode": {
+                    "description": "Enable or disable host networking mode. NOTE: this requires the default port to be available on the target host **THIS IS CURRENTLY NOT THE CASE IN A DEFAULT DC/OS INSTALLATION**. This also forces to have a single instance per node.",
+                    "type": "boolean",
+                    "default": false                    
+                },
+                "external_access": {
+                    "type": "object",
+                    "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+                    "properties": {    
+                        "enable": {
+                            "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+                            "type": "boolean",
+                            "default": false                    
+                        },
+                        "external_access_port": {
+                            "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+                            "type": "number",
+                            "default": 10389
+                        }
+                    }
+                }                
+            }
+        }   
+    }
+}

--- a/repo/packages/O/openldap/3/marathon.json.mustache
+++ b/repo/packages/O/openldap/3/marathon.json.mustache
@@ -1,0 +1,107 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{openldap.cpus}},
+  "mem": {{openldap.mem}},
+  "instances": 1,
+  "env": {
+    "SLAPD_PASSWORD": "{{database.admin_password}}",
+    "SLAPD_DOMAIN": "{{database.domain}}",
+    "SLAPD_ORGANIZATION": "{{database.organization}}",
+    "SLAPD_CONFIG_PASSWORD": "{{database.config_password}}",
+    "SLAPD_ADDITIONAL_SCHEMAS": "{{database.additional_schemas}}",
+    "SLAPD_ADDITIONAL_MODULES": "{{database.additional_modules}}",
+    "SLAPD_FORCE_RECONFIGURE": "{{database.force_reconfigure}}"
+  },
+  "container": {
+    "type": "DOCKER",
+    "volumes": [
+      {
+        "containerPath": "var",
+        {{^storage.persistence.enable}}
+        "hostPath": "{{storage.host_volume}}/{{service.name}}/var",
+        {{/storage.persistence.enable}}
+        {{#storage.persistence.enable}}
+        "persistent": {
+          "size": {{storage.persistence.ldap_volume_size}}
+        },
+        {{/storage.persistence.enable}}
+        "mode": "RW"
+      },
+      {
+        "containerPath": "etc",
+        {{^storage.persistence.enable}}
+        "hostPath": "{{storage.host_volume}}/{{service.name}}/etc",
+        {{/storage.persistence.enable}}
+        {{#storage.persistence.enable}}
+        "persistent": {
+          "size": {{storage.persistence.slapd_volume_size}}
+        },
+        {{/storage.persistence.enable}}
+        "mode": "RW"
+      }
+    ],
+    "docker": {
+      "image": "{{resource.assets.container.docker.openldap-docker}}",
+      {{#networking.host_mode}}
+      "network": "HOST",
+      {{/networking.host_mode}}            
+      {{^networking.host_mode}}      
+      "network": "BRIDGE",
+      "portMappings": [{
+          "containerPort": 389,
+          "hostPort": 0,
+          {{#networking.external_access.enable}}
+          "servicePort": {{networking.external_access.external_access_port}},
+          {{/networking.external_access.enable}}
+          "protocol": "tcp",
+          "name": "{{service.name}}",
+          "labels": {
+            "VIP_0": "/{{service.name}}:{{networking.port}}"
+          }
+      }],
+      {{/networking.host_mode}}
+      "forcePullImage": false
+    }
+  },
+  {{#networking.host_mode}}
+  "portDefinitions": [{
+      "protocol": "tcp",
+      "port": 389,
+      "name": "{{service.name}}",
+      {{#networking.external_access.enable}}
+      "servicePort": {{networking.external_access.external_access_port}},
+      {{/networking.external_access.enable}}
+      "labels": {
+        "VIP_0": "/{{service.name}}:{{networking.port}}"
+      }
+  }],
+  "requirePorts": true,
+  "constraints": [["hostname", "UNIQUE"]],
+  {{/networking.host_mode}}  
+  "healthChecks": [{
+      "protocol": "TCP",
+      {{#networking.host_mode}}
+      "port": 389,
+      {{/networking.host_mode}}
+      {{^networking.host_mode}}
+      "portIndex": 0,
+      {{/networking.host_mode}}  
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 10,
+      "maxConsecutiveFailures": 3
+  }],
+  "labels": {
+    "DCOS_PACKAGE_VERSION": "2.4.40-0.4",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    {{#networking.external_access.enable}}
+    "HAPROXY_GROUP": "external",
+    {{/networking.external_access.enable}}
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/O/openldap/3/package.json
+++ b/repo/packages/O/openldap/3/package.json
@@ -1,0 +1,24 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.7",
+  "name": "openldap",
+  "version": "2.4.40-0.4",
+  "scm": "https://github.com/dinkel/docker-openldap",
+  "maintainer": "support@mesosphere.io",
+  "website": "http://www.openldap.org/",
+  "description": "OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.",
+  "framework": true,
+  "tags": [
+    "ldap",
+    "directory"
+  ],
+ "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\n```Advanced Installation options notes```\n\nstorage / *persistence*: create local persistent volumes for internal storage files to survive across restarts or failures.\n\nstorage / *host_volume*:  if persistence is not selected, this package can use a local volume in the host for storage, like a local directory or an NFS mount. The parameter *host_volume* controls the path in the host in which these volumes will be created, which MUST be the same on all nodes of the cluster.\n\nNOTE: If you didn't select persistence in the storage section, or provided a valid value for *host_volume* on installation,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n\nnetworking / *port*: This DC/OS service can be accessed from any other application through a NAMED VIP in the format *`service_name.marathon.l4lb.thisdcos.directory:port`*. Check status of the VIP in the *Network* tab of the DC/OS Dashboard (Enterprise DC/OS only).\n\nnetworking / *host_mode: Enable or disable host networking mode. NOTE: this requires the default port to be available on the target host **THIS IS CURRENTLY NOT THE CASE IN A DEFAULT DC/OS INSTALLATION, SO ADDITIONAL CONFIGURATION IS REQUIRED TO MAKE THAT PORT AVAILABLE IN AGENT NODES**. This also forces to have a single instance per node.\n\nnetworking / *external_access*: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / *external_access_port*: port to be used in Marathon-LB for accessing the service.\nnetworking / *external_ui_access*: create an entry in Marathon-LB for accessing the status UI web page",
+"postInstallNotes": "Service installed.\n\nDefault login: `cn=admin,dc=example,dc=org`/`password`.",
+"postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "MIT License",
+      "url": "https://opensource.org/licenses/MIT"
+    }
+  ]
+}

--- a/repo/packages/O/openldap/3/resource.json
+++ b/repo/packages/O/openldap/3/resource.json
@@ -1,0 +1,14 @@
+  {
+  "images": {
+    "icon-small": "https://a.fsdn.com/allura/p/ldapnis2rfc2307bis/icon",
+    "icon-medium": "https://cdn6.aptoide.com/imgs/6/6/f/66f13d86b96187885e665f5634df7bfa.png",
+    "icon-large": "http://tecdistro.com/wp-content/uploads/2016/02/ldap.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "openldap-docker": "dinkel/openldap:2.4.40"
+      }
+    }
+  }
+}

--- a/repo/packages/O/openldap/4/config.json
+++ b/repo/packages/O/openldap/4/config.json
@@ -113,7 +113,7 @@
                                     "volume_name": {
                                         "description": "Name that your volume driver uses to look up your external volume. When your task is staged on an agent, the volume driver queries the storage service for a volume with this name. If one does not exist, it is created implicitly. Otherwise, the existing volume is reused.",
                                         "type": "string",
-                                        "default": "mysql"
+                                        "default": "openldap"
                                     },
                                     "provider": {
                                         "description": "Provider of the external persistent volume. The default value should be correct for most use cases.",

--- a/repo/packages/O/openldap/4/config.json
+++ b/repo/packages/O/openldap/4/config.json
@@ -1,0 +1,167 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service":{
+            "type":"object",
+            "description": "DC/OS service configuration properties",
+            "properties":{
+                "name" : {
+                    "description":"Name of this service instance.",
+                    "type":"string",
+                    "default":"openldap"
+                }
+            }
+        },
+        "openldap":{
+            "type": "object",
+            "description": "OpenLDAP service configuration properties",
+            "properties": {
+                "cpus": {
+                    "description": "CPU shares to allocate to each service instance.",
+                    "type": "number",
+                    "default": 0.3,
+                    "minimum": 0.3
+                },
+                "mem": {
+                    "description": "Memory to allocate to each service instance.",
+                    "type": "number",
+                    "default": 256.0,
+                    "minimum": 128.0
+                }
+            },
+            "required": [
+                "cpus",
+                "mem"
+            ]
+        },
+        "database": {
+            "type": "object",
+            "description": "OpenLDAP database configuration properties",
+            "properties":{
+                "admin_password":{
+                    "description": "Administrator password.",
+                    "type": "string",
+                    "default": "password"
+                },
+                "domain":{
+                    "description": "LDAP domain.",
+                    "type": "string",
+                    "default": "example.org"
+                },
+                "organization":{
+                    "description": "Organization name.",
+                    "type": "string",
+                    "default": "example"
+                },
+                "config_password":{
+                    "description": "Allows password protected access to the dn=config branch. This helps to reconfigure the server without interruption.",
+                    "type": "string",
+                    "default": "password"
+                },
+                "additional_schemas":{
+                    "description": "Loads additional schemas provided in the slapd package.",
+                    "type": "string"
+                },
+                "additional_modules":{
+                    "description": "Comma-separated list of modules to load.",
+                    "type": "string"
+                },
+                "force_reconfigure":{
+                    "description": "Reconfigure the service after the image has been initialized.",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "storage": {
+            "type": "object",
+            "description": "OpenLDAP storage configuration properties",
+            "properties":{
+                "host_volume": {
+                    "description": "If using non-persistent volumes (local volumes), this sets the location of a volume on the host to be used for the service. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/service_name`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents. NOTE: if you don't change the default /tmp value, YOUR DATA WILL NOT BE SAVED IN ANY WAY.",
+                    "type": "string",
+                    "default": "/tmp"
+                },  
+                "persistence": {
+                    "type": "object",
+                    "description": "Enable persistent storage.",
+                    "properties": {    
+                       "enable": {
+                            "description": "Enable or disable data persistence.",
+                            "type": "boolean",
+                            "default": false                    
+                        },
+                        "ldap_volume_size": {
+                            "description": "Size in MBs of the volume to be created for the LDAP database",
+                            "type": "number",
+                            "default": 256
+                        },
+                        "slapd_volume_size": {
+                            "description": "Size in MBs of the volume to be created for internal storage of the SLAPD daemon.",
+                            "type": "number",
+                            "default": 64
+                        },
+                        "external": {
+                            "type": "object",
+                            "description": "External persistent storage properties",
+                                "properties":{   
+                                    "enable": {
+                                        "description": "Enable or disable external persistent storage. The `persistence` option must also be selected. Please note that for these to work, your DC/OS cluster MUST have been installed with the right options in `config.yaml`. Also, please note this requires a working  configuration file for the driver (e.g. `rexray.yaml`).",
+                                        "type": "boolean",
+                                        "default": false                    
+                                    },
+                                    "volume_name": {
+                                        "description": "Name that your volume driver uses to look up your external volume. When your task is staged on an agent, the volume driver queries the storage service for a volume with this name. If one does not exist, it is created implicitly. Otherwise, the existing volume is reused.",
+                                        "type": "string",
+                                        "default": "mysql"
+                                    },
+                                    "provider": {
+                                        "description": "Provider of the external persistent volume. The default value should be correct for most use cases.",
+                                        "type": "string",
+                                        "default": "dvdi"
+                                    },
+                                    "driver": {
+                                        "description": "Volume driver to use for storage. The default value should be correct for most use cases.",
+                                        "type": "string",
+                                        "default": "rexray"
+                                    }
+                                }
+                        }                        
+                    }
+                }
+            }
+        },
+        "networking": {
+            "type": "object",
+            "description": "OpenLDAP networking configuration properties",
+            "properties": {    
+                "port": {
+                    "description": "Port number to be used for clear communication internally to the cluster.",
+                    "type": "number",
+                    "default": 389
+                },
+                "host_mode": {
+                    "description": "Enable or disable host networking mode. NOTE: this requires the default port to be available on the target host **THIS IS CURRENTLY NOT THE CASE IN A DEFAULT DC/OS INSTALLATION**. This also forces to have a single instance per node.",
+                    "type": "boolean",
+                    "default": false                    
+                },
+                "external_access": {
+                    "type": "object",
+                    "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+                    "properties": {    
+                        "enable": {
+                            "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+                            "type": "boolean",
+                            "default": false                    
+                        },
+                        "external_access_port": {
+                            "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+                            "type": "number",
+                            "default": 10389
+                        }
+                    }
+                }                
+            }
+        }   
+    }
+}

--- a/repo/packages/O/openldap/4/marathon.json.mustache
+++ b/repo/packages/O/openldap/4/marathon.json.mustache
@@ -30,7 +30,7 @@
         {{#storage.persistence.external.enable}}
         "containerPath": "/var",
         "external": {
-          "name": "{{storage.persistence.external.volume_name}}",
+          "name": "{{storage.persistence.external.volume_name}}var",
           "provider": "{{storage.persistence.external.provider}}",
           "options": { "dvdi/driver": "{{storage.persistence.external.driver}}" }
         },
@@ -52,7 +52,7 @@
         {{#storage.persistence.external.enable}}
         "containerPath": "/etc",
         "external": {
-          "name": "{{storage.persistence.external.volume_name}}",
+          "name": "{{storage.persistence.external.volume_name}}etc",
           "provider": "{{storage.persistence.external.provider}}",
           "options": { "dvdi/driver": "{{storage.persistence.external.driver}}" }
         },

--- a/repo/packages/O/openldap/4/marathon.json.mustache
+++ b/repo/packages/O/openldap/4/marathon.json.mustache
@@ -1,0 +1,128 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{openldap.cpus}},
+  "mem": {{openldap.mem}},
+  "instances": 1,
+  "env": {
+    "SLAPD_PASSWORD": "{{database.admin_password}}",
+    "SLAPD_DOMAIN": "{{database.domain}}",
+    "SLAPD_ORGANIZATION": "{{database.organization}}",
+    "SLAPD_CONFIG_PASSWORD": "{{database.config_password}}",
+    "SLAPD_ADDITIONAL_SCHEMAS": "{{database.additional_schemas}}",
+    "SLAPD_ADDITIONAL_MODULES": "{{database.additional_modules}}",
+    "SLAPD_FORCE_RECONFIGURE": "{{database.force_reconfigure}}"
+  },
+  "container": {
+    "type": "DOCKER",
+    "volumes": [
+      {
+        {{^storage.persistence.enable}}
+        "containerPath": "var",
+        "hostPath": "{{storage.host_volume}}/{{service.name}}/var",
+        {{/storage.persistence.enable}}
+        {{#storage.persistence.enable}}
+        {{^storage.persistence.external.enable}}  
+        "containerPath": "var",         
+        "persistent": {
+          "size": {{storage.persistence.ldap_volume_size}}
+        },
+        {{/storage.persistence.external.enable}}       
+        {{#storage.persistence.external.enable}}
+        "containerPath": "/var",
+        "external": {
+          "name": "{{storage.persistence.external.volume_name}}",
+          "provider": "{{storage.persistence.external.provider}}",
+          "options": { "dvdi/driver": "{{storage.persistence.external.driver}}" }
+        },
+        {{/storage.persistence.external.enable}}
+        {{/storage.persistence.enable}}        
+        "mode": "RW"
+      },
+      {
+        {{^storage.persistence.enable}}        
+        "containerPath": "etc",
+        "hostPath": "{{storage.host_volume}}/{{service.name}}/etc",
+        {{/storage.persistence.enable}}
+        {{#storage.persistence.enable}}
+        {{^storage.persistence.external.enable}}          
+        "persistent": {
+          "size": {{storage.persistence.slapd_volume_size}}
+        },
+        {{/storage.persistence.external.enable}}       
+        {{#storage.persistence.external.enable}}
+        "containerPath": "/etc",
+        "external": {
+          "name": "{{storage.persistence.external.volume_name}}",
+          "provider": "{{storage.persistence.external.provider}}",
+          "options": { "dvdi/driver": "{{storage.persistence.external.driver}}" }
+        },
+        {{/storage.persistence.external.enable}}        
+        {{/storage.persistence.enable}}
+        "mode": "RW"
+      }
+    ],
+    "docker": {
+      "image": "{{resource.assets.container.docker.openldap-docker}}",
+      {{#networking.host_mode}}
+      "network": "HOST",
+      {{/networking.host_mode}}            
+      {{^networking.host_mode}}      
+      "network": "BRIDGE",
+      "portMappings": [{
+          "containerPort": 389,
+          "hostPort": 0,
+          {{#networking.external_access.enable}}
+          "servicePort": {{networking.external_access.external_access_port}},
+          {{/networking.external_access.enable}}
+          "protocol": "tcp",
+          "name": "{{service.name}}",
+          "labels": {
+            "VIP_0": "/{{service.name}}:{{networking.port}}"
+          }
+      }],
+      {{/networking.host_mode}}
+      "forcePullImage": false
+    }
+  },
+  {{#networking.host_mode}}
+  "portDefinitions": [{
+      "protocol": "tcp",
+      "port": 389,
+      "name": "{{service.name}}",
+      {{#networking.external_access.enable}}
+      "servicePort": {{networking.external_access.external_access_port}},
+      {{/networking.external_access.enable}}
+      "labels": {
+        "VIP_0": "/{{service.name}}:{{networking.port}}"
+      }
+  }],
+  "requirePorts": true,
+  "constraints": [["hostname", "UNIQUE"]],
+  {{/networking.host_mode}}  
+  "healthChecks": [{
+      "protocol": "TCP",
+      {{#networking.host_mode}}
+      "port": 389,
+      {{/networking.host_mode}}
+      {{^networking.host_mode}}
+      "portIndex": 0,
+      {{/networking.host_mode}}  
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 10,
+      "maxConsecutiveFailures": 3
+  }],
+  "labels": {
+    "DCOS_PACKAGE_VERSION": "2.4.40-0.5",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    {{#networking.external_access.enable}}
+    "HAPROXY_GROUP": "external",
+    {{/networking.external_access.enable}}
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/O/openldap/4/package.json
+++ b/repo/packages/O/openldap/4/package.json
@@ -1,0 +1,24 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.7",
+  "name": "openldap",
+  "version": "2.4.40-0.5",
+  "scm": "https://github.com/dinkel/docker-openldap",
+  "maintainer": "support@mesosphere.io",
+  "website": "http://www.openldap.org/",
+  "description": "OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.",
+  "framework": true,
+  "tags": [
+    "ldap",
+    "directory"
+  ],
+ "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\n```Advanced Installation options notes```\n\nstorage / *persistence*: create local persistent volumes for internal storage files to survive across restarts or failures.\n\nstorage / persistence / *external*: create external persistent volumes. This allows to use an external storage system such as Amazon EBS, OpenStack Cinder, EMC Isilon, EMC ScaleIO, EMC XtremIO, EMC VMAX and Google Compute Engine persistent storage. *NOTE*: To use external volumes with DC/OS, you MUST enable them during CLI or Advanced installation.\n\nstorage / *host_volume*:  if persistence is not selected, this package can use a local volume in the host for storage, like a local directory or an NFS mount. The parameter *host_volume* controls the path in the host in which these volumes will be created, which MUST be the same on all nodes of the cluster.\n\nNOTE: If you didn't select persistence in the storage section, or provided a valid value for *host_volume* on installation,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n\nnetworking / *port*: This DC/OS service can be accessed from any other application through a NAMED VIP in the format *`service_name.marathon.l4lb.thisdcos.directory:port`*. Check status of the VIP in the *Network* tab of the DC/OS Dashboard (Enterprise DC/OS only).\n\nnetworking / *host_mode: Enable or disable host networking mode. NOTE: this requires the default port to be available on the target host **THIS IS CURRENTLY NOT THE CASE IN A DEFAULT DC/OS INSTALLATION, SO ADDITIONAL CONFIGURATION IS REQUIRED TO MAKE THAT PORT AVAILABLE IN AGENT NODES**. This also forces to have a single instance per node.\n\nnetworking / *external_access*: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / *external_access_port*: port to be used in Marathon-LB for accessing the service.\nnetworking / *external_ui_access*: create an entry in Marathon-LB for accessing the status UI web page",
+"postInstallNotes": "Service installed.\n\nDefault login: `cn=admin,dc=example,dc=org`/`password`.",
+"postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "MIT License",
+      "url": "https://opensource.org/licenses/MIT"
+    }
+  ]
+}

--- a/repo/packages/O/openldap/4/resource.json
+++ b/repo/packages/O/openldap/4/resource.json
@@ -1,0 +1,14 @@
+  {
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/openldap/assets/openldap-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/mysql/assets/openldap-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/mysql/assets/openldap-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "openldap-docker": "dinkel/openldap:2.4.40"
+      }
+    }
+  }
+}

--- a/repo/packages/O/openldap/4/resource.json
+++ b/repo/packages/O/openldap/4/resource.json
@@ -1,8 +1,8 @@
   {
   "images": {
-    "icon-small": "https://downloads.mesosphere.com/openldap/assets/openldap-small.png",
-    "icon-medium": "https://downloads.mesosphere.com/mysql/assets/openldap-medium.png",
-    "icon-large": "https://downloads.mesosphere.com/mysql/assets/openldap-large.png"
+    "icon-small": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-openldap-small.png",
+    "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-openldap-medium.png",
+    "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-openldap-large.png"
   },
   "assets": {
     "container": {


### PR DESCRIPTION

* correct install Notes and improve info about configurable parameters
* fix scm links where appropriate
* add screenshots in the admin apps
* add note recommending to use endpoint in marathon-LB vs admin router to remove load from AR when possible
* remove configurable "instances" qty - fix to 1
* add "MARATHON_SINGLE_INSTANCE_APP": "true",
* add "upgradeStrategy" (0/0) for single instance apps
* remove "defaults" comments - defaults are obvious when configuring
* use coherent variable names across apps
* use standard default credentials where appropriate: "admin" "password"
* remove "version" from config.json
* move persistent storage to top of description, host_volume to bottom
* fix descriptions of cpus and mem for homogeneity and clarity
* add HOST mode for performance
* ports are only configurable only in bridge option - most dockers don't listen to $PORT0
* add "requirePorts" if host mode
* change version format to $SOFTWAREVERSION-PACKAGEVERSION
e.g. mysql version 6.5.2, package version 0.2 gives
6.5.2-0.2
* bump package minor version

* add note about port 389 not being available on a default DCOS installation by default so host mode requires additional manual configuration to allocate that port