### PR TITLE
gen-universe: packages should be deep, not shallow copied

### DIFF
--- a/scripts/gen-universe.py
+++ b/scripts/gen-universe.py
@@ -4,6 +4,7 @@ from distutils.version import LooseVersion
 import argparse
 import base64
 import collections
+import copy
 import itertools
 import json
 import pathlib
@@ -406,7 +407,7 @@ def write_package_in_zip(zip_file, path, package):
     :rtype: None
     """
 
-    package = package.copy()
+    package = copy.deepcopy(package)
     package.pop('releaseVersion')
     package.pop('minDcosReleaseVersion', None)
     package['packagingVersion'] = "2.0"


### PR DESCRIPTION
Mutable data structure caused removed of resource.cli property from
versions that accepted it, since earlier versions that DO NOT accept
that property were processed first.