### PR TITLE
tunnel-cli: Bump to version 0.3.1

### DIFF
--- a/repo/packages/T/tunnel-cli/2/package.json
+++ b/repo/packages/T/tunnel-cli/2/package.json
@@ -1,0 +1,9 @@
+{
+  "packagingVersion": "3.0",
+  "name": "tunnel-cli",
+  "version": "0.2.0",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.8",
+  "description": "Proxy and VPN access to your DC/OS cluster",
+  "tags": [ "mesosphere", "subcommand", "proxy", "vpn", "socks", "http", "cli" ]
+}

--- a/repo/packages/T/tunnel-cli/2/package.json
+++ b/repo/packages/T/tunnel-cli/2/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "tunnel-cli",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "maintainer": "support@mesosphere.io",
   "minDcosReleaseVersion": "1.8",
   "description": "Proxy and VPN access to your DC/OS cluster",

--- a/repo/packages/T/tunnel-cli/2/resource.json
+++ b/repo/packages/T/tunnel-cli/2/resource.json
@@ -1,0 +1,30 @@
+{
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "8af41b70a6913c82af4aa1a0f4521cb183e04a8c6d4bfca7a4011dd0a86603af"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.2.0/dcos-tunnel.zip"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "225958b4b3c06575ea55581016a992cd2537b30780283404cd0b2d1f97c6d9e6"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.2.0/dcos-tunnel.zip"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/T/tunnel-cli/2/resource.json
+++ b/repo/packages/T/tunnel-cli/2/resource.json
@@ -6,11 +6,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "8af41b70a6913c82af4aa1a0f4521cb183e04a8c6d4bfca7a4011dd0a86603af"
+                            "value": "e435e6e372c4a156cfa0abba1d06013925625eae551b93c1e74af5c636a9eea9"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.2.0/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.3.1/dcos-tunnel.zip"
                 }
             },
             "linux": {
@@ -18,11 +18,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "225958b4b3c06575ea55581016a992cd2537b30780283404cd0b2d1f97c6d9e6"
+                            "value": "1ee6683a5279b977672a21afe178b923d6dae1467bb4a54a7ebde90a7d4d1e7e"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.2.0/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.3.1/dcos-tunnel.zip"
                 }
             }
         }


### PR DESCRIPTION
Includes bugfixes and documentation updates.