### PR TITLE
Fix for elasticsearch:latest docker image moving to 5.0

### DIFF
--- a/repo/packages/E/elasticsearch/1/marathon.json.mustache
+++ b/repo/packages/E/elasticsearch/1/marathon.json.mustache
@@ -32,7 +32,8 @@
     {{/elasticsearch.executor.settings-location}}
 
     "--executorForcePullImage", "{{elasticsearch.force-pull-image}}",
-    "--executorName", "{{elasticsearch.executor.name}}"
+    "--executorName", "{{elasticsearch.executor.name}}",
+    "--elasticsearchDockerImage", "elasticsearch:2.3"
   ],
   "env": {
     "JAVA_OPTS": "{{elasticsearch.scheduler.java-heap}}"


### PR DESCRIPTION
Addresses #789.