### PR TITLE
Make universe-base Docker image build again

### DIFF
--- a/docker/local-universe/Dockerfile.base
+++ b/docker/local-universe/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM registry:2.4.1
 
-ENV NGINX_VERSION 1.10.1-1~jessie
+ENV NGINX_VERSION 1.10.2-1~jessie
 
 RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62 \
   && echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list \


### PR DESCRIPTION
Bumping NGINX version fixes the compilation error

This closes #779 