### PR TITLE
A Bookkeeper DCOS package.

### DIFF
--- a/repo/packages/B/bookkeeper/0/config.json
+++ b/repo/packages/B/bookkeeper/0/config.json
@@ -4,9 +4,9 @@
         "bookkeeper": {
             "description": "bookkeeper specific configuration properties",
             "properties": {
-                "app_id": {
+                "name": {
                     "default": "bookkeeper",
-                    "description": "Marathon Application ID",
+                    "description": "The name of this DC/OS service.",
                     "type": "string"
                 },
                 "cpus": {
@@ -27,9 +27,9 @@
                     "minimum": 512.0,
                     "type": "number"
                 },
-                "psize": {
+                "volume_size": {
                     "default": 70,
-                    "description": "psistent Volme size(MB).",
+                    "description": "persistent Volme size(MB).",
                     "minimum": 10,
                     "type": "number"
                 },

--- a/repo/packages/B/bookkeeper/0/config.json
+++ b/repo/packages/B/bookkeeper/0/config.json
@@ -1,10 +1,11 @@
 {
+    "$schema": "http://json-schema.org/schema#",
     "properties": {
         "bookkeeper": {
             "description": "bookkeeper specific configuration properties",
             "properties": {
                 "app_id": {
-                    "default": "bookies",
+                    "default": "bookkeeper",
                     "description": "Marathon Application ID",
                     "type": "string"
                 },
@@ -40,15 +41,12 @@
                 "service_port": {
                     "default": 3181,
                     "description": "env -- bookkeeper service port that export",
-                    "type": "number"
+                    "type": "integer"
                 }
             },
-            
+            "required": ["cpus", "mem", "instances"],
             "type": "object"
         }
     },
-    "required": [
-        "bookkeeper"
-    ],
     "type": "object"
 }

--- a/repo/packages/B/bookkeeper/0/config.json
+++ b/repo/packages/B/bookkeeper/0/config.json
@@ -1,0 +1,48 @@
+{
+    "properties": {
+        "bookkeeper": {
+            "description": "bookkeeper specific configuration properties",
+            "properties": {
+                "app_id": {
+                    "default": "bookies",
+                    "description": "Marathon Application ID",
+                    "type": "string"
+                },
+                "cpus": {
+                    "default": 1,
+                    "description": "CPU shares to allocate to each Marathon instance.",
+                    "minimum": 1,
+                    "type": "number"
+                },
+                "instances": {
+                    "default": 1,
+                    "description": "Number of Marathon instances to run.",
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "mem": {
+                    "default": 1024.0,
+                    "description": "Memory (MB) to allocate to each Marathon task.",
+                    "minimum": 512.0,
+                    "type": "number"
+                },
+                "service_port": {
+                    "default": 3181,
+                    "description": "service port, config file contains in docker",
+                    "type": "integer"
+                },
+                "stats_port": {
+                    "default": 9001,
+                    "description": "stats at port codahaleStatsHttpPort",
+                    "type": "integer"
+                }
+            },
+            
+            "type": "object"
+        }
+    },
+    "required": [
+        "bookkeeper"
+    ],
+    "type": "object"
+}

--- a/repo/packages/B/bookkeeper/0/config.json
+++ b/repo/packages/B/bookkeeper/0/config.json
@@ -40,7 +40,7 @@
                 },
                 "service_port": {
                     "default": 3181,
-                    "description": "env -- bookkeeper service port that export",
+                    "description": "bookkeeper export service port, using PORT0 in marathon",
                     "type": "integer"
                 }
             },

--- a/repo/packages/B/bookkeeper/0/config.json
+++ b/repo/packages/B/bookkeeper/0/config.json
@@ -10,31 +10,37 @@
                 },
                 "cpus": {
                     "default": 1,
-                    "description": "CPU shares to allocate to each Marathon instance.",
+                    "description": "CPU shares to allocate to each bookkeeper instance.",
                     "minimum": 1,
                     "type": "number"
                 },
                 "instances": {
                     "default": 1,
-                    "description": "Number of Marathon instances to run.",
+                    "description": "Number of bookkeeper instances to run.",
                     "minimum": 1,
                     "type": "integer"
                 },
                 "mem": {
                     "default": 1024.0,
-                    "description": "Memory (MB) to allocate to each Marathon task.",
+                    "description": "Memory (MB) to allocate to each bookkeeper task.",
                     "minimum": 512.0,
                     "type": "number"
                 },
+                "psize": {
+                    "default": 70,
+                    "description": "psistent Volme size(MB).",
+                    "minimum": 10,
+                    "type": "number"
+                },
+                "zk_client": {
+                    "default": "master.mesos:2181",
+                    "description": "env -- zookeeper client instance",
+                    "type": "string"
+                },
                 "service_port": {
                     "default": 3181,
-                    "description": "service port, config file contains in docker",
-                    "type": "integer"
-                },
-                "stats_port": {
-                    "default": 9001,
-                    "description": "stats at port codahaleStatsHttpPort",
-                    "type": "integer"
+                    "description": "env -- bookkeeper service port that export",
+                    "type": "number"
                 }
             },
             

--- a/repo/packages/B/bookkeeper/0/marathon.json.mustache
+++ b/repo/packages/B/bookkeeper/0/marathon.json.mustache
@@ -47,10 +47,10 @@
   {
       "protocol": "TCP",
       "port": {{bookkeeper.service_port}},
-      "gracePeriodSeconds": 300,
+      "gracePeriodSeconds": 900,
       "intervalSeconds": 60,
       "timeoutSeconds": 20,
-      "maxConsecutiveFailures": 3,
+      "maxConsecutiveFailures": 0,
       "ignoreHttp1xx": false
   }
   ],

--- a/repo/packages/B/bookkeeper/0/marathon.json.mustache
+++ b/repo/packages/B/bookkeeper/0/marathon.json.mustache
@@ -1,0 +1,49 @@
+{
+  "id": "{{bookkeeper.app_id}}",
+  "cpus":{{bookkeeper.cpus}},
+  "mem": {{bookkeeper.mem}},
+  "instances": {{bookkeeper.instances}},
+  "container": {
+    "type": "DOCKER",
+    "volumes": [
+      {
+        "containerPath": "/bk/journal",
+        "hostPath": "/mnt/journal",
+        "mode": "RW"
+      },
+      {
+        "containerPath": "/bk/index",
+        "hostPath": "/mnt/index",
+        "mode": "RW"
+      },
+      {
+        "containerPath": "/bk/ledgers",
+        "hostPath": "/mnt/ledgers",
+        "mode": "RW"
+      },
+  
+      {
+        "containerPath": "persist",
+        "mode": "RW",
+        "persistent": {
+          "size": 70
+        }
+      }
+    ],
+
+    "docker": {
+      "image": "{{resource.assets.container.docker.bookkeeper}}",
+      "network": "HOST",
+      "portMappings": [
+        { "containerPort": 3181, "hostPort": 3181, "protocol": "tcp" },
+        { "containerPort": 9001, "hostPort": 9001, "protocol": "tcp" }
+      ]
+    }
+  },
+  
+  "upgradeStrategy": {
+    "maximumOverCapacity": 0,
+    "minimumHealthCapacity": 0
+  }
+  
+} 

--- a/repo/packages/B/bookkeeper/0/marathon.json.mustache
+++ b/repo/packages/B/bookkeeper/0/marathon.json.mustache
@@ -1,5 +1,5 @@
 {
-  "id": "{{bookkeeper.app_id}}",
+  "id": "{{bookkeeper.name}}",
   "cpus":{{bookkeeper.cpus}},
   "mem": {{bookkeeper.mem}},
   "instances": {{bookkeeper.instances}},
@@ -27,7 +27,7 @@
         "containerPath": "persist",
         "mode": "RW",
         "persistent": {
-          "size": {{bookkeeper.psize}}
+          "size": {{bookkeeper.volume_size}}
         }
       }
     ],

--- a/repo/packages/B/bookkeeper/0/marathon.json.mustache
+++ b/repo/packages/B/bookkeeper/0/marathon.json.mustache
@@ -35,14 +35,25 @@
     "docker": {
       "image": "{{resource.assets.container.docker.bookkeeper}}",
       "network": "HOST"
-    },
-    
-    "env": {
-        "ZK": {{bookkeeper.zk_client}},
-        "BPORT": {{bookkeeper.service_port}}
     }
-
   },
+  
+  "env": {
+      "ZK": "{{bookkeeper.zk_client}}",
+      "BPORT": "{{bookkeeper.service_port}}"
+  },
+
+  "healthChecks": [
+  {
+      "protocol": "TCP",
+      "port": {{bookkeeper.service_port}},
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+  }
+  ],
   
   "upgradeStrategy": {
     "maximumOverCapacity": 0,

--- a/repo/packages/B/bookkeeper/0/marathon.json.mustache
+++ b/repo/packages/B/bookkeeper/0/marathon.json.mustache
@@ -3,6 +3,7 @@
   "cpus":{{bookkeeper.cpus}},
   "mem": {{bookkeeper.mem}},
   "instances": {{bookkeeper.instances}},
+  "constraints": [["hostname", "UNIQUE"]],
   "container": {
     "type": "DOCKER",
     "volumes": [
@@ -26,19 +27,21 @@
         "containerPath": "persist",
         "mode": "RW",
         "persistent": {
-          "size": 70
+          "size": {{bookkeeper.psize}}
         }
       }
     ],
 
     "docker": {
       "image": "{{resource.assets.container.docker.bookkeeper}}",
-      "network": "HOST",
-      "portMappings": [
-        { "containerPort": 3181, "hostPort": 3181, "protocol": "tcp" },
-        { "containerPort": 9001, "hostPort": 9001, "protocol": "tcp" }
-      ]
+      "network": "HOST"
+    },
+    
+    "env": {
+        "ZK": {{bookkeeper.zk_client}},
+        "BPORT": {{bookkeeper.service_port}}
     }
+
   },
   
   "upgradeStrategy": {

--- a/repo/packages/B/bookkeeper/0/marathon.json.mustache
+++ b/repo/packages/B/bookkeeper/0/marathon.json.mustache
@@ -37,10 +37,17 @@
       "network": "HOST"
     }
   },
-  
+ 
+  "portDefinitions": [
+    {
+      "protocol": "tcp",
+      "port": {{bookkeeper.service_port}}
+    }
+   ],
+  "requirePorts": true,
+ 
   "env": {
-      "ZK": "{{bookkeeper.zk_client}}",
-      "BPORT": "{{bookkeeper.service_port}}"
+      "ZK": "{{bookkeeper.zk_client}}"
   },
 
   "healthChecks": [

--- a/repo/packages/B/bookkeeper/0/package.json
+++ b/repo/packages/B/bookkeeper/0/package.json
@@ -15,6 +15,6 @@
  ],
  "website":  "http://bookkeeper.apache.org",
  "postInstallNotes": "bookkeeper on DCOS installed successfully!",
- "preInstallNotes": "Be sure zk could access,  by default it's master.mesos:2181,  bk default port:3181",
- "postUninstallNotes": "Thank you for using bookkeeper"
+ "preInstallNotes": "Welcome using bookkeeper. Be sure zk could access, by default it's master.mesos:2181,  bk default service port:3181.",
+ "postUninstallNotes": "Thank you for using bookkeeper."
 }

--- a/repo/packages/B/bookkeeper/0/package.json
+++ b/repo/packages/B/bookkeeper/0/package.json
@@ -15,6 +15,6 @@
  ],
  "website":  "http://bookkeeper.apache.org",
  "postInstallNotes": "bookkeeper on DCOS installed successfully!",
- "preInstallNotes": "Be sure zk could access by master.mesos:2181, and bk will use port:3181",
+ "preInstallNotes": "Be sure zk could access,  by default it's master.mesos:2181,  bk default port:3181",
  "postUninstallNotes": "Thank you for using bookkeeper"
 }

--- a/repo/packages/B/bookkeeper/0/package.json
+++ b/repo/packages/B/bookkeeper/0/package.json
@@ -1,20 +1,20 @@
 {
  "packagingVersion": "3.0",
  "name": "bookkeeper",
- "version": "4.3.4",
+ "version": "4.3.4-0.1",
  "scm": "https://github.com/twitter/bookkeeper",
  "maintainer": "jia.zhai@emc.com",
- "description": "bookkeeper",
+ "description": "BookKeeper is a replicated log service which can be used to build replicated state machines. A log contains a sequence of events which can be applied to a state machine. BookKeeper guarantees that each replica state machine will see all the same entries, in the same order. One bookkeeper instance is called a bookie, By default this package deploy 1 bookie. Usually we should deploy at least 3 bookies to start a bookkeeper cluster. And there is an example included here:https://github.com/dcos/examples",
  "framework": false,
- "tags": ["mesosphere", "service", "bookkeeper"],
+ "tags": ["service", "bookkeeper"],
  "licenses": [
    {
      "name": "BSD",
-     "url": "http://www.apache.org/licenses/"
+     "url": "https://github.com/apache/bookkeeper/blob/master/LICENSE"
    }
  ],
  "website":  "http://bookkeeper.apache.org",
  "postInstallNotes": "bookkeeper on DCOS installed successfully!",
- "preInstallNotes": "Welcome using bookkeeper. Be sure zk could access, by default it's master.mesos:2181,  bk default service port:3181.",
+ "preInstallNotes": "Welcome using bookkeeper. This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.  Be sure zk could access, by default it's master.mesos:2181,  bk default service port:3181.",
  "postUninstallNotes": "Thank you for using bookkeeper."
 }

--- a/repo/packages/B/bookkeeper/0/package.json
+++ b/repo/packages/B/bookkeeper/0/package.json
@@ -1,0 +1,20 @@
+{
+ "packagingVersion": "3.0",
+ "name": "bookkeeper",
+ "version": "4.3.4",
+ "scm": "https://github.com/twitter/bookkeeper",
+ "maintainer": "jia.zhai@emc.com",
+ "description": "bookkeeper",
+ "framework": false,
+ "tags": ["mesosphere", "service", "bookkeeper"],
+ "licenses": [
+   {
+     "name": "BSD",
+     "url": "http://www.apache.org/licenses/"
+   }
+ ],
+ "website":  "http://bookkeeper.apache.org",
+ "postInstallNotes": "bookkeeper on DCOS installed successfully!",
+ "preInstallNotes": "Be sure zk could access by master.mesos:2181, and bk will use port:3181",
+ "postUninstallNotes": "Thank you for using bookkeeper"
+}

--- a/repo/packages/B/bookkeeper/0/resource.json
+++ b/repo/packages/B/bookkeeper/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "bookkeeper": "zhaijia/bookkeeper"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "http://bookkeeper.apache.org/img/bookkeeper_blk40.png",
+    "icon-medium": "http://bookkeeper.apache.org/img/bookkeeper_blk40.png",
+    "icon-large": "http://bookkeeper.apache.org/img/bookkeeper_blk40.png"
+  }
+}

--- a/repo/packages/B/bookkeeper/0/resource.json
+++ b/repo/packages/B/bookkeeper/0/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "bookkeeper": "zhaijia/bookkeeper"
+        "bookkeeper": "zhaijia/bookie"
       }
     }
   },

--- a/repo/packages/B/bookkeeper/0/resource.json
+++ b/repo/packages/B/bookkeeper/0/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "bookkeeper": "zhaijia/bookie:latest"
+        "bookkeeper": "zhaijia/bookie:nov16"
       }
     }
   },

--- a/repo/packages/B/bookkeeper/0/resource.json
+++ b/repo/packages/B/bookkeeper/0/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "bookkeeper": "zhaijia/bookie"
+        "bookkeeper": "zhaijia/bookie:latest"
       }
     }
   },


### PR DESCRIPTION
Here is bookkeeper's home page: http://bookkeeper.apache.org/.
This package will automatic start a bookie and export bookie read/write service to slave_ip:3181, the zookeeper instance and bookie service port is configurable through docker env vars.

