### PR TITLE
Influxdb: first version

### DIFF
--- a/repo/packages/I/influxdb/0/config.json
+++ b/repo/packages/I/influxdb/0/config.json
@@ -1,0 +1,127 @@
+{
+	"$schema": "http://json-schema.org/schema#",
+	"properties": {
+		"service": {
+			"type": "object",
+			"description": "DC/OS service configuration properties",
+			"properties": {
+				"name": {
+					"description": "Name of this service instance",
+					"type": "string",
+					"default": "influxdb"
+				},
+				"cpus": {
+					"description": "CPU shares to allocate to each service instance.",
+					"type": "number",
+					"default": 0.5,
+					"minimum": 0.3
+				},
+				"mem": {
+					"description":  "Memory to allocate to each service instance.",
+					"type": "number",
+					"default": 256.0,
+					"minimum": 256.0
+				}
+			},
+			"required": [
+				"cpus",
+				"mem"
+			]
+		},
+		"storage": {
+			"type": "object",
+			"description": "influxdb storage configuration properties",
+			"properties":{
+				"pre_create_database": {
+					"description": "Check to create one or more databases on the first time the service starts automatically.",
+					"type": "boolean",
+					"default": "true"
+				},
+				"database_name": {
+					"description": "Use 'db1;db2;db3' to create databases named 'db1', 'db2', and 'db3' on the first time the service starts automatically. Each database name is separated by ; .",
+					"type": "string",
+					"default": "cadvisor"
+				},
+				"host_volume_influxdb": {
+					"description": "If using non-persistent volumes (local volumes), this sets the location of a volume on the host to be used for the influxdb service to store the contents of the influxdb. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/service_name`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents. NOTE: if you don't change the default /tmp value, YOUR DATA WILL NOT BE SAVED IN ANY WAY.",
+					"type": "string",
+					"default": "/tmp"
+				},     
+				"persistence": {
+					"type": "object",
+					"description": "Enable persistent storage.",
+					"properties": {    
+						"enable": {
+							"description": "Enable or disable persistent storage.",
+							"type": "boolean",
+							"default": false                    
+						},
+						"volume_size_influxdb": {
+							"description": "If a new volume is to be created, this controls its size in MBs.",
+							"type": "number",
+							"default": 2048
+						},
+						"external": {
+							"type": "object",
+							"description": "External persistent storage properties",
+								"properties":{   
+									"enable": {
+										"description": "Enable or disable external persistent storage. The `persistence` option must also be selected. Please note that for these to work, your DC/OS cluster MUST have been installed with the right options in `config.yaml`. Also, please note this requires a working  configuration file for the driver (e.g. `rexray.yaml`).",
+										"type": "boolean",
+										"default": false                    
+									},
+									"volume_name_influxdb": {
+										"description": "Name that your volume driver uses to look up your external volume. When your task is staged on an agent, the volume driver queries the storage service for a volume with this name. If one does not exist, it is created implicitly. Otherwise, the existing volume is reused.",
+										"type": "string",
+										"default": "influxdb"
+									},
+									"provider": {
+										"description": "Provider of the external persistent volume. The default value should be correct for most use cases.",
+										"type": "string",
+										"default": "dvdi"
+									},
+									"driver": {
+										"description": "Volume driver to use for storage. The default value should be correct for most use cases.",
+										"type": "string",
+										"default": "rexray"
+									}
+								}
+						}
+					}
+				}
+			}
+		},
+		"networking": {
+			"type": "object",
+			"description": "influxdb networking configuration properties",
+			"properties": {    
+				"port": {
+					"description": "Port number to be used for administration internally to the cluster.",
+					"type": "number",
+					"default": 8083
+				},
+  				"port_api": {
+					"description": "Port number to be used for api communication internally to the cluster.",
+					"type": "number",
+					"default": 8086
+				},
+				"external_access": {
+					"type": "object",
+					"description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+						"properties": {    
+							"enable": {
+								"description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+								"type": "boolean",
+								"default": false                    
+							},
+							"external_access_port": {
+								"description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+								"type": "number",
+								"default": 18083
+							}
+						}
+					}
+			}      
+		}
+	}
+}

--- a/repo/packages/I/influxdb/0/config.json
+++ b/repo/packages/I/influxdb/0/config.json
@@ -19,8 +19,8 @@
 				"mem": {
 					"description":  "Memory to allocate to each service instance.",
 					"type": "number",
-					"default": 1024.0,
-					"minimum": 1024.0
+					"default": 2048.0,
+					"minimum": 2048.0
 				}
 			},
 			"required": [

--- a/repo/packages/I/influxdb/0/config.json
+++ b/repo/packages/I/influxdb/0/config.json
@@ -37,7 +37,7 @@
 					"type": "boolean",
 					"default": "true"
 				},
-				"database_name": {
+				"pre_create_database_name": {
 					"description": "Use 'db1;db2;db3' to create databases named 'db1', 'db2', and 'db3' on the first time the service starts automatically. Each database name is separated by ; .",
 					"type": "string",
 					"default": "cadvisor"

--- a/repo/packages/I/influxdb/0/config.json
+++ b/repo/packages/I/influxdb/0/config.json
@@ -35,7 +35,7 @@
 				"pre_create_database": {
 					"description": "Check to create one or more databases on the first time the service starts automatically.",
 					"type": "boolean",
-					"default": "true"
+					"default": true
 				},
 				"pre_create_database_name": {
 					"description": "Use 'db1;db2;db3' to create databases named 'db1', 'db2', and 'db3' on the first time the service starts automatically. Each database name is separated by ; .",

--- a/repo/packages/I/influxdb/0/config.json
+++ b/repo/packages/I/influxdb/0/config.json
@@ -20,7 +20,7 @@
 					"description":  "Memory to allocate to each service instance.",
 					"type": "number",
 					"default": 2048.0,
-					"minimum": 2048.0
+					"minimum": 1024.0
 				}
 			},
 			"required": [

--- a/repo/packages/I/influxdb/0/config.json
+++ b/repo/packages/I/influxdb/0/config.json
@@ -13,14 +13,14 @@
 				"cpus": {
 					"description": "CPU shares to allocate to each service instance.",
 					"type": "number",
-					"default": 0.5,
-					"minimum": 0.3
+					"default": 1,
+					"minimum": 1
 				},
 				"mem": {
 					"description":  "Memory to allocate to each service instance.",
 					"type": "number",
-					"default": 256.0,
-					"minimum": 256.0
+					"default": 1024.0,
+					"minimum": 1024.0
 				}
 			},
 			"required": [

--- a/repo/packages/I/influxdb/0/marathon.json.mustache
+++ b/repo/packages/I/influxdb/0/marathon.json.mustache
@@ -56,7 +56,7 @@
         "labels": {
           "VIP_0": "/{{service.name}}:{{networking.port_api}}"
         }
-      }],
+      ],
       "forcePullImage": false
     }
   },

--- a/repo/packages/I/influxdb/0/marathon.json.mustache
+++ b/repo/packages/I/influxdb/0/marathon.json.mustache
@@ -47,6 +47,7 @@
         "name": "{{service.name}}-admin",
         "labels": {
           "VIP_0": "/{{service.name}}:{{networking.port}}"
+          }
         },
         {
         "containerPort": 8086,
@@ -55,6 +56,7 @@
         "name": "{{service.name}}-api",
         "labels": {
           "VIP_0": "/{{service.name}}:{{networking.port_api}}"
+          }
         }
       ],
       "forcePullImage": false

--- a/repo/packages/I/influxdb/0/marathon.json.mustache
+++ b/repo/packages/I/influxdb/0/marathon.json.mustache
@@ -44,7 +44,7 @@
         "servicePort": {{networking.external_access.external_access_port}},
         {{/networking.external_access.enable}}
         "protocol": "tcp",
-        "name": "{{service.name}}-admin",
+        "name": "influxdb-admin",
         "labels": {
           "VIP_0": "/{{service.name}}:{{networking.port}}"
           }
@@ -53,7 +53,7 @@
         "containerPort": 8086,
         "hostPort": 0,
         "protocol": "tcp",
-        "name": "{{service.name}}-api",
+        "name": "influxdb-api",
         "labels": {
           "VIP_0": "/{{service.name}}:{{networking.port_api}}"
           }

--- a/repo/packages/I/influxdb/0/marathon.json.mustache
+++ b/repo/packages/I/influxdb/0/marathon.json.mustache
@@ -5,7 +5,7 @@
   "instances": 1,
   "env": {  
   {{#storage.pre_create_database}}
-    "PRE_CREATE_DB: "{{storage.database_name}}"
+    "PRE_CREATE_DB: "{{storage.pre_create_database_name}}"
   {{/storage.pre_create_database}}
   },
   "container": {

--- a/repo/packages/I/influxdb/0/marathon.json.mustache
+++ b/repo/packages/I/influxdb/0/marathon.json.mustache
@@ -1,0 +1,87 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "instances": 1,
+  "env": {  
+  {{#storage.pre_create_database}}
+    "PRE_CREATE_DB: "{{storage.database_name}}"
+  {{/storage.pre_create_database}}
+  },
+  "container": {
+    "type": "DOCKER",
+    "volumes": [{
+      {{^storage.persistence.enable}}
+      "containerPath": "/data",
+      "hostPath": "{{storage.host_volume_influxdb}}/{{service.name}}",
+      {{/storage.persistence.enable}}
+      {{#storage.persistence.enable}}
+      {{^storage.persistence.external.enable}}
+      "containerPath": "data",
+      "persistent": {
+        "size": {{storage.persistence.volume_size_influxdb}}
+      },
+      {{/storage.persistence.external.enable}}
+      {{#storage.persistence.external.enable}}
+      "containerPath": "/data",
+      "external": {
+        "name": "{{storage.persistence.external.volume_name_influxdb}}",
+        "provider": "{{storage.persistence.external.provider}}",
+        "options": { "dvdi/driver": "{{storage.persistence.external.driver}}" }
+      },
+      {{/storage.persistence.external.enable}}
+      {{/storage.persistence.enable}}
+      "mode": "RW"
+    }],
+    "docker": {
+      "image": "{{resource.assets.container.docker.influxdb-docker}}",
+      "network": "BRIDGE",
+      "portMappings": [
+        {
+        "containerPort": 8083,
+        "hostPort": 0,
+        {{#networking.external_access.enable}}
+        "servicePort": {{networking.external_access.external_access_port}},
+        {{/networking.external_access.enable}}
+        "protocol": "tcp",
+        "name": "{{service.name}}-admin",
+        "labels": {
+          "VIP_0": "/{{service.name}}:{{networking.port}}"
+        },
+        {
+        "containerPort": 8086,
+        "hostPort": 0,
+        "protocol": "tcp",
+        "name": "{{service.name}}-api",
+        "labels": {
+          "VIP_0": "/{{service.name}}:{{networking.port_api}}"
+        }
+      }],
+      "forcePullImage": false
+    }
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/",
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "labels": {
+    "DCOS_PACKAGE_VERSION": "0.13-0.1",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    {{#networking.external_access.enable}}
+    "HAPROXY_GROUP": "external",
+    {{/networking.external_access.enable}}
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/I/influxdb/0/marathon.json.mustache
+++ b/repo/packages/I/influxdb/0/marathon.json.mustache
@@ -5,7 +5,7 @@
   "instances": 1,
   "env": {  
   {{#storage.pre_create_database}}
-    "PRE_CREATE_DB: "{{storage.pre_create_database_name}}"
+    "PRE_CREATE_DB": "{{storage.pre_create_database_name}}"
   {{/storage.pre_create_database}}
   },
   "container": {

--- a/repo/packages/I/influxdb/0/package.json
+++ b/repo/packages/I/influxdb/0/package.json
@@ -1,0 +1,20 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.7",
+  "name": "influxdb",
+  "version": "0.13-0.1",
+  "scm": "https://github.com/influxdata/influxdb",
+  "maintainer": "support@mesosphere.io",
+  "website": "https://github.com/influxdata/influxdb",
+  "description": "InfluxDB is an open-source time series database developed by InfluxData as part of their time series platform. It is written in Go and optimized for fast, high-availability storage and retrieval of time series data in fields such as operations monitoring, application metrics, Internet of Things sensor data, and real-time analytics.\n\nThis package can be used alongside the DC/OS 'cadvisor' and 'grafana' packages for a cluster-wide monitoring solution.\n\nInstallation Documentation: https://github.com/dcos/examples/tree/master/1.8/cadvisor-influxdb-grafana\n\n", 
+  "tags": ["docker", "influxdb", "database", "monitoring"],
+  "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nAdvanced Installation options notes\n\nstorage / persistence: create local persistent volumes for internal storage files to survive across restarts or failures.\n\nstorage / persistence / *external*: create external persistent volumes. This allows to use an external storage system such as Amazon EBS, OpenStack Cinder, EMC Isilon, EMC ScaleIO, EMC XtremIO, EMC VMAX and Google Compute Engine persistent storage. NOTE: To use external volumes with DC/OS, you MUST enable them during CLI or Advanced installation.\n\nstorage / host_volume:  if persistence is not selected, this package can use a local volume in the host for storage, like a local directory or an NFS mount. The parameter host_volume controls the path in the host in which these volumes will be created, which MUST be the same on all nodes of the cluster.\n\nNOTE: If you didn't select persistence in the storage section, or provided a valid value for host_volume on installation,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n\nnetworking / port: This DC/OS service can be accessed from any other application through a NAMED VIP in the format service_name.marathon.l4lb.thisdcos.directory:port. Check status of the VIP in the Network tab of the DC/OS Dashboard (Enterprise DC/OS only).\n\nnetworking / external_access: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / external_access_port: port to be used in Marathon-LB for accessing the service.",
+ "postInstallNotes": "Service installed.",
+ "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed from the agent where the service was deployed.",
+  "licenses": [
+    {
+      "name": "Apache License",
+      "url": "http://en.wikipedia.org/wiki/Apache_License"
+    }
+  ]
+}

--- a/repo/packages/I/influxdb/0/resource.json
+++ b/repo/packages/I/influxdb/0/resource.json
@@ -1,0 +1,17 @@
+{
+  "images": {
+    "icon-small": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-influxdb-small.png",
+    "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-influxdb-medium.png",
+    "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-influxdb-large.png",
+     "screenshots": [
+     "https://raw.githubusercontent.com/Kentik/docker-monitor/master/screenshots/influxdb-screenshot.png"
+   ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "influxdb-docker": "tutum/influxdb:0.13"
+      }
+    }
+  }
+}


### PR DESCRIPTION
influxdb from tutum/influxdb:0.13

Supports all storage backends of the latest stateful mini-packages

tested to run with cadvisor and grafana for monitoring.