### PR TITLE
Downgrade ElasticSearch default version to 2.4.1

### DIFF
--- a/repo/packages/E/elasticsearch/2/config.json
+++ b/repo/packages/E/elasticsearch/2/config.json
@@ -43,7 +43,7 @@
           "type":"boolean"
         },
         "docker-image":{
-          "default":"elasticsearch:latest",
+          "default":"elasticsearch:2.4.1",
           "description":"The elasticsearch docker image to use",
           "type":"string"
         },


### PR DESCRIPTION
As per the issue raised by @gisjedi in #789 ElasticSearch will fail to start up for images greater than 2.4.1 so we have decided to set the default image to 2.4.1.