### PR TITLE
Myriad 0.2

### DIFF
--- a/repo/packages/M/myriad/0/config.json
+++ b/repo/packages/M/myriad/0/config.json
@@ -1,22 +1,22 @@
 {
   "type": "object",
   "properties": {
-    "myriad": {
+    "service": {
       "description": "Myriad framework configuration properties",
       "type": "object",
       "properties": {
-        "framework-name": {
+        "name": {
           "description": "The framework name to register with Mesos.",
           "type": "string",
           "default": "myriad"
         }
       },
       "required": [
-        "framework-name"
+        "name"
       ]
     }
   },
   "required": [
-    "myriad"
+    "service"
   ]
 }

--- a/repo/packages/M/myriad/0/config.json
+++ b/repo/packages/M/myriad/0/config.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "myriad": {
+      "description": "Myriad framework configuration properties",
+      "type": "object",
+      "properties": {
+        "framework-name": {
+          "description": "The framework name to register with Mesos.",
+          "type": "string",
+          "default": "myriad"
+        }
+      },
+      "required": [
+        "framework-name"
+      ]
+    }
+  },
+  "required": [
+    "myriad"
+  ]
+}

--- a/repo/packages/M/myriad/0/config.json
+++ b/repo/packages/M/myriad/0/config.json
@@ -6,9 +6,21 @@
       "type": "object",
       "properties": {
         "name": {
-          "description": "The framework name to register with Mesos.",
+          "description": "The framework name to register with Mesos, which is also used for the DC/OS service URL and DNS name.",
           "type": "string",
           "default": "myriad"
+        },
+        "cpus": {
+          "description": "CPUs to allocate to Myriad scheduler and YARN Resource Manager.",
+          "type": "number",
+          "default": 1.0,
+          "minimum": 0.1
+        },
+        "mem": {
+          "description": "Memory (in MB) to allocate to Myriad scheduler and YARN Resource Manager.",
+          "type": "number",
+          "default": 2048.0,
+          "minimum": 2048.0
         }
       },
       "required": [

--- a/repo/packages/M/myriad/0/marathon.json.mustache
+++ b/repo/packages/M/myriad/0/marathon.json.mustache
@@ -43,7 +43,7 @@
     "DCOS_PACKAGE_FRAMEWORK_NAME": "myriad"
   },
   "env":{
-    "YARN_RESOURCEMANAGER_OPTS":"-Dyarn.resourcemanager.hostname=myriad.marathon.mesos"
-    ,"USER":"root"
+    "YARN_RESOURCEMANAGER_OPTS":"-Dyarn.resourcemanager.hostname=myriad.marathon.mesos",
+    "USER":"root"
   }
 }

--- a/repo/packages/M/myriad/0/marathon.json.mustache
+++ b/repo/packages/M/myriad/0/marathon.json.mustache
@@ -36,8 +36,8 @@
     }
   ],
   "uris": [
-    "https://s3-us-west-2.amazonaws.com/myriad-dev/universe/hadoop-2.7.1-rm.tar.xz",
-    "https://downloads.mesosphere.com/java/jre-7u76-linux-x64.tar.gz"
+    "{{resource.assets.uris.apache-myriad-hadoop-tar-xz}}",
+    "{{resource.assets.uris.jre-tar-gz}}"
   ],
   "labels": {
     "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}"

--- a/repo/packages/M/myriad/0/marathon.json.mustache
+++ b/repo/packages/M/myriad/0/marathon.json.mustache
@@ -1,0 +1,49 @@
+{
+  "id": "myriad",
+  "cmd": "until nslookup myriad.marathon.mesos; do echo 'Cannot resolve myriad.marathon.mesos yet. Trying again...'; sleep 2; done && export JAVA_HOME=$MESOS_DIRECTORY/jre1.7.0_76 && env && ./hadoop-2.7.1/bin/yarn resourcemanager",
+  "instances": 1,
+  "cpus": 1,
+  "mem": 2048,
+  "requirePorts": true,
+  "portDefinitions": [
+    {
+      "port": 8192,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": {
+        "VIP_0": "1.2.3.4:5000"
+      }
+    },
+    {
+      "port": 8088,
+      "protocol": "tcp",
+      "name": "rm",
+      "labels": {
+        "VIP_0": "1.2.3.4:6000"
+      }
+    }
+  ],
+  "healthChecks": [
+    {
+      "path": "/api/config",
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "uris": [
+    "https://s3-us-west-2.amazonaws.com/myriad-dev/universe/hadoop-2.7.1-rm.tar.xz",
+    "https://downloads.mesosphere.com/java/jre-7u76-linux-x64.tar.gz"
+  ],
+  "labels": {
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "myriad"
+  },
+  "env":{
+    "YARN_RESOURCEMANAGER_OPTS":"-Dyarn.resourcemanager.hostname=myriad.marathon.mesos"
+    ,"USER":"root"
+  }
+}

--- a/repo/packages/M/myriad/0/marathon.json.mustache
+++ b/repo/packages/M/myriad/0/marathon.json.mustache
@@ -1,9 +1,9 @@
 {
-  "id": "myriad",
-  "cmd": "until nslookup myriad.marathon.mesos; do echo 'Cannot resolve myriad.marathon.mesos yet. Trying again...'; sleep 2; done && export JAVA_HOME=$MESOS_DIRECTORY/jre1.7.0_76 && env && ./hadoop-2.7.1/bin/yarn resourcemanager",
+  "id": "{{service.name}}",
+  "cmd": "until nslookup {{service.name}}.marathon.mesos; do echo 'Cannot resolve {{service.name}}.marathon.mesos yet. Trying again...'; sleep 2; done && export JAVA_HOME=$MESOS_DIRECTORY/jre1.7.0_76 && env && ./hadoop-2.7.1/bin/yarn resourcemanager",
   "instances": 1,
-  "cpus": 1,
-  "mem": 2048,
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
   "requirePorts": true,
   "portDefinitions": [
     {
@@ -40,10 +40,10 @@
     "https://downloads.mesosphere.com/java/jre-7u76-linux-x64.tar.gz"
   ],
   "labels": {
-    "DCOS_PACKAGE_FRAMEWORK_NAME": "myriad"
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}"
   },
   "env":{
-    "YARN_RESOURCEMANAGER_OPTS":"-Dyarn.resourcemanager.hostname=myriad.marathon.mesos",
+    "YARN_RESOURCEMANAGER_OPTS":"-Dyarn.resourcemanager.hostname={{service.name}}.marathon.mesos",
     "USER":"root"
   }
 }

--- a/repo/packages/M/myriad/0/package.json
+++ b/repo/packages/M/myriad/0/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion" : "2.0",
+  "name" : "myriad",
+  "version" : "0.0.1",
+  "scm" : "https://github.com/apache/incubator-myriad",
+  "maintainer" : "dev@myriad.incubator.apache.org",
+  "description" : "Apache Myriad (incubating) installs, manages, and scales Hadoop/YARN on Mesos",
+  "framework" : true,
+  "licenses" : [ {
+    "name" : "Apache License Version 2.0",
+    "url" : "https://github.com/mesosphere/marathon/blob/master/LICENSE"
+  } ],
+  "tags" : [ "hadoop", "yarn", "myriad" ],
+  "preInstallNotes" : "You are about to install Hadoop/YARN on DC/OS with the Apache Myriad service.",
+  "postInstallNotes" : "Your Myriad cluster is being deployed.",
+  "postUninstallNotes" : "Your Myriad cluster has been uninstalled. Please run the framework_cleaner to remove any persistent state if required.",
+  "selected" : false
+}

--- a/repo/packages/M/myriad/0/package.json
+++ b/repo/packages/M/myriad/0/package.json
@@ -1,18 +1,19 @@
 {
   "packagingVersion" : "2.0",
-  "name" : "myriad",
-  "version" : "0.0.1",
-  "scm" : "https://github.com/apache/incubator-myriad",
-  "maintainer" : "dev@myriad.incubator.apache.org",
   "description" : "Apache Myriad (incubating) installs, manages, and scales Hadoop/YARN on Mesos",
-  "framework" : true,
+  "name" : "myriad",
+  "version" : "0.2.0",
+  "scm" : "https://github.com/apache/incubator-myriad",
+  "website": "https://myriad.incubator.apache.org",
+  "maintainer" : "dev@myriad.incubator.apache.org",
   "licenses" : [ {
     "name" : "Apache License Version 2.0",
-    "url" : "https://github.com/mesosphere/marathon/blob/master/LICENSE"
+    "url" : "https://github.com/apache/incubator-myriad/blob/master/LICENSE"
   } ],
   "tags" : [ "hadoop", "yarn", "myriad" ],
-  "preInstallNotes" : "You are about to install Hadoop/YARN on DC/OS with the Apache Myriad service.",
-  "postInstallNotes" : "Your Myriad cluster is being deployed.",
+  "preInstallNotes" : "You are about to install Hadoop/YARN on DC/OS with the Apache Myriad service. This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, or incorrect documentation. Please contact dev@myriad.incubator.apache.org with any problems you encounter.",
+  "postInstallNotes" : "Your Myriad cluster is being deployed. Once it is healthy, you may want to flex up some more NodeManagers.",
   "postUninstallNotes" : "Your Myriad cluster has been uninstalled. Please run the framework_cleaner to remove any persistent state if required.",
+  "framework" : true,
   "selected" : false
 }

--- a/repo/packages/M/myriad/0/package.json
+++ b/repo/packages/M/myriad/0/package.json
@@ -1,8 +1,9 @@
 {
-  "packagingVersion" : "2.0",
+  "packagingVersion" : "3.0",
+  "minDcosReleaseVersion" : "1.7",
   "description" : "Apache Myriad (incubating) installs, manages, and scales Hadoop/YARN on Mesos",
   "name" : "myriad",
-  "version" : "0.2.0",
+  "version" : "0.2.0-0.0.1",
   "scm" : "https://github.com/apache/incubator-myriad",
   "website": "https://myriad.incubator.apache.org",
   "maintainer" : "dev@myriad.incubator.apache.org",
@@ -11,7 +12,7 @@
     "url" : "https://github.com/apache/incubator-myriad/blob/master/LICENSE"
   } ],
   "tags" : [ "hadoop", "yarn", "myriad" ],
-  "preInstallNotes" : "You are about to install Hadoop/YARN on DC/OS with the Apache Myriad service. This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, or incorrect documentation. Please contact dev@myriad.incubator.apache.org with any problems you encounter.",
+  "preInstallNotes" : "The DC/OS Service for Apache Myriad is currently EXPERIMENTAL. There may be bugs, incomplete features, or incorrect documentation. You are about to install Hadoop/YARN on DC/OS with the Apache Myriad service. Please contact dev@myriad.incubator.apache.org with any problems you encounter.",
   "postInstallNotes" : "Your Myriad cluster is being deployed. Once it is healthy, you may want to flex up some more NodeManagers.",
   "postUninstallNotes" : "Your Myriad cluster has been uninstalled. Please run the framework_cleaner to remove any persistent state if required.",
   "framework" : true,

--- a/repo/packages/M/myriad/0/resource.json
+++ b/repo/packages/M/myriad/0/resource.json
@@ -1,8 +1,8 @@
 {
   "images" : {
-    "icon-small" : "https://raw.githubusercontent.com/apache/incubator-myriad/master/website/img/myriad_elephant.png",
-    "icon-medium" : "https://raw.githubusercontent.com/apache/incubator-myriad/master/website/img/myriad_elephant.png",
-    "icon-large" : "https://raw.githubusercontent.com/apache/incubator-myriad/master/website/img/myriad_elephant.png"
+    "icon-small" : "https://s3-us-west-2.amazonaws.com/myriad-dev/universe/icon-myriad-small.png",
+    "icon-medium" : "https://s3-us-west-2.amazonaws.com/myriad-dev/universe/icon-myriad-medium.png",
+    "icon-large" : "https://s3-us-west-2.amazonaws.com/myriad-dev/universe/icon-myriad-large.png"
   },
   "assets": {
     "uris": {

--- a/repo/packages/M/myriad/0/resource.json
+++ b/repo/packages/M/myriad/0/resource.json
@@ -1,0 +1,9 @@
+{
+  "images" : {
+    "icon-small" : "https://raw.githubusercontent.com/apache/incubator-myriad/master/website/img/myriad_elephant.png",
+    "icon-medium" : "https://raw.githubusercontent.com/apache/incubator-myriad/master/website/img/myriad_elephant.png",
+    "icon-large" : "https://raw.githubusercontent.com/apache/incubator-myriad/master/website/img/myriad_elephant.png"
+  },
+  "assets" : {
+  }
+}

--- a/repo/packages/M/myriad/0/resource.json
+++ b/repo/packages/M/myriad/0/resource.json
@@ -4,6 +4,10 @@
     "icon-medium" : "https://raw.githubusercontent.com/apache/incubator-myriad/master/website/img/myriad_elephant.png",
     "icon-large" : "https://raw.githubusercontent.com/apache/incubator-myriad/master/website/img/myriad_elephant.png"
   },
-  "assets" : {
+  "assets": {
+    "uris": {
+      "apache-myriad-hadoop-tar-xz": "https://s3-us-west-2.amazonaws.com/myriad-dev/universe/hadoop-2.7.1-rm.tar.xz",
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-7u76-linux-x64.tar.gz"
+    }
   }
 }


### PR DESCRIPTION
It installs healthy for me! But I haven't figured out how to get to the webUI via Marathon-lb yet.
A few more things I want to see:
- [x] Use packagingVersion 3.0 (what's our minDcosReleaseVersion?)
- [x] move uris into resource.json
- [x] mustache variables for cpus, mem, 

Future (post v0) improvements:
- [ ] mustache variables for ports/vips, user, role, principal/secret
- [ ] Additional RM_OPTS, NM options (https, security?)
- [ ] split hadoop uri from myriad binary, support any distro, jre/hadoop paths not hardcoded
- [ ] CLI subcommands to flex up/down