### PR TITLE
tunnel-cli: Bump to version 0.3.2

### DIFF
--- a/repo/packages/T/tunnel-cli/3/package.json
+++ b/repo/packages/T/tunnel-cli/3/package.json
@@ -1,0 +1,9 @@
+{
+  "packagingVersion": "3.0",
+  "name": "tunnel-cli",
+  "version": "0.3.1",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.8",
+  "description": "Proxy and VPN access to your DC/OS cluster",
+  "tags": [ "mesosphere", "subcommand", "proxy", "vpn", "socks", "http", "cli" ]
+}

--- a/repo/packages/T/tunnel-cli/3/package.json
+++ b/repo/packages/T/tunnel-cli/3/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "tunnel-cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "maintainer": "support@mesosphere.io",
   "minDcosReleaseVersion": "1.8",
   "description": "Proxy and VPN access to your DC/OS cluster",

--- a/repo/packages/T/tunnel-cli/3/resource.json
+++ b/repo/packages/T/tunnel-cli/3/resource.json
@@ -1,0 +1,30 @@
+{
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "e435e6e372c4a156cfa0abba1d06013925625eae551b93c1e74af5c636a9eea9"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.3.1/dcos-tunnel.zip"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "1ee6683a5279b977672a21afe178b923d6dae1467bb4a54a7ebde90a7d4d1e7e"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.3.1/dcos-tunnel.zip"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/T/tunnel-cli/3/resource.json
+++ b/repo/packages/T/tunnel-cli/3/resource.json
@@ -6,11 +6,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "e435e6e372c4a156cfa0abba1d06013925625eae551b93c1e74af5c636a9eea9"
+                            "value": "cc53d2257f5d6c0b8b2a6386534c0f8ffcd989a8097226ef0177b1ba52108394"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.3.1/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.3.2/dcos-tunnel.zip"
                 }
             },
             "linux": {
@@ -18,11 +18,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "1ee6683a5279b977672a21afe178b923d6dae1467bb4a54a7ebde90a7d4d1e7e"
+                            "value": "58fe1fe132968189c58a461aacccee24980085c14b103d37b2da6f625f1b52f2"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.3.1/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.3.2/dcos-tunnel.zip"
                 }
             }
         }


### PR DESCRIPTION
This includes fixes in documentation and alternative docker clients