### PR TITLE
tunnel-cli: Bump to 0.3.3

### DIFF
--- a/repo/packages/T/tunnel-cli/4/package.json
+++ b/repo/packages/T/tunnel-cli/4/package.json
@@ -1,0 +1,9 @@
+{
+  "packagingVersion": "3.0",
+  "name": "tunnel-cli",
+  "version": "0.3.2",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.8",
+  "description": "Proxy and VPN access to your DC/OS cluster",
+  "tags": [ "mesosphere", "subcommand", "proxy", "vpn", "socks", "http", "cli" ]
+}

--- a/repo/packages/T/tunnel-cli/4/package.json
+++ b/repo/packages/T/tunnel-cli/4/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "tunnel-cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "maintainer": "support@mesosphere.io",
   "minDcosReleaseVersion": "1.8",
   "description": "Proxy and VPN access to your DC/OS cluster",

--- a/repo/packages/T/tunnel-cli/4/resource.json
+++ b/repo/packages/T/tunnel-cli/4/resource.json
@@ -1,0 +1,30 @@
+{
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "cc53d2257f5d6c0b8b2a6386534c0f8ffcd989a8097226ef0177b1ba52108394"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.3.2/dcos-tunnel.zip"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "58fe1fe132968189c58a461aacccee24980085c14b103d37b2da6f625f1b52f2"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.3.2/dcos-tunnel.zip"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/T/tunnel-cli/4/resource.json
+++ b/repo/packages/T/tunnel-cli/4/resource.json
@@ -6,11 +6,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "cc53d2257f5d6c0b8b2a6386534c0f8ffcd989a8097226ef0177b1ba52108394"
+                            "value": "59c29f80aec28d94fbb13bc6fda5b2508b7b8599b2516c6a25099f07ad6890d4"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.3.2/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.3.3/dcos-tunnel.zip"
                 }
             },
             "linux": {
@@ -18,11 +18,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "58fe1fe132968189c58a461aacccee24980085c14b103d37b2da6f625f1b52f2"
+                            "value": "35b0e2193cc650fcf5ff867e7ec8ee6586091e8c54e6581198721dd5179cd154"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.3.2/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.3.3/dcos-tunnel.zip"
                 }
             }
         }


### PR DESCRIPTION
https://github.com/dcos/dcos-tunnel

This adds a bit more retry logic when probing for a valid docker command to run on the cluster. This also tweaks the CLI behavior when no arguments are passed in (previously it would give an error message, now it prints usage details).