### PR TITLE
updating to linkerd 0.8.3, api auth support

### DIFF
--- a/repo/packages/L/linkerd/8/config.json
+++ b/repo/packages/L/linkerd/8/config.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "required": ["linkerd"],
+  "properties": {
+    "linkerd": {
+      "type": "object",
+      "required": ["admin-port", "cpus", "instances", "internal-port", "marathon-host", "marathon-port", "mem", "resource-roles", "routing-port"],
+      "properties": {
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "admin-port": {
+          "default": 9990,
+          "description": "Admin port. Provides an administrative UI for this instance.",
+          "type": "integer"
+        },
+        "internal-port": {
+          "default": 4141,
+          "description": "Internal routing port.",
+          "type": "integer"
+        },
+        "routing-port": {
+          "default": 4140,
+          "description": "Routing port.",
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 0.25,
+          "description": "CPU shares to allocate to each linkerd instance.",
+          "minimum": 0.25,
+          "type": "number"
+        },
+        "mem": {
+          "default": 256.0,
+          "description": "Memory (MB) to allocate to each linkerd task.",
+          "minimum": 256.0,
+          "type": "number"
+        },
+        "marathon-host": {
+          "default": "leader.mesos",
+          "description": "DC/OS leader hostname, for Marathon API access.",
+          "type": "string"
+        },
+        "marathon-port": {
+          "default": "8080",
+          "description": "DC/OS leader port, for Marathon API access.",
+          "type": "string"
+        },
+        "marathon-uri-prefix": {
+          "default": "",
+          "description": "Marathon API prefix. Typically left blank, or '/marathon'.",
+          "type": "string"
+        },
+        "secret_name": {
+          "default": "",
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed. For more information see https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/",
+          "type": "string"
+        },
+        "resource-roles": {
+          "default": "\"*\", \"slave_public\"",
+          "description": "The accepted resource roles (e.g. slave_public). By default, this will deploy to any agents with the \"*\" or \"slave_public\" roles.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/L/linkerd/8/config.json
+++ b/repo/packages/L/linkerd/8/config.json
@@ -46,9 +46,9 @@
           "type": "string"
         },
         "marathon-port": {
-          "default": "8080",
+          "default": 8080,
           "description": "DC/OS leader port, for Marathon API access.",
-          "type": "string"
+          "type": "integer"
         },
         "marathon-uri-prefix": {
           "default": "",
@@ -57,7 +57,7 @@
         },
         "secret_name": {
           "default": "",
-          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed. For more information see https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/",
+          "description": "Enterprise Only. Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed. For more information see https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/",
           "type": "string"
         },
         "resource-roles": {

--- a/repo/packages/L/linkerd/8/marathon.json.mustache
+++ b/repo/packages/L/linkerd/8/marathon.json.mustache
@@ -1,0 +1,57 @@
+{
+  "id": "linkerd",
+  "instances": {{linkerd.instances}},
+  "cpus": {{linkerd.cpus}},
+  "mem": {{linkerd.mem}},
+  "acceptedResourceRoles": [{{{linkerd.resource-roles}}}],
+  "constraints": [["hostname", "UNIQUE"]],
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.linkerd-docker}}",
+      "network": "HOST",
+      "privileged": true
+    }
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/admin/ping"
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": {{linkerd.admin-port}},
+      "protocol": "tcp",
+      "name": "admin"
+    },
+    {
+      "port": {{linkerd.routing-port}},
+      "protocol": "tcp",
+      "name": "outgoing"
+    },
+    {
+      "port": {{linkerd.internal-port}},
+      "protocol": "tcp",
+      "name": "incoming"
+    }
+  ],
+  "requirePorts": true,
+  "labels": {
+    "DCOS_SERVICE_NAME": "linkerd",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  },
+  {{#linkerd.secret_name}}
+  "env": {
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" }
+  },
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{linkerd.secret_name}}"
+    }
+  },
+  {{/linkerd.secret_name}}
+  "cmd": "echo \"{\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"{{linkerd.marathon-host}}\\\",\\\"port\\\":{{linkerd.marathon-port}},\\\"prefix\\\":\\\"/io.l5d.marathon\\\",\\\"uriPrefix\\\":\\\"{{linkerd.marathon-uri-prefix}}\\\",\\\"experimental\\\":true}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":{{linkerd.routing-port}},\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"baseDtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/http/1.1/*=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"outgoing\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"default\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.port\\\",\\\"port\\\":{{linkerd.internal-port}}}]}},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":{{linkerd.internal-port}},\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"incoming\\\",\\\"dstPrefix\\\":\\\"/\\\",\\\"identifier\\\":{\\\"kind\\\":\\\"io.l5d.header\\\",\\\"header\\\":\\\"l5d-dst-concrete\\\"},\\\"interpreter\\\":{\\\"kind\\\":\\\"default\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.localhost\\\"}]}}],\\\"admin\\\":{\\\"port\\\":{{linkerd.admin-port}}}}\"|/io.buoyant/linkerd/0.8.3/bundle-exec -- -"
+}

--- a/repo/packages/L/linkerd/8/package.json
+++ b/repo/packages/L/linkerd/8/package.json
@@ -7,7 +7,7 @@
   "maintainer": "hello@buoyant.io",
   "website": "https://linkerd.io",
   "tags": ["linkerd", "namerd", "buoyant", "loadbalancer", "service-discovery", "proxy", "microservices", "rpc"],
-  "preInstallNotes": "We recommend a minimum of 0.25 CPUs and 256 MB of RAM available for linkerd. We also recommend running linkerd on every host. To ensure this, set instances to the number of nodes in your cluster.",
+  "preInstallNotes": "We recommend a minimum of 0.25 CPUs and 256 MB of RAM available for linkerd. We also recommend running linkerd on every host. To ensure this, set instances to the number of nodes in your cluster. Installation Documentation: https://github.com/dcos/examples/tree/master/1.8/linkerd",
   "postInstallNotes": "linkerd DC/OS Service has been successfully installed!\nSee https://linkerd.io for documentation.",
   "postUninstallNotes": "linkerd DC/OS Service has been uninstalled and will no longer run.",
   "licenses": [

--- a/repo/packages/L/linkerd/8/package.json
+++ b/repo/packages/L/linkerd/8/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "linkerd",
+  "version": "0.8.3-0.1",
+  "scm": "https://github.com/BuoyantIO/linkerd/",
+  "description": "A dynamic linker for microservices. Install, set your http proxy to $HOST:4140, and connect to your services via app name. linkerd will handle Marathon service discovery for you.",
+  "maintainer": "hello@buoyant.io",
+  "website": "https://linkerd.io",
+  "tags": ["linkerd", "namerd", "buoyant", "loadbalancer", "service-discovery", "proxy", "microservices", "rpc"],
+  "preInstallNotes": "We recommend a minimum of 0.25 CPUs and 256 MB of RAM available for linkerd. We also recommend running linkerd on every host. To ensure this, set instances to the number of nodes in your cluster.",
+  "postInstallNotes": "linkerd DC/OS Service has been successfully installed!\nSee https://linkerd.io for documentation.",
+  "postUninstallNotes": "linkerd DC/OS Service has been uninstalled and will no longer run.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/BuoyantIO/linkerd/blob/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/L/linkerd/8/resource.json
+++ b/repo/packages/L/linkerd/8/resource.json
@@ -1,0 +1,17 @@
+{
+  "images": {
+    "icon-small": "https://linkerd.io/images/dcos/linkerd-logo-small.png",
+    "icon-medium": "https://linkerd.io/images/dcos/linkerd-logo-medium.png",
+    "icon-large": "https://linkerd.io/images/dcos/linkerd-logo-large.png",
+    "screenshots": [
+      "https://linkerd.io/images/dcos/linkerd-screenshot.png"
+    ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "linkerd-docker": "buoyantio/linkerd:0.8.3"
+      }
+    }
+  }
+}


### PR DESCRIPTION
changes:
- added marathon api auth support, for DC/OS Enterprise
- added marathon host, port, and uri prefix options
- updated linkerd from 0.8.1 to 0.8.3