### PR TITLE
Scale package update for 4.1.0 release.

### DIFF
--- a/repo/packages/S/scale/1/config.json
+++ b/repo/packages/S/scale/1/config.json
@@ -1,0 +1,97 @@
+{
+  "properties": {
+    "scale": {
+      "properties": {
+        "name": {
+          "description": "Name of this service instance. MUST BE LOWERCASE! Will also be used as a prefix in all supporting services.",
+          "default": "scale",
+          "type": "string"
+        },
+        "virtual-host": {
+          "description": "Virtual Hostname for Marathon-LB webserver exposure outside cluster.",
+          "default": "scale.marathon.slave.mesos",
+          "type": "string"
+        },
+        "docker-credentials": {
+          "description": "URI to .dockercfg file with Docker credentials for retrieving private images.",
+          "type": "string"
+        }
+      },
+      "required": ["name"],
+      "type": "object"
+    },
+    "logging":{
+      "properties":{
+        "logstash-address": {
+          "description": "Address for logstash service. When left empty logstash will deployed into the cluster.",
+          "type": "string"
+        },
+        "elasticsearch-urls": {
+          "description": "ElasticSearch URL's for Scale. Note: Not needed if you use DCOS ElasticSearch package.",
+          "type": "string"
+        }
+      }
+    },
+    "webserver":{
+      "properties":{
+        "cpu": {
+          "description": "Allocation of CPU resources for Scale web server.",
+          "default": 1,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "memory": {
+          "description": "Allocation of Memory (MiB) resources for Scale web server.",
+          "default": 2048,
+          "minimum": 512,
+          "type": "integer"
+        }
+      }
+    },
+    "dcos":{
+      "properties":{
+        "dcos-user": {
+          "description": "DCOS User for automation of supporting containers. This is only needed if DCOS Enterprise is installed.",
+          "type": "string"
+        },
+        "dcos-pass": {
+          "description": "DCOS Password for automation of supporting containers. This is only needed if DCOS Enterprise is installed.",
+          "type": "string"
+        },
+        "dcos-oauth-token": {
+          "description": "DCOS OAuth token for automation of supporting containers. This is only needed if OAuth is enabled.",
+          "type": "string"
+        }
+      }
+    },
+    "db": {
+      "properties":{
+        "db-host": {
+          "description": "Hostname to the database server. When left empty a sample database will be deployed. THIS DEFAULT SHOULD NEVER BE USED FOR PRODUCTION!",
+          "type": "string"
+        },
+        "db-name": {
+          "description": "DB Name. This database must have the postgis extension already installed.",
+          "default": "scale",
+          "type": "string"
+        },
+        "db-port": {
+          "description": "DB Port",
+          "default": 5432,
+          "type": "integer"
+        },
+        "db-user": {
+          "description": "DB User",
+          "default": "scale",
+          "type": "string"
+        },
+        "db-pass": {
+          "description": "DB Pass",
+          "default": "scale",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/S/scale/1/marathon.json.mustache
+++ b/repo/packages/S/scale/1/marathon.json.mustache
@@ -1,0 +1,57 @@
+{
+    "id": "/{{scale.name}}",
+    "cpus": 1.0,
+    "mem": 1024.0,
+    "instances": 1,
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.scale}}",
+            "network": "HOST",
+            "forcePullImage": true
+        }
+    },
+    "constraints": [["hostname", "UNIQUE"]],
+    "healthChecks": [{
+        "protocol": "COMMAND",
+        "command": { "value": "if [[ `ps -ef | grep \"scale_scheduler\" | grep -v grep | wc -l` -gt 1 ]]; then exit 0; else exit 1; fi" },
+        "gracePeriodSeconds": 300,
+        "intervalSeconds": 30,
+        "timeoutSeconds": 20,
+        "maxConsecutiveFailures": 3
+    }],
+    "labels":{
+      "DCOS_PACKAGE_FRAMEWORK_NAME": "{{scale.name}}"
+    },
+    "env": {
+      {{#scale.docker-credentials}}
+      "CONFIG_URI": "{{scale.docker-credentials}}",
+      {{/scale.docker-credentials}}
+      "DB_DOCKER_IMAGE": "{{resource.assets.container.docker.db}}",
+      "DCOS_OAUTH_TOKEN": "{{dcos.dcos-oauth-token}}",
+      "DCOS_PACKAGE_FRAMEWORK_NAME": "{{scale.name}}",
+      "DCOS_PASS": "{{dcos.dcos-pass}}",
+      "DCOS_USER": "{{dcos.dcos-user}}",
+      "DEPLOY_WEBSERVER": "true",
+      "ENABLE_BOOTSTRAP": "true",
+      "LOGSTASH_DOCKER_IMAGE": "{{resource.assets.container.docker.logstash}}",
+      "SCALE_DB_HOST": "{{db.db-host}}",
+      "SCALE_DB_NAME": "{{db.db-name}}",
+      "SCALE_DB_PASS": "{{db.db-pass}}",
+      "SCALE_DB_PORT": "{{db.db-port}}",
+      "SCALE_DB_USER": "{{db.db-user}}",
+      "SCALE_ELASTICSEARCH_URLS": "{{logging.elasticsearch-urls}}",
+      "SCALE_LOGGING_ADDRESS": "{{logging.logstash-address}}",
+      "SCALE_VHOST": "{{scale.virtual-host}}",
+      "SCALE_WEBSERVER_CPU": "{{webserver.cpu}}",
+      "SCALE_WEBSERVER_MEMORY": "{{webserver.memory}}"
+    },
+    "args": [
+    "scale_scheduler"
+    ]
+    {{#scale.docker-credentials}},
+    "uris": [
+      "{{scale.docker-credentials}}"
+    ]
+    {{/scale.docker-credentials}}
+}

--- a/repo/packages/S/scale/1/package.json
+++ b/repo/packages/S/scale/1/package.json
@@ -1,0 +1,29 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.7",
+  "scm": "https://github.com/ngageoint/scale.git",
+  "maintainer": "scale@nga.mil",
+  "website": "https://ngageoint.github.io/scale",
+  "name": "scale",
+  "tags": [
+    "bigdata",
+    "batch",
+    "analytics",
+    "remotesensing",
+    "algorithms",
+    "geospatial"
+  ],
+  "framework": true,
+  "version": "4.1.0-0.0.2",
+  "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nWe recommend a minimum of three nodes with at least 4 CPU and 6GB of RAM available for the Scale services and running Scale jobs.\n\nBy default, Elasticsearch package *must* be running within your DCOS cluster. If you wish to use an externally hosted Elasticsearch cluster, specify one or more of the nodes in comma delimited format in the SCALE_ELASTICSEARCH_URLS variable. For quick-start purposes, Scale is bootstrapped with a Postgres database. This should *NEVER* be used for production purposes as it offers no underlying storage persistence. It can be replaced with an externally hosted Postgres by setting DB_HOST and associated settings appropriately.\n\nIf you are running DCOS 1.8 Enterprise Edition or higher, you will need to set the DCOS_OAUTH_TOKEN in the DCOS section of the Advanced Settings. This value can be found within the dcos.toml file under in the dcos_acs_token value on a system with an authenticated DCOS CLI.\n\nTutorial documentation for Scale can be found here: https://github.com/dcos/examples/tree/master/1.8/scale",
+  "postInstallNotes": "The Scale DCOS Service has been successfully installed!\n\n\tNew User Tutorial: https://github.com/dcos/examples/tree/master/1.8/scale\n\n\tDocumentation: https://ngageoint.github.io/scale/\n\tIssues: https://github.com/ngageoint/scale/issues",
+  "postUninstallNotes": "The Scale Scheduler has been uninstalled and will no longer run. You may need to remove supporting services - scale-logstash, scale-webserver and scale-db.",
+  "licenses": [
+    {
+      "url": "https://github.com/ngageoint/scale/blob/master/LICENSE",
+      "name": "Apache License Version 2.0"
+    }
+  ],
+  "description": "Scale enables on-demand, near real-time, automated processing of large datasets (satellite, medical, audio, video, ...) using a dynamic bank of algorithms. Algorithm execution is seamlessly distributed across thousands of CPU cores. Docker provides algorithm containerization. Apache Mesos enables optimum resource utilization.\n\nRelease Notes: https://github.com/ngageoint/scale/releases/tag/4.1.0\n\nNew User Tutorial: https://github.com/dcos/examples/tree/master/1.8/scale",
+  "selected": false
+}

--- a/repo/packages/S/scale/1/resource.json
+++ b/repo/packages/S/scale/1/resource.json
@@ -1,0 +1,16 @@
+{
+  "images": {
+    "icon-small": "https://raw.githubusercontent.com/ngageoint/scale/gh-pages/demo/images/icon-service-scale-small.png",
+    "icon-medium": "https://raw.githubusercontent.com/ngageoint/scale/gh-pages/demo/images/icon-service-scale-medium.png",
+    "icon-large": "https://raw.githubusercontent.com/ngageoint/scale/gh-pages/demo/images/icon-service-scale-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+         "scale": "geoint/scale:4.1.0",
+         "db": "mdillon/postgis:9.5",
+         "logstash": "geoint/logstash-elastic-ha:4.1.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Scale 4.1.0 has been released and this pull request merely updates the package to reference the newer images.

Specific improvements / fixes for DC/OS packaging include:
- Scale webserver logs are now captured ([Issue 584](https://github.com/ngageoint/scale/issues/584))
- Fixed DC/OS health check for the Scale webserver ([Issue 568](https://github.com/ngageoint/scale/issues/568))
- Fixed REST API to work within the context of the DC/OS /service URL ([Issue 569](https://github.com/ngageoint/scale/issues/569))
- Fixed deployment bug where sometimes the Scale webserver or logstash apps would not destroy/re-create correctly ([Issue 594](https://github.com/ngageoint/scale/issues/594))

Full release notes can be found here:
https://github.com/ngageoint/scale/releases/tag/4.1.0