### PR TITLE
Add calico-dcos v3

### DIFF
--- a/repo/packages/C/calico/3/config.json
+++ b/repo/packages/C/calico/3/config.json
@@ -1,0 +1,216 @@
+{
+  "properties": {
+    "Framework Settings": {
+      "description": "Configuration options for Calico's DC/OS Framework.",
+      "properties": {
+        "framework-name": {
+          "type": "string",
+          "description": "The name of the framework.",
+          "default": "calico-install-framework"
+        },
+        "master": {
+          "default": "zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos",
+          "description": "The URL of the Mesos master. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard host:port patterns, like localhost:5050 or 10.0.0.5:5050,10.0.0.6:5050, are also acceptable.",
+          "type": "string"
+        },
+        "max-concurrent-restarts": {
+          "type": "integer",
+          "description": "The maximum number of Agent or Docker restarts that are allowed to be scheduled concurrently by the Calico framework.",
+          "default": 1
+        },
+        "zk": {
+          "default": "zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/calico",
+          "description": "The URL of Zookeeper to be used to persist Calico framework data. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/calico, including the trailing path.",
+          "type": "string"
+        },
+        "cpu-limit": {
+          "default": 0.2,
+          "description": "The CPU shares for the Calico framework.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem-limit": {
+          "default": 512,
+          "description": "Memory limit (MB) for the Calico framework.",
+          "minimum": 32,
+          "type": "integer"
+        },
+        "status-dns": {
+          "default": "calico.marathon.mesos",
+          "description": "The DNS name used to resolve the Calico status web page.",
+          "type": "string"
+        },
+        "override-framework-image": {
+          "type": "string",
+          "description": "Override the docker image for the calico-dcos framework."
+        },
+        "override-installer-url": {
+          "type": "string",
+          "description": "Override the URL for the installer binary."
+        }
+      },
+      "required": [
+        "framework-name",
+        "master",
+        "max-concurrent-restarts",
+        "zk",
+        "cpu-limit",
+        "mem-limit",
+        "status-dns"
+      ],
+      "type": "object"
+    },
+    "Etcd Settings": {
+      "description": "Configure etcd settings used by calico/node and calico-CNI. Below presents the option of whether to run etcd on each agent in proxy mode, forwarding requests made to localhost:2379 to the etcd clutser avaiable via the etcd-discovery-url presented by the Universe etcd package. Users who prefer to run etcd themselves on an agent can disable etcd proxy, and modify etcd-endpoints to point at their own etcd server directly.\n\nWARNING: The docker cluster-store configuration by default will use etcd-proxy. Ensure if you have disabled etcd-proxy, that you configure docker to use a different datastore as well.",
+      "type": "object",
+      "properties": {
+        "run-proxy": {
+          "type": "boolean",
+          "description": "Enable running etcd-proxy on each agent. Keep enabled if using Universe etcd package.",
+          "default": true
+        },
+        "etcd-discovery-url": {
+          "default": "etcd.mesos",
+          "description": "The etcd service discovery URL which via an SRV lookup resolves to the Universe etcd package. Used by etcd-proxy to forward etcd requests made on localhost:2379 to the universe etcd package.",
+          "type": "string"
+        },
+        "etcd-endpoints": {
+          "description": "The address used by Calico to connect to etcd. If etcd-proxy is enabled, keep as 'http://localhost:2379'. Otherwise, enter url of etcd server.",
+          "type": "string",
+          "default": "http://localhost:2379"
+        },
+        "cpu-limit": {
+          "default": 0.1,
+          "description": "The CPU shares for each etcd proxy instance.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem-limit": {
+          "default": 128,
+          "description": "Memory limit (MB) for each etcd proxy instance.",
+          "minimum": 32,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "run-proxy",
+        "etcd-discovery-url",
+        "etcd-endpoints",
+        "cpu-limit",
+        "mem-limit"
+      ]
+    },
+    "Configure Docker Cluster-Store": {
+      "description": "Reconfigure Docker with a cluster-store. Only required if using Calico's Docker plugin.",
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "description": "Whether the Calico framework is allowed to reconfigure and restart Docker on the Mesos Agent to install Docker with multi-host networking.  Note that during restart, the agent will not be available, and tasks running on the agent will be lost.",
+          "default": true
+        },
+        "override-docker-cluster-store": {
+          "description": "URL of the distributed storage backend for Docker. When ommitted, this will be constructed from etcd-endpoints.",
+          "type": "string"
+        },
+        "cpu-limit": {
+          "description": "The CPU shares for each Calico node instance.",
+          "type": "number",
+          "default": 0.2,
+          "minimum": 0.01
+        },
+        "mem-limit": {
+          "description": "Memory limit (MB) for each Calico node instance.",
+          "type": "integer",
+          "default": 256,
+          "minimum": 32
+        }
+      },
+      "required": [
+        "enable",
+        "cpu-limit",
+        "mem-limit"
+      ]
+    },
+    "Install CNI": {
+      "description": "Installs Calico's CNI plugin and a default CNI network configuration on all agents, then restarts each agent (to pickup the new configuration).",
+      "type": "object",
+      "properties": {
+        "enable": {
+          "type": "boolean",
+          "description": "Enable installation of CNI plugin and network.",
+          "default": true
+        },
+        "cni-plugins-dir": {
+          "default": "/opt/mesosphere/active/cni/",
+          "description": "Location of CNI plugins on the Agent.",
+          "type": "string"
+        },
+        "cni-config-dir": {
+          "default": "/opt/mesosphere/etc/dcos/network/cni/",
+          "description": "Location of CNI configs.",
+          "type": "string"
+        },
+        "cpu-limit": {
+          "default": 0.2,
+          "description": "The CPU shares for each install task instance.",
+          "minimum": 0.01,
+          "type": "number"
+        },
+        "mem-limit": {
+          "default": 512,
+          "description": "Memory limit (MB) for each install task instance.",
+          "minimum": 32,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "enable",
+        "cni-plugins-dir",
+        "cni-config-dir",
+        "cpu-limit",
+        "mem-limit"
+      ]
+    },
+    "Run Calico-Node": {
+      "description": "Run the calico/node docker container on all agents. Required if using either Calico's CNI or Docker plugin.",
+      "type": "object",
+      "properties": {
+        "enable": {
+          "description": "Enable running calico/node on each agent.",
+          "type": "boolean",
+          "default": true
+        },
+        "cpu-limit": {
+          "description": "The CPU shares for each Calico node instance.",
+          "type": "number",
+          "default": 0.2,
+          "minimum": 0.01
+        },
+        "mem-limit": {
+          "description": "Memory limit (MB) for each Calico node instance.",
+          "type": "integer",
+          "default": 256,
+          "minimum": 32
+        },
+        "override-node-image": {
+          "description": "Override the node image specified in resources.json",
+          "type": "string"
+        }
+      },
+      "required": [
+        "enable",
+        "cpu-limit",
+        "mem-limit"
+      ]
+    }
+  },
+  "required": [
+    "Framework Settings",
+    "Etcd Settings",
+    "Configure Docker Cluster-Store",
+    "Install CNI",
+    "Run Calico-Node"
+  ],
+  "type": "object"
+}

--- a/repo/packages/C/calico/3/marathon.json.mustache
+++ b/repo/packages/C/calico/3/marathon.json.mustache
@@ -1,0 +1,90 @@
+{
+  "id": "{{Framework Settings.framework-name}}",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "network": "HOST",
+      "forcePullImage": true,
+      "image":
+        {{! If Framework Settings.override-framework-image is set, use it as the framework image. }}
+        {{#Framework Settings.override-framework-image}}
+          "{{Framework Settings.override-framework-image}}"
+        {{/Framework Settings.override-framework-image}}
+
+        {{! If its not set, default to the one in resources.json }}
+        {{^Framework Settings.override-framework-image}}
+          "{{resource.assets.container.docker.calico-dcos}}"
+        {{/Framework Settings.override-framework-image}}
+    }
+  },
+  "args": [],
+  "cpus": {{Framework Settings.cpu-limit}},
+  "mem": {{Framework Settings.mem-limit}},
+  "instances": 1,
+  "env": {
+    "CALICO_INSTALLER_URL":
+      {{! If Framework Settings.override-installer-url is set, use it as the installer url. }}
+      {{#Framework Settings.override-installer-url}}
+        "{{Framework Settings.override-installer-url}}",
+      {{/Framework Settings.override-installer-url}}
+      {{! Otherwise, default to the one in resources.json }}
+      {{^Framework Settings.override-installer-url}}
+        "{{resource.assets.uris.calico-installer}}",
+      {{/Framework Settings.override-installer-url}}
+
+    "MESOS_MASTER": "{{Framework Settings.master}}",
+    "CALICO_MAX_CONCURRENT_RESTARTS": "{{Framework Settings.max-concurrent-restarts}}",
+    "CALICO_ZK": "{{Framework Settings.zk}}",
+    "CALICO_STATUS_DNS": "{{Framework Settings.status-dns}}",
+
+    "CALICO_ALLOW_DOCKER_UPDATE": "{{Configure Docker Cluster-Store.enable}}",
+    "CALICO_CPU_LIMIT_INSTALL_DOCKER": "{{Configure Docker Cluster-Store.cpu-limit}}",
+    "CALICO_MEM_LIMIT_INSTALL_DOCKER": "{{Configure Docker Cluster-Store.mem-limit}}",
+    "DOCKER_CLUSTER_STORE": "{{Configure Docker Cluster-Store.override-docker-cluster-store}}",
+
+    "CALICO_ENABLE_RUN_ETCD_PROXY": "{{Etcd Settings.run-proxy}}",
+    "ETCD_SRV": "{{Etcd Settings.etcd-discovery-url}}",
+    "CALICO_CPU_LIMIT_ETCD_PROXY": "{{Etcd Settings.cpu-limit}}",
+    "CALICO_MEM_LIMIT_ETCD_PROXY": "{{Etcd Settings.mem-limit}}",
+    "ETCD_BINARY_URL": "{{resource.assets.uris.etcd}}",
+
+
+    "CALICO_ENABLE_INSTALL_CNI": "{{Install CNI.enable}}",
+    "MESOS_CNI_PLUGINS_DIR": "{{Install CNI.cni-plugins-dir}}",
+    "MESOS_CNI_CONFIG_DIR": "{{Install CNI.cni-config-dir}}",
+    "CALICO_CPU_LIMIT_INSTALL_CNI": "{{Install CNI.cpu-limit}}",
+    "CALICO_MEM_LIMIT_INSTALL_CNI": "{{Install CNI.mem-limit}}",
+    "CALICO_CNI_BINARY_URL": "{{resource.assets.uris.calico-cni}}",
+    "CALICO_CNI_IPAM_BINARY_URL": "{{resource.assets.uris.calico-ipam}}",
+
+
+    "CALICO_ENABLE_RUN_NODE": "{{Run Calico-Node.enable}}",
+    "ETCD_ENDPOINTS": "{{Etcd Settings.etcd-endpoints}}",
+    "CALICO_CPU_LIMIT_NODE": "{{Run Calico-Node.cpu-limit}}",
+    "CALICO_MEM_LIMIT_NODE": "{{Run Calico-Node.mem-limit}}",
+    "CALICO_NODE_IMG":
+    {{! If resource-overrides.node-image is set, use it as the node-image. }}
+    {{#Run Calico-Node.override-node-image}}
+      "{{Run Calico-Node.override-node-image}}"
+    {{/Run Calico-Node.override-node-image}}
+    {{! Otherwise, default to the node-image in resources.json }}
+    {{^Run Calico-Node.override-node-image}}
+      "{{resource.assets.container.docker.calico-node}}"
+    {{/Run Calico-Node.override-node-image}}
+  },
+  "labels": {
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{Framework Settings.framework-name}}"
+  },
+  "requirePorts":true,
+  "ports": [
+    0
+  ],
+  "healthChecks": [{
+    "protocol": "HTTP",
+    "path": "/health",
+    "portIndex": 0,
+    "gracePeriodSeconds": 60,
+    "intervalSeconds": 30,
+    "maxConsecutiveFailures": 0
+  }]
+}

--- a/repo/packages/C/calico/3/package.json
+++ b/repo/packages/C/calico/3/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "calico",
+  "version": "0.4.0",
+  "tags": ["calico", "networking", "ip-per-container", "ip-per-task", "policy"],
+  "description": "Calico networking for DC/OS.  Calico provides IP-per-task functionality with rich policy.  This Universe Package simplifies the installation of Calico and its dependencies on a stock DC/OS cluster. It is configurable such that it assumes Calico's dependencies are installed, and merely serves to ensure calico's core processes are running. By default, it configures Docker with multi-host networking (required to use Calico with the Docker Containerizer), and reboots each Agent to pick up Calico's CNI configuration (required for Calico with Unified tasks). Both of these steps will cause temporary restarts of an Agent causing transient task loss. A more stable approach to Calico in DC/OS will have users performing these steps manually, and disabling them in the Universe Package. At the moment, only a limited set of DC/OS versions and OSes are supported - check the documentation for details.  The framework will still run on unsupported versions, in which case the Agent network hooks will not be installed and Calico networking will only be available with the Docker containerizer.",
+  "scm": "https://github.com/projectcalico/calico-containers.git",
+  "website": "https://projectcalico.org",
+  "preInstallNotes": "Before installing Calico, ensure the DC/OS etcd package is installed (if not using own etcd server). Note: this scheduler may makes permament changes to all Agents and Docker Daemons in the cluster. Calico's DC/OS installation framework is currently in beta.",
+  "postInstallNotes": "Calico services are now running on your cluster. Follow the Calico DC/OS guide available at https://github.com/projectcalico/calico-containers/blob/master/docs/mesos/dcos.md",
+  "maintainer": "rob@projectcalico.org",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/projectcalico/calico-containers/master/LICENSE"
+    }
+  ],
+  "framework": true
+}

--- a/repo/packages/C/calico/3/resource.json
+++ b/repo/packages/C/calico/3/resource.json
@@ -1,0 +1,21 @@
+{
+  "images": {
+    "icon-small": "https://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-48-48.png",
+    "icon-medium": "https://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-96-96.png",
+    "icon-large": "https://www.projectcalico.org/wp-content/uploads/2016/04/Calico-logo-felix-only-transparent-256-256.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "calico-dcos": "calico/calico-dcos:v0.4.0",
+        "calico-node": "calico/node:v1.0.0"
+      }
+    },
+    "uris": {
+      "etcd": "https://github.com/coreos/etcd/releases/download/v2.3.1/etcd-v2.3.1-linux-amd64.tar.gz",
+      "calico-cni": "https://github.com/projectcalico/calico-cni/releases/download/v1.5.5/calico",
+      "calico-ipam": "https://github.com/projectcalico/calico-cni/releases/download/v1.5.5/calico-ipam",
+      "calico-installer": "https://github.com/projectcalico/calico-dcos/releases/download/v0.4.0/installer"
+    }
+  }
+}


### PR DESCRIPTION
Calico v3 introduces Calico v2.0 to DC/OS, running our latest platform release of calico services.