### PR TITLE
Initial Portworx DC/OS Catalog

### DIFF
--- a/repo/packages/P/portworx/0/config.json
+++ b/repo/packages/P/portworx/0/config.json
@@ -1,0 +1,90 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service":{
+            "type":"object",
+            "description": "DC/OS service configuration properties",
+            "properties":{
+                "name" : {
+                    "description":"Name of this service instance.",
+                    "type":"string",
+                    "default": "portworx"
+                }
+            }
+        },
+        "portworx":{
+	    "additionalProperties": false,
+            "description":  "PX configuration properties",
+            "properties": {
+               "framework-name": {
+               "description": "The name of the framework. Until this is configurable, please do not change this from it's default value.",
+               "type": "string",
+               "default": "portworx"
+               },
+               "cpus": {
+		      "default": 1.0,
+		      "description": "CPU shares to allocate to each Marathon instance.",
+		      "minimum": 0.0,
+		      "type": "number"
+	        },
+	       "mem": {
+			   "default": 2048.0,
+			   "description": "Memory (MB) to allocate to each Marathon task.",
+			   "minimum": 2048.0,
+			   "type": "number"
+		},
+		"instances": {
+			"default": 3,
+			"description": "Number of PX instances to run.",
+			"minimum": 3,
+			"type": "integer"
+			},
+                "kvdb": {
+                    "description": "Key Value database to use for PX to store configuration parameters.",
+                    "type": "string",
+                    "default": "etcd://etcd.mycompany.com:4001"
+                },
+                "clusterid": {
+                    "description":  "PX Cluster ID",
+                    "type": "string",
+                    "default": "my-cluster"
+                },
+                "storage": {
+                    "description":  "Local storage devices to use.  Specify devices using the -s option.  Multiple devices can be specified using multiple -s options.  To use all available devices, just use -a",
+                    "type": "string",
+                    "default": "/dev/sdb"
+                },
+                "mgmtif": {
+                    "description":  "Network interface to use for Mgmt traffic.  Specify using the -m option.",  
+                    "type": "string",
+                    "default": "enp0s3"
+                },
+                "dataif": {
+                    "description":  "Network interface to use for Data traffic.  Specify using the -d option.",  
+                    "type": "string",
+                    "default": "enp0s3"
+                },
+                "headers_dir": {
+                    "description":  "Directory location for system headers",
+                    "type": "string",
+                    "default": "/usr/src"
+                },
+                "api_port": {
+                    "description":  "API access port",
+                    "type": "integer",
+                    "default": 9001
+                }
+            },
+            "required": [
+                "kvdb",
+                "clusterid",
+		"storage",
+                "mgmtif",
+                "dataif",
+                "headers_dir",
+                "api_port",
+                "instances"
+            ]
+        }
+    }
+}

--- a/repo/packages/P/portworx/0/marathon.json.mustache
+++ b/repo/packages/P/portworx/0/marathon.json.mustache
@@ -1,0 +1,71 @@
+{
+  "id": "{{portworx.framework-name}}",
+  "cpus": {{portworx.cpus}},
+  "mem": {{portworx.mem}},
+  "instances": {{portworx.instances}},
+  "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.portworx-docker}}",
+            "forcePullImage": true,
+            "network": "HOST",
+            "privileged": true,
+            "parameters": [
+			{
+			    "key": "volume",
+			    "value": "/run/docker/plugins:/run/docker/plugins"
+			},
+			{
+			    "key": "volume",
+			    "value": "/etc/pwx:/etc/pwx"
+			},
+			{
+			    "key": "volume",
+			    "value": "/var/lib/osd:/var/lib/osd:shared"
+			},
+			{
+			    "key": "volume",
+			    "value": "/dev:/dev"
+			},
+			{
+			    "key": "volume",
+			    "value": "/opt/pwx/bin:/export_bin:shared"
+			},
+			{
+			    "key": "volume",
+			    "value": "/var/run/docker.sock:/var/run/docker.sock"
+			},
+			{
+			    "key": "volume",
+			    "value": "/var/cores:/var/cores"
+			},
+			{
+			    "key": "volume",
+			    "value": "{{portworx.headers_dir}}:{{portworx.headers_dir}}"
+			}
+	      ]
+	}
+    },
+    "args": [
+        "--name pxcluster.mesos",
+        "--ipc host",
+        "-k {{portworx.kvdb}}",
+        "-c {{portworx.clusterid}}",
+        "-s {{portworx.storage}}",
+        "-m {{portworx.mgmtif}}",
+        "-d {{portworx.dataif}}"
+
+    ],
+    "healthChecks": [
+    {
+     "protocol": "COMMAND",
+     "command": { "value": "curl -X GET http://$HOST:{{portworx.api_port}}/status"},
+        "portIndex": 0,
+        "gracePeriodSeconds": 300,
+        "intervalSeconds": 60,
+        "timeoutSeconds": 20,
+        "maxConsecutiveFailures": 3,
+        "ignoreHttp1xx": false
+    }
+    ]
+}

--- a/repo/packages/P/portworx/0/package.json
+++ b/repo/packages/P/portworx/0/package.json
@@ -1,0 +1,29 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.7",
+  "name": "portworx",
+  "version": "1.1",
+  "scm": "https://github.com/portworx/px-dev",
+  "maintainer": "support@portworx.com",
+  "website": "http://www.portworx.com/",
+  "description": "Portworx PX provides scheduler integrated data services for containers.",
+  "framework": true,
+  "tags": [
+    "portworx",
+    "storage",
+    "data",
+    "cloud",
+    "volume",
+    "s3",
+    "database"
+  ],
+  "preInstallNotes": "Please visit http://docs.portworx.com/run-with-mesosphere.html for detailed instructions",
+ "postInstallNotes": "",
+ "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "Apache 2.0 License",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ]
+}

--- a/repo/packages/P/portworx/0/package.json
+++ b/repo/packages/P/portworx/0/package.json
@@ -1,8 +1,8 @@
 {
-  "packagingVersion": "1.0",
+  "packagingVersion": "3.0",
   "minDcosReleaseVersion": "1.8",
   "name": "portworx",
-  "version": "1.2.0-1.0",
+  "version": "1.1.2-3.0",
   "scm": "https://github.com/portworx/px-dev",
   "maintainer": "support@portworx.com",
   "website": "http://www.portworx.com/",

--- a/repo/packages/P/portworx/0/package.json
+++ b/repo/packages/P/portworx/0/package.json
@@ -1,12 +1,12 @@
 {
-  "packagingVersion": "3.0",
-  "minDcosReleaseVersion": "1.7",
+  "packagingVersion": "1.0",
+  "minDcosReleaseVersion": "1.8",
   "name": "portworx",
-  "version": "1.1",
+  "version": "1.2.0-1.0",
   "scm": "https://github.com/portworx/px-dev",
   "maintainer": "support@portworx.com",
   "website": "http://www.portworx.com/",
-  "description": "Portworx PX provides scheduler integrated data services for containers.",
+  "description": "Portworx PX provides scheduler integrated data services for containers, such as data persistence, multi-node replication, cloud-agnostic snapshots and data encryption. Portworx itself is deployed as a container and is suitable for both cloud and on-prem deployments.  Portworx enables containerized applications to be persistent, portable and protected.  For DCOS examples of Portworx, please see dcos/examples/portworx",
   "framework": true,
   "tags": [
     "portworx",
@@ -17,8 +17,8 @@
     "s3",
     "database"
   ],
-  "preInstallNotes": "Please visit http://docs.portworx.com/run-with-mesosphere.html for detailed instructions",
- "postInstallNotes": "",
+  "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Experimental packages should never be used in production!  Please visit http://docs.portworx.com/run-with-mesosphere.html for detailed instructions",
+ "postInstallNotes": "To see how Portorx data services integrate with common applications and services, to view the application solutions and to view Portworx reference architectures,  please visit http://docs.portworx.com",
  "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
   "licenses": [
     {

--- a/repo/packages/P/portworx/0/resource.json
+++ b/repo/packages/P/portworx/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "portworx-docker": "portworx/px-dev:latest"
+        "portworx-docker": "portworx/px-dev:1.1.2"
       }
     }
   }

--- a/repo/packages/P/portworx/0/resource.json
+++ b/repo/packages/P/portworx/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://raw.githubusercontent.com/portworx/px-dev/master/images/pwx-48.png",
+    "icon-medium": "https://raw.githubusercontent.com/portworx/px-dev/master/images/pwx-96.png",
+    "icon-large": "https://raw.githubusercontent.com/portworx/px-dev/master/images/pwx-256-1.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "portworx-docker": "portworx/px-dev:latest"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Portworx provides scale-out, persistent data services for containers.

Our primary doc site (http://docs.portworx.com) provides instructions for how to easily deploy Portworx through Mesos and Marathon:  http://docs.portworx.com/run-with-mesosphere.html


