### PR TITLE
Ceph dash

### DIFF
--- a/repo/packages/C/ceph-dash/0/config.json
+++ b/repo/packages/C/ceph-dash/0/config.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service":{
+            "type":"object",
+            "description": "DC/OS service configuration properties.",
+            "properties":{
+                "name" : {
+                    "description":"Name of this service instance.",
+                    "type":"string",
+                    "default":"ceph-dash"
+                },
+                "cpus": {
+                    "description": "CPU shares to allocate to this service instance.",
+                    "type": "number",
+                    "default": 0.5,
+                    "minimum": 0.3
+                },
+                "mem": {
+                    "description": "Memory to allocate to this service instance.",
+                    "type": "number",
+                    "default": 512.0,
+                    "minimum": 512.0
+                },
+                "ceph.conf_URI": {
+                    "description": "MANDATORY: URI location of the ceph.conf configuration file holding the Ceph cluster configuration. example: http://172.16.0.31/ceph.conf",
+                    "type": "string"
+                },
+                "ceph.client.admin.keyring_URI": {
+                    "description": "MANDATORY: URI location of the ceph.client.admin.keyring keyring file used to authenticate against the Ceph cluster. example: http://172.16.0.31/ceph.client.admin.keyring",
+                    "type": "string"
+                },
+                "external_access": {
+                    "type": "object",
+                    "description": "Enable access from outside the cluster through Marathon-LB.\n PLEASE NOTE THIS CONNECTION IS UNENCRYPTED.",
+                    "properties": {    
+                        "enable": {
+                            "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+                            "type": "boolean",
+                            "default": true                    
+                        },
+                        "external_access_port": {
+                            "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+                            "type": "number",
+                            "default": 15000
+                        },
+                        "virtual_host": {
+                            "description": "For external access, Virtual Host URL to be used in the external load balancer.",
+                            "type": "string",
+                            "default": "ceph-dash.example.org"
+                        }
+                    }
+                },
+                "required": [
+                    "cpus",
+                    "mem",
+                    "ceph.conf_URI",
+                    "ceph.client.admin.keyring_URI"
+                ]
+            }
+        }
+    }
+}

--- a/repo/packages/C/ceph-dash/0/config.json
+++ b/repo/packages/C/ceph-dash/0/config.json
@@ -50,14 +50,14 @@
                             "default": "ceph-dash.example.org"
                         }
                     }
-                },
-                "required": [
-                    "cpus",
-                    "mem",
-                    "ceph.conf_URI",
-                    "ceph.client.admin.keyring_URI"
-                ]
-            }
+                }
+            },
+            "required": [
+                "cpus",
+                "mem",
+                "ceph.conf_URI",
+                "ceph.client.admin.keyring_URI"
+            ]
         }
     }
 }

--- a/repo/packages/C/ceph-dash/0/config.json
+++ b/repo/packages/C/ceph-dash/0/config.json
@@ -22,11 +22,11 @@
                     "default": 512.0,
                     "minimum": 512.0
                 },
-                "ceph.conf_URI": {
+                "ceph_conf_URI": {
                     "description": "MANDATORY: URI location of the ceph.conf configuration file holding the Ceph cluster configuration. example: http://172.16.0.31/ceph.conf",
                     "type": "string"
                 },
-                "ceph.client.admin.keyring_URI": {
+                "ceph_client_admin_keyring_URI": {
                     "description": "MANDATORY: URI location of the ceph.client.admin.keyring keyring file used to authenticate against the Ceph cluster. example: http://172.16.0.31/ceph.client.admin.keyring",
                     "type": "string"
                 },

--- a/repo/packages/C/ceph-dash/0/config.json
+++ b/repo/packages/C/ceph-dash/0/config.json
@@ -55,8 +55,8 @@
             "required": [
                 "cpus",
                 "mem",
-                "ceph.conf_URI",
-                "ceph.client.admin.keyring_URI"
+                "ceph_conf_URI",
+                "ceph_client_admin_keyring_URI"
             ]
         }
     }

--- a/repo/packages/C/ceph-dash/0/marathon.json.mustache
+++ b/repo/packages/C/ceph-dash/0/marathon.json.mustache
@@ -2,14 +2,10 @@
     "id": "{{service.name}}",
     "cpus": {{service.cpus}},
     "mem": {{service.mem}},
-    "fetch": [
-    {
-      "uri": "{{service.ceph_conf_URI}}"
-    },
-    {
-      "uri": "{{service.ceph_client_admin_keyring_URI}}"
-    }
-  ],
+    "uris": [
+        "{{service.ceph_conf_URI}}",
+        "{{service.ceph_client_admin_keyring_URI}}"
+    ],
     "instances": 1,
     "container": {
         "type": "DOCKER",

--- a/repo/packages/C/ceph-dash/0/marathon.json.mustache
+++ b/repo/packages/C/ceph-dash/0/marathon.json.mustache
@@ -1,0 +1,66 @@
+{
+    "id": "{{service.name}}",
+    "cpus": {{service.cpus}},
+    "mem": {{service.mem}},
+    "fetch": [
+    {
+      "uri": "{{service.ceph.conf_URI}}"
+    },
+    {
+      "uri": "{{ceph.client.admin.keyring_URI}}"
+    }
+  ],
+    "instances": 1,
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.ceph-dash-docker}}",
+            "forcePullImage": false,
+            "network": "BRIDGE",
+            "portMappings": [
+                {
+                    "containerPort": 5000,
+                    {{#service.external_access.enable}}
+                    "servicePort": {{service.external_access.external_access_port}},
+                    {{/service.external_access.enable}}
+                    "protocol": "tcp"
+                }
+            ],
+        }
+    },
+    {{#service.external_access.enable}}
+    "portDefinitions": [
+        {
+
+            "port": {{service.external_access.external_access_port}},
+            "protocol": "tcp"
+        }
+    ],
+    {{/service.external_access.enable}}
+    "healthChecks": [
+        {
+            "protocol": "COMMAND",
+            "command": {
+                "value": "`test \"$(curl -4 -w '%{http_code}' -s http://localhost:5000/|cut -f1 -d\" \")\" == 200`"
+            },
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ],
+    "labels": {
+        "DCOS_PACKAGE_VERSION": "0.1-0.1",
+        "DCOS_SERVICE_NAME": "{{service.name}}",
+        "MARATHON_SINGLE_INSTANCE_APP": "true",
+        {{#networking.external_access.enable}}
+        "HAPROXY_GROUP": "external",
+        "HAPROXY_0_VHOST": "{{service.external_access.virtual_host}}",
+        {{/networking.external_access.enable}}             
+        "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+    },
+    "upgradeStrategy":{
+        "minimumHealthCapacity": 0,
+        "maximumOverCapacity": 0
+    }
+}

--- a/repo/packages/C/ceph-dash/0/marathon.json.mustache
+++ b/repo/packages/C/ceph-dash/0/marathon.json.mustache
@@ -25,7 +25,7 @@
                     {{/service.external_access.enable}}
                     "protocol": "tcp"
                 }
-            ],
+            ]
         }
     },
     {{#service.external_access.enable}}

--- a/repo/packages/C/ceph-dash/0/marathon.json.mustache
+++ b/repo/packages/C/ceph-dash/0/marathon.json.mustache
@@ -4,10 +4,10 @@
     "mem": {{service.mem}},
     "fetch": [
     {
-      "uri": "{{service.ceph.conf_URI}}"
+      "uri": "{{service.ceph_conf_URI}}"
     },
     {
-      "uri": "{{ceph.client.admin.keyring_URI}}"
+      "uri": "{{service.ceph_client_admin_keyring_URI}}"
     }
   ],
     "instances": 1,

--- a/repo/packages/C/ceph-dash/0/marathon.json.mustache
+++ b/repo/packages/C/ceph-dash/0/marathon.json.mustache
@@ -53,10 +53,10 @@
         "DCOS_PACKAGE_VERSION": "0.1-0.1",
         "DCOS_SERVICE_NAME": "{{service.name}}",
         "MARATHON_SINGLE_INSTANCE_APP": "true",
-        {{#networking.external_access.enable}}
+        {{#service.external_access.enable}}
         "HAPROXY_GROUP": "external",
         "HAPROXY_0_VHOST": "{{service.external_access.virtual_host}}",
-        {{/networking.external_access.enable}}             
+        {{/service.external_access.enable}}             
         "DCOS_PACKAGE_IS_FRAMEWORK": "false"
     },
     "upgradeStrategy":{

--- a/repo/packages/C/ceph-dash/0/package.json
+++ b/repo/packages/C/ceph-dash/0/package.json
@@ -1,0 +1,20 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.7",
+  "name": "ceph-dash",
+  "version": "0.1-0.1",
+  "scm": "https://github.com/Crapworks/ceph-dash",
+  "maintainer": "support@mesosphere.io",
+  "website": "https://github.com/Crapworks/ceph-dash",
+  "description": "Ceph-dash is a small and clean approach of providing the Ceph overall cluster health status via a restful json api as well as via a web GUI. There are no dependecies to the existing ceph-rest-api. This wsgi application talks to the cluster directly via librados.",
+  "tags": ["monitoring", "admin", "ceph", "storage"],
+"preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.",
+"postInstallNotes": "Service installed.\n\nAccess this service through Marathon-LB in http://YOUR_PUBLIC_NODE_IP_ADDRESS:15000.",
+"postUninstallNotes": "Service uninstalled.",
+  "licenses": [
+    {
+      "name": "License",
+      "url": "https://github.com/Crapworks/ceph-dash/blob/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/ceph-dash/0/package.json
+++ b/repo/packages/C/ceph-dash/0/package.json
@@ -6,7 +6,7 @@
   "scm": "https://github.com/Crapworks/ceph-dash",
   "maintainer": "support@mesosphere.io",
   "website": "https://github.com/Crapworks/ceph-dash",
-  "description": "Ceph-dash is a small and clean approach of providing the Ceph overall cluster health status via a restful json api as well as via a web GUI. There are no dependecies to the existing ceph-rest-api. This wsgi application talks to the cluster directly via librados.",
+  "description": "Ceph-dash is a small and clean approach of providing the Ceph overall cluster health status via a restful json api as well as via a web GUI. There are no dependecies to the existing ceph-rest-api. This wsgi application talks to the cluster directly via librados.\n\n Please check the installation tutorial at: https://github.com/dcos/examples/tree/master/1.8/ceph-dash",
   "tags": ["monitoring", "admin", "ceph", "storage"],
 "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.",
 "postInstallNotes": "Service installed.\n\nAccess this service through Marathon-LB in http://YOUR_PUBLIC_NODE_IP_ADDRESS:15000.",

--- a/repo/packages/C/ceph-dash/0/package.json
+++ b/repo/packages/C/ceph-dash/0/package.json
@@ -6,7 +6,7 @@
   "scm": "https://github.com/Crapworks/ceph-dash",
   "maintainer": "support@mesosphere.io",
   "website": "https://github.com/Crapworks/ceph-dash",
-  "description": "Ceph-dash is a small and clean approach of providing the Ceph overall cluster health status via a restful json api as well as via a web GUI. There are no dependecies to the existing ceph-rest-api. This wsgi application talks to the cluster directly via librados.\n\n Please check the installation tutorial at: https://github.com/dcos/examples/tree/master/1.8/ceph-dash",
+  "description": "Ceph-dash is a small and clean approach of providing the Ceph overall cluster health status via a restful json api as well as via a web GUI. There are no dependecies to the existing ceph-rest-api. This wsgi application talks to the cluster directly via librados.\n\n Please check the installation tutorial at: https://github.com/dcos/examples/tree/master/1.8/ceph",
   "tags": ["monitoring", "admin", "ceph", "storage"],
 "preInstallNotes": "This DC/OS Service is currently EXPERIMENTAL. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.",
 "postInstallNotes": "Service installed.\n\nAccess this service through Marathon-LB in http://YOUR_PUBLIC_NODE_IP_ADDRESS:15000.",

--- a/repo/packages/C/ceph-dash/0/resource.json
+++ b/repo/packages/C/ceph-dash/0/resource.json
@@ -1,0 +1,18 @@
+{
+  "images": {
+    "icon-small": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-ceph-small.png",
+    "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-ceph-medium.png",
+    "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-ceph-large.png",
+    "screenshots": [
+      "https://raw.githubusercontent.com/crapworks/ceph-dash/master/screenshots/ceph-dash.png",
+      "https://raw.githubusercontent.com/crapworks/ceph-dash/master/screenshots/ceph-dash-graphite.png"
+    ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "ceph-dash-docker": "fernandosanchez/ceph-dash:0.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
A tiny little dashboard to see how you're DC/OS Ceph cluster is doing today.

Tutorial for this one will be merged immediately in the main Ceph tutorial as a section. Authentication is common to both packages and... hey, who would run a Ceph cluster and NOT want to see how it's doing?

 