### PR TITLE
Bump Docker registry version in the `local-universe.py` script

### DIFF
--- a/scripts/local-universe.py
+++ b/scripts/local-universe.py
@@ -188,7 +188,7 @@ def run_docker_registry(volume_path):
     print('Start docker registry.')
     command = [ 'docker', 'run', '-d', '-p', '5000:5000', '--name',
         'registry', '-v', '{}:/var/lib/registry'.format(volume_path),
-        'registry:2.4.0']
+        'registry:2.4.1']
 
     subprocess.check_call(command)
 


### PR DESCRIPTION
This PR bumps the Docker registry version that is started by the `local-universe.py` script to 2.4.1 in order to match the one that is required by the base image (2.4.1). This way we don't have to download another registry image, which might save a few minutes if that version is not already cached in the machine.