### PR TITLE
Missing temporary registry directory

### DIFF
--- a/scripts/local-universe.py
+++ b/scripts/local-universe.py
@@ -75,6 +75,7 @@ def main():
 
         os.makedirs(str(http_artifacts))
         os.makedirs(str(repo_artifacts))
+        os.makedirs(str(docker_artifacts))
 
         failed_packages = []
         def handle_package(opts):


### PR DESCRIPTION
When running following -(py3env) sh-3.2# ./scripts/local-universe.py --repository ./repo/packages --include="marathon-lb,nginx,kafka"
Command fails because of missing line in local-universe.py that would normally create the local /tmp directory "registry" that is used in Docker Volume Mount to COPY data into local Universe Docker Image.

tep 3 : COPY registry /var/lib/registry/
lstat registry: no such file or directory
Stopping docker registry.
registry
Traceback (most recent call last):
  File "./scripts/local-universe.py", line 326, in <module>
    sys.exit(main())
  File "./scripts/local-universe.py", line 112, in main
    build_universe_docker(pathlib.Path(dir_path))
  File "./scripts/local-universe.py", line 241, in build_universe_docker
    subprocess.check_call(command, cwd=str(dir_path))
  File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py", line 291, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['docker', 'build', '-t', 'mesosphere/universe:1483643750', '-t', 'mesosphere/universe:latest', '.']' returned non-zero exit status 1.