### PR TITLE
Fixing the Zepplin website link

### DIFF
--- a/repo/packages/Z/zeppelin/3/package.json
+++ b/repo/packages/Z/zeppelin/3/package.json
@@ -14,6 +14,6 @@
         "notebook",
         "interactive"
     ],
-    "website": "https://docs.mesosphere.com/zeppelin/",
+    "website": "https://github.com/mesosphere/dcos-zeppelin",
     "postInstallNotes": "DC/OS Zeppelin is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/zeppelin/\n\tIssues: https://docs.mesosphere.com/support/"
 }


### PR DESCRIPTION
https://docs.mesosphere.com/zeppelin/ doesn't work