### PR TITLE
tunnel-cli: Bump to version 1.0.0

### DIFF
--- a/repo/packages/T/tunnel-cli/5/package.json
+++ b/repo/packages/T/tunnel-cli/5/package.json
@@ -1,0 +1,9 @@
+{
+  "packagingVersion": "3.0",
+  "name": "tunnel-cli",
+  "version": "0.3.3",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.8",
+  "description": "Proxy and VPN access to your DC/OS cluster",
+  "tags": [ "mesosphere", "subcommand", "proxy", "vpn", "socks", "http", "cli" ]
+}

--- a/repo/packages/T/tunnel-cli/5/package.json
+++ b/repo/packages/T/tunnel-cli/5/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "tunnel-cli",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "maintainer": "support@mesosphere.io",
   "minDcosReleaseVersion": "1.8",
   "description": "Proxy and VPN access to your DC/OS cluster",

--- a/repo/packages/T/tunnel-cli/5/resource.json
+++ b/repo/packages/T/tunnel-cli/5/resource.json
@@ -1,0 +1,30 @@
+{
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "59c29f80aec28d94fbb13bc6fda5b2508b7b8599b2516c6a25099f07ad6890d4"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.3.3/dcos-tunnel.zip"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "35b0e2193cc650fcf5ff867e7ec8ee6586091e8c54e6581198721dd5179cd154"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.3.3/dcos-tunnel.zip"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/T/tunnel-cli/5/resource.json
+++ b/repo/packages/T/tunnel-cli/5/resource.json
@@ -6,11 +6,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "59c29f80aec28d94fbb13bc6fda5b2508b7b8599b2516c6a25099f07ad6890d4"
+                            "value": "f7edfbcd6e1e381f45923f512016d6c6888c269f13e112aac6fadf5e286b96bc"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.3.3/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/1.0.0/dcos-tunnel.zip"
                 }
             },
             "linux": {
@@ -18,11 +18,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "35b0e2193cc650fcf5ff867e7ec8ee6586091e8c54e6581198721dd5179cd154"
+                            "value": "b389d5726175eba088c902619ce77ef0beafd16ce9ddfab40cfee39c090beba6"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.3.3/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/1.0.0/dcos-tunnel.zip"
                 }
             }
         }


### PR DESCRIPTION
This includes a update to the version of pyinstaller used. This fixes a bug where the environment for python subprocess calls were dirty and caused openvpn to fail.