### PR TITLE
Increased grace period for MoM.

### DIFF
--- a/repo/packages/M/marathon/0/marathon.json.mustache
+++ b/repo/packages/M/marathon/0/marathon.json.mustache
@@ -14,7 +14,7 @@
   "uris": {{marathon.uris}},
   "healthChecks": [
     {
-      "gracePeriodSeconds": 120,
+      "gracePeriodSeconds": 1800,
       "intervalSeconds": 10,
       "maxConsecutiveFailures": 3,
       "path": "/v2/info",

--- a/repo/packages/M/marathon/1/marathon.json.mustache
+++ b/repo/packages/M/marathon/1/marathon.json.mustache
@@ -17,7 +17,7 @@
   "uris": {{service.uris}},
   "healthChecks": [
     {
-      "gracePeriodSeconds": 120,
+      "gracePeriodSeconds": 1800,
       "intervalSeconds": 10,
       "maxConsecutiveFailures": 3,
       "path": "/ping",

--- a/repo/packages/M/marathon/2/marathon.json.mustache
+++ b/repo/packages/M/marathon/2/marathon.json.mustache
@@ -17,7 +17,7 @@
   "uris": {{service.uris}},
   "healthChecks": [
     {
-      "gracePeriodSeconds": 120,
+      "gracePeriodSeconds": 1800,
       "intervalSeconds": 10,
       "maxConsecutiveFailures": 3,
       "path": "/ping",

--- a/repo/packages/M/marathon/3/marathon.json.mustache
+++ b/repo/packages/M/marathon/3/marathon.json.mustache
@@ -17,7 +17,7 @@
   "uris": {{service.uris}},
   "healthChecks": [
     {
-      "gracePeriodSeconds": 120,
+      "gracePeriodSeconds": 1800,
       "intervalSeconds": 10,
       "maxConsecutiveFailures": 3,
       "path": "/ping",

--- a/repo/packages/M/marathon/4/marathon.json.mustache
+++ b/repo/packages/M/marathon/4/marathon.json.mustache
@@ -17,7 +17,7 @@
   "uris": {{service.uris}},
   "healthChecks": [
     {
-      "gracePeriodSeconds": 120,
+      "gracePeriodSeconds": 1800,
       "intervalSeconds": 10,
       "maxConsecutiveFailures": 3,
       "path": "/ping",

--- a/repo/packages/M/marathon/5/marathon.json.mustache
+++ b/repo/packages/M/marathon/5/marathon.json.mustache
@@ -17,7 +17,7 @@
   "uris": {{service.uris}},
   "healthChecks": [
     {
-      "gracePeriodSeconds": 120,
+      "gracePeriodSeconds": 1800,
       "intervalSeconds": 10,
       "maxConsecutiveFailures": 3,
       "path": "/ping",

--- a/repo/packages/M/marathon/6/marathon.json.mustache
+++ b/repo/packages/M/marathon/6/marathon.json.mustache
@@ -17,7 +17,7 @@
   "uris": {{service.uris}},
   "healthChecks": [
     {
-      "gracePeriodSeconds": 120,
+      "gracePeriodSeconds": 1800,
       "intervalSeconds": 10,
       "maxConsecutiveFailures": 3,
       "path": "/ping",


### PR DESCRIPTION
When migrating, marathon will not respond to health checks until all applications are migrated. When migrating a lot of applications, marathon will -in some cases- not be able to finish migration within the grace period. Therefore this period should be increased.