### PR TITLE
gestalt-framework 1.0.0 launcher release

### DIFF
--- a/repo/packages/G/gestalt-framework/2/config.json
+++ b/repo/packages/G/gestalt-framework/2/config.json
@@ -1,0 +1,177 @@
+{
+  "properties": {
+    "service": {
+      "description": "Gestalt framework-wide configuration properties",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the framework scheduler inside the base Marathon.",
+          "default": "gestalt-framework",
+          "pattern" : "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$"
+        },
+        "accept-eula": {
+          "type": "string",
+          "description": "Must enter \"yes\"",
+          "default": "[empty]",
+          "pattern": "yes"
+        },
+        "marathon-url": {
+          "type": "string",
+          "description": "The base URL for accessing Marathon by the launcher.",
+          "default": "http://marathon.mesos:8080"
+        },
+        "lb-url": {
+           "type": "string",
+           "description": "The base URL for a marathon-lb instance, for accessing services by their assigned service ports.",
+           "default": ""
+        },
+        "tld": {
+          "type": "string",
+          "description": "Top-level domain for creating marathon-lb virtual hosts for framework services."
+        },
+        "framework-version": {
+          "type": "string",
+          "description": "Version of the Gestalt framework to install",
+          "default": "1.0.0"
+        },
+        "role": {
+          "description": "Deploy gestalt-framework-scheduler only on nodes with this role.",
+          "type": "string"
+        },
+        "debug-logging": {
+          "description": "Enable debug logging.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "name",
+        "accept-eula",
+        "framework-version",
+        "marathon-url",
+        "debug-logging"
+      ],
+      "type": "object"
+    },
+    "database" : {
+      "description": "database configuration properties",
+      "properties": {
+        "provision": {
+          "type": "boolean",
+          "description": "Provision a database server for use by the framework services. Otherwise, requires a pre-existing database server.",
+          "default": true
+        },
+        "num-secondaries": {
+          "type": "integer",
+          "description": "When provisioning the database, number of redundant secondaries to be provisioned.",
+          "default": 0
+        },
+        "provisioned-size": {
+          "type": "integer",
+          "description": "When provisioning the database, size for the persistent volume in MB.",
+          "default": 100
+        },
+        "hostname": {
+          "type": "string",
+          "description": "The hostname for the database (only if pre-existing)."
+        },
+        "port": {
+          "type": "integer",
+          "description": "The port for the database (only if pre-existing).",
+          "minimum": 1,
+          "maximum": 32000
+        },
+        "username": {
+          "type": "string",
+          "description": "The username for the database (provisioned or pre-existing)",
+          "default": "gestaltdev"
+        },
+        "password": {
+          "type": "string",
+          "description": "The password for the database (provisioned or pre-existing)",
+          "default": "letmein"
+        },
+        "prefix": {
+          "type": "string",
+          "description": "A prefix for database names for the database (only if pre-existing)",
+          "default": "gestalt-"
+        }
+      },
+      "required": [
+        "provision",
+        "username",
+        "password",
+        "prefix"
+      ],
+      "type": "object"
+    },
+    "security" : {
+      "description": "gestalt-security configuration properties",
+      "properties": {
+        "admin-username": {
+          "type": "string",
+          "description": "The username for the bootstrapped admin account.",
+          "default": "gestalt-admin"
+        },
+        "admin-password": {
+          "type": "string",
+          "description": "The password for the bootstrapped admin account (leave blank for none/no-login).",
+          "default": "letmein"
+        },
+        "api-key": {
+          "type": "string",
+          "description": "Admin API key, required if security is already initialized."
+        },
+        "api-secret": {
+          "type": "string",
+          "description": "Admin API secret, required if security is already initialized."
+        }
+      },
+      "required": [
+        "admin-username",
+        "admin-password"
+      ],
+      "type": "object"
+    },
+    "laser" : {
+      "description": "gestalt-laser lambda scheduler configuration properties",
+      "properties": {
+        "min-cool-executors": {
+          "type": "integer",
+          "description": "Minimum number of cool executors.",
+          "default" : 1,
+          "minimum" : 1
+        },
+        "scale-down-timeout": {
+          "type": "integer",
+          "description": "Lambda executor scale down timeout (seconds)",
+          "default" : 15,
+          "minimum" : 1
+        },
+        "min-port-range": {
+          "type": "integer",
+          "description": "Minimum port number for scheduler listening sockets.",
+          "default" : 60000,
+          "minimum" : 1
+        },
+        "max-port-range": {
+          "type": "integer",
+          "description": "Maximum port number for scheduler listening sockets.",
+          "default" : 60500,
+          "minimum" : 1
+        }
+      },
+      "required": [
+        "min-cool-executors",
+        "scale-down-timeout",
+        "min-port-range",
+        "max-port-range"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "service", "database", "security", "laser"
+  ],
+  "type": "object"
+}

--- a/repo/packages/G/gestalt-framework/2/marathon.json.mustache
+++ b/repo/packages/G/gestalt-framework/2/marathon.json.mustache
@@ -1,0 +1,42 @@
+{
+  "id": "{{service.name}}",
+  "maintainer": "support@galacticfog.com",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "galacticfog/gestalt-dcos:{{service.framework-version}}",
+      "network": "HOST",
+      "forcePullImage": true
+    }
+  },
+  "env": {
+    "JVM_OPTS": "-Xmx384m",
+    "GESTALT_FRAMEWORK_VERSION": "{{service.framework-version}}"
+  },
+  "cmd": "./bin/gestalt-dcos -Dhttp.port=$PORT0 -Dmarathon.url={{service.marathon-url}} -Dmarathon.app-group={{service.name}}-tasks -Dlaser.scale-down-timeout={{laser.scale-down-timeout}} -Dlaser.max-port-range={{laser.max-port-range}} -Dlaser.min-port-range={{laser.min-port-range}} -Dlaser.min-cool-executors={{laser.min-cool-executors}} -Dsecurity.username={{security.admin-username}} -Dsecurity.password=\"{{security.admin-password}}\" {{#security.api-key}}-Dsecurity.key={{security.api-key}}{{/security.api-key}} {{#security.api-secret}}-Dsecurity.secret=\"{{security.api-secret}}\"{{/security.api-secret}} {{#service.debug-logging}}-Dlogger.resource=debug-logging.xml{{/service.debug-logging}} {{#service.lb-url}}-Dmarathon.lb-url={{service.lb-url}}{{/service.lb-url}} {{#service.tld}}-Dmarathon.tld={{service.tld}}{{/service.tld}} {{#database.hostname}}-Ddatabase.hostname={{database.hostname}}{{/database.hostname}} {{#database.num-secondaries}}-Ddatabase.num-secondaries={{database.num-secondaries}}{{/database.num-secondaries}} {{#database.port}}-Ddatabase.port={{database.port}}{{/database.port}} {{#database.prefix}}-Ddatabase.prefix={{database.prefix}}{{/database.prefix}} -Ddatabase.username={{database.username}} -Ddatabase.password=\"{{database.password}}\" -Ddatabase.provision={{database.provision}} {{#database.provisioned-size}}-Ddatabase.provisioned-size={{database.provisioned-size}}{{/database.provisioned-size}}",
+  "cpus": 0.5,
+  "mem": 512,
+  "instances": 1,
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  },
+  "requirePorts":true,
+  "ports": [
+    0
+  ],
+  {{#service.role}}
+     "acceptedResourceRoles": [
+       "{{service.role}}"
+     ],
+  {{/service.role}}
+  "healthChecks": [{
+    "protocol": "HTTP",
+    "path": "/_gfhealth",
+    "portIndex": 0,
+    "gracePeriodSeconds": 60,
+    "intervalSeconds": 30,
+    "maxConsecutiveFailures": 0
+  }]
+}

--- a/repo/packages/G/gestalt-framework/2/package.json
+++ b/repo/packages/G/gestalt-framework/2/package.json
@@ -1,0 +1,31 @@
+{
+  "description": "The Gestalt Framework is a solution for building enterprise-grade cloud-native applications using containers and lambdas.",
+  "framework": true,
+  "maintainer": "team@galacticfog.com",
+  "minDcosReleaseVersion": "1.8",
+  "name": "gestalt-framework",
+  "packagingVersion" : "3.0",
+  "preInstallNotes": "Requires DC/OS 1.8.3 or later. Please see the Getting started guide at http://www.galacticfog.com/get-started",
+  "postInstallNotes": "The Gestalt Framework is now running on your server.",
+  "postUninstallNotes": "The gestalt-framework launcher has been uninstalled.\nIf the framework services were not shutdown from the launcher, they will need to be manually removed from Marathon.",
+  "selected": false,
+  "tags": [
+    "gestalt-framework", 
+    "orchestration", 
+    "lambda", 
+    "policy"
+  ],
+  "version" : "1.0.0",
+  "scm" : "https://github.com/GalacticFog/gestalt-dcos.git",
+  "website" : "http://www.galacticfog.com/get-started",
+  "licenses" : [ {
+      "name" : "Apache License Version 2.0",
+      "url" : "https://github.com/GalacticFog/gestalt-dcos/blob/develop/LICENSE"
+  }, {
+      "name" : "Commercial",
+      "url" : "http://www.galacticfog.com/contact"
+  }, {
+      "name" : "End User License Agreement",
+      "url" : "http://www.galacticfog.com/gestalt-eula.html"
+  } ]
+}

--- a/repo/packages/G/gestalt-framework/2/resource.json
+++ b/repo/packages/G/gestalt-framework/2/resource.json
@@ -1,0 +1,32 @@
+{
+  "images": {
+    "icon-large": "https://s3.amazonaws.com/gfi.misc/Gestalt-Icon-Large.png",
+    "icon-medium": "https://s3.amazonaws.com/gfi.misc/Gestalt-Icon-Medium.png",
+    "icon-small": "https://s3.amazonaws.com/gfi.misc/Gestalt-Icon-Small.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "launcher":                   "galacticfog/gestalt-dcos:1.0.0",
+        "rabbit":                     "galacticfog/rabbit:dcos-1.0.0",
+        "kong":                       "galacticfog/kong:dcos-1.0.0",
+        "gestalt-dcos":               "galacticfog/gestalt-dcos:1.0.0",
+        "data":                       "galacticfog/gestalt-data:dcos-1.0.0",
+        "api-gateway":                "galacticfog/gestalt-api-gateway:dcos-1.0.0",
+        "api-proxy":                  "galacticfog/gestalt-api-proxy:dcos-1.0.0",
+        "laser":                      "galacticfog/gestalt-laser:dcos-1.0.0",
+        "meta":                       "galacticfog/gestalt-meta:dcos-1.0.0",
+        "policy":                     "galacticfog/gestalt-policy:dcos-1.0.0",
+        "security":                   "galacticfog/gestalt-security:dcos-1.0.0",
+        "ui":                         "galacticfog/gestalt-ui:dcos-1.0.0",
+        "laser-ruby-executor":        "galacticfog/gestalt-laser-executor-ruby:dcos-1.0.0",
+        "laser-js-executor":          "galacticfog/gestalt-laser-executor-js:dcos-1.0.0",
+        "laser-golang-executor":      "galacticfog/gestalt-laser-executor-golang:dcos-1.0.0",
+        "laser-python-executor":      "galacticfog/gestalt-laser-executor-python:dcos-1.0.0",
+        "laser-jvm-executor":         "galacticfog/gestalt-laser-executor-jvm:dcos-1.0.0",
+        "laser-dotnet-executor":      "galacticfog/gestalt-laser-executor-dotnet:dcos-1.0.0"
+      }
+    },
+    "uris": {}
+  }
+}


### PR DESCRIPTION
added eula to licenses and requirement in config
removed mesos config from gestalt launcher
added lambda.scale-down-timeout config for gestalt-framework launcher
updated docker images
added config for laser min/max port range, injected into launcher payload
added database.num-secondaries config
removed defunct config for framework launcher