### PR TITLE
Add v4Package Schema

### DIFF
--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -295,8 +295,7 @@
         "version",
         "maintainer",
         "description",
-        "tags",
-        "minDcosReleaseVersion"
+        "tags"
       ],
       "additionalProperties": false
     }

--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -198,7 +198,7 @@
       "properties": {
         "packagingVersion": {
           "type": "string",
-          "enum": ["3.0"]
+          "enum": ["4.0"]
         },
         "name": {
           "type": "string"
@@ -294,7 +294,7 @@
   },
 
   "type": "object",
-  "anyOf": [
+  "oneOf": [
     { "$ref": "#/definitions/v20Package" },
     { "$ref": "#/definitions/v30Package" },
     { "$ref": "#/definitions/v40Package" }

--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -223,12 +223,19 @@
           "default": false,
           "description": "True if this package installs a new Mesos framework."
         },
-        "upgrades": {
+        "upgradesFrom": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "List of versions from which this package can upgrade from. If the property is missing or null it means that it can upgrade from any package. If the property is the empty list then it means that it can’t upgrade from any package."
+          "description": "Versions this package can upgrade from."
+        },
+        "downgradesTo": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Versions this package can downgrade to."
         },
         "preInstallNotes": {
           "type": "string",
@@ -286,7 +293,9 @@
         "version",
         "maintainer",
         "description",
-        "tags"
+        "tags",
+        "upgradesFrom",
+        "downgradesTo"
       ],
       "additionalProperties": false
     }

--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -114,7 +114,8 @@
           "type": "string"
         },
         "version": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[-a-zA-Z0-9.]+$"
         },
         "scm": {
           "type": "string"
@@ -204,7 +205,8 @@
           "type": "string"
         },
         "version": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[-a-zA-Z0-9.]+$"
         },
         "scm": {
           "type": "string"
@@ -228,14 +230,14 @@
           "items": {
             "type": "string"
           },
-          "description": "List of versions that can upgrade to this package."
+          "description": "List of versions that can upgrade to this package. If the property is a list containing '*', any version can upgrade to this package. If the property is the empty list, no version can upgrade to this package."
         },
         "downgradesTo": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "List of versions that this package can downgrade to."
+          "description": "List of versions that this package can downgrade to. If the property is a list containing '*', this package can downgrade to any version. If the property is the empty list, this package cannot downgrade."
         },
         "preInstallNotes": {
           "type": "string",

--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -230,14 +230,14 @@
           "items": {
             "type": "string"
           },
-          "description": "List of versions that can upgrade to this package. If the property is a list containing '*', any version can upgrade to this package. If the property is the empty list, no version can upgrade to this package."
+          "description": "List of versions that can upgrade to this package. If the property is a list containing the string '*', any version can upgrade to this package. If the property is not set or the empty list, no version can upgrade to this package."
         },
         "downgradesTo": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "List of versions that this package can downgrade to. If the property is a list containing '*', this package can downgrade to any version. If the property is the empty list, this package cannot downgrade."
+          "description": "List of versions that this package can downgrade to. If the property is a list containing the string '*', this package can downgrade to any version. If the property is not set or the empty list, this package cannot downgrade."
         },
         "preInstallNotes": {
           "type": "string",
@@ -296,8 +296,6 @@
         "maintainer",
         "description",
         "tags",
-        "upgradesFrom",
-        "downgradesTo",
         "minDcosReleaseVersion"
       ],
       "additionalProperties": false

--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -192,14 +192,112 @@
         "tags"
       ],
       "additionalProperties": false
+    },
+
+    "v40Package": {
+      "properties": {
+        "packagingVersion": {
+          "type": "string",
+          "enum": ["3.0"]
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "scm": {
+          "type": "string"
+        },
+        "maintainer": {
+          "type": "string"
+        },
+        "website": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "framework": {
+          "type": "boolean",
+          "default": false,
+          "description": "True if this package installs a new Mesos framework."
+        },
+        "upgrades": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of versions from which this package can upgrade from. If the property is missing or null it means that it can upgrade from any package. If the property is the empty list then it means that it can’t upgrade from any package."
+        },
+        "preInstallNotes": {
+          "type": "string",
+          "description": "Pre installation notes that would be useful to the user of this package."
+        },
+        "postInstallNotes": {
+          "type": "string",
+          "description": "Post installation notes that would be useful to the user of this package."
+        },
+        "postUninstallNotes": {
+          "type": "string",
+          "description": "Post uninstallation notes that would be useful to the user of this package."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[^\\s]+$"
+          }
+        },
+        "selected": {
+          "type": "boolean",
+          "description": "Flag indicating if the package is selected in search results",
+          "default": false
+        },
+        "licenses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the license. For example one of [Apache License Version 2.0 | MIT License | BSD License | Proprietary]"
+              },
+              "url": {
+                "$ref": "#/definitions/url",
+                "description": "The URL where the license can be accessed"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "url"
+            ]
+          }
+        },
+        "minDcosReleaseVersion": {
+          "$ref": "#/definitions/dcosReleaseVersion",
+          "description": "The minimum DC/OS Release Version the package can run on."
+        }
+      },
+      "required": [
+        "packagingVersion",
+        "name",
+        "version",
+        "maintainer",
+        "description",
+        "tags"
+      ],
+      "additionalProperties": false
     }
 
   },
 
   "type": "object",
-  "oneOf": [
+  "anyOf": [
     { "$ref": "#/definitions/v20Package" },
-    { "$ref": "#/definitions/v30Package" }
+    { "$ref": "#/definitions/v30Package" },
+    { "$ref": "#/definitions/v40Package" }
   ]
 
 }

--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -228,14 +228,14 @@
           "items": {
             "type": "string"
           },
-          "description": "Versions this package can upgrade from."
+          "description": "List of versions that can upgrade to this package."
         },
         "downgradesTo": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Versions this package can downgrade to."
+          "description": "List of versions that this package can downgrade to."
         },
         "preInstallNotes": {
           "type": "string",

--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -297,7 +297,8 @@
         "description",
         "tags",
         "upgradesFrom",
-        "downgradesTo"
+        "downgradesTo",
+        "minDcosReleaseVersion"
       ],
       "additionalProperties": false
     }

--- a/repo/meta/schema/v3-repo-schema.json
+++ b/repo/meta/schema/v3-repo-schema.json
@@ -603,8 +603,7 @@
         "releaseVersion",
         "maintainer",
         "description",
-        "tags",
-        "minDcosReleaseVersion"
+        "tags"
       ],
       "additionalProperties": false
     }

--- a/repo/meta/schema/v3-repo-schema.json
+++ b/repo/meta/schema/v3-repo-schema.json
@@ -605,7 +605,8 @@
         "description",
         "tags",
         "upgradesFrom",
-        "downgradesTo"
+        "downgradesTo",
+        "minDcosReleaseVersion"
       ],
       "additionalProperties": false
     }

--- a/repo/meta/schema/v3-repo-schema.json
+++ b/repo/meta/schema/v3-repo-schema.json
@@ -386,7 +386,8 @@
           "type": "string"
         },
         "version": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[-a-zA-Z0-9.]+$"
         },
         "releaseVersion": {
           "type": "integer",
@@ -482,6 +483,129 @@
         "tags"
       ],
       "additionalProperties": false
+    },
+
+    "v40Package": {
+      "properties": {
+        "packagingVersion": {
+          "type": "string",
+          "enum": ["4.0"]
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^[-a-zA-Z0-9.]+$"
+        },
+        "releaseVersion": {
+          "type": "integer",
+          "description": "Corresponds to the revision index from the universe directory structure",
+          "minimum": 0
+        },
+        "scm": {
+          "type": "string"
+        },
+        "maintainer": {
+          "type": "string"
+        },
+        "website": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "framework": {
+          "type": "boolean",
+          "default": false,
+          "description": "True if this package installs a new Mesos framework."
+        },
+        "upgradesFrom": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of versions that can upgrade to this package. If the property is a list containing '*', any version can upgrade to this package. If the property is the empty list, no version can upgrade to this package."
+        },
+        "downgradesTo": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of versions that this package can downgrade to. If the property is a list containing '*', this package can downgrade to any version. If the property is the empty list, this package cannot downgrade."
+        },
+        "preInstallNotes": {
+          "type": "string",
+          "description": "Pre installation notes that would be useful to the user of this package."
+        },
+        "postInstallNotes": {
+          "type": "string",
+          "description": "Post installation notes that would be useful to the user of this package."
+        },
+        "postUninstallNotes": {
+          "type": "string",
+          "description": "Post uninstallation notes that would be useful to the user of this package."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[^\\s]+$"
+          }
+        },
+        "selected": {
+          "type": "boolean",
+          "description": "Flag indicating if the package is selected in search results",
+          "default": false
+        },
+        "licenses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the license. For example one of [Apache License Version 2.0 | MIT License | BSD License | Proprietary]"
+              },
+              "url": {
+                "$ref": "#/definitions/url",
+                "description": "The URL where the license can be accessed"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "url"
+            ]
+          }
+        },
+        "minDcosReleaseVersion": {
+          "$ref": "#/definitions/dcosReleaseVersion",
+          "description": "The minimum DC/OS Release Version the package can run on."
+        },
+        "marathon": {
+          "$ref": "#/definitions/marathon"
+        },
+        "resource": {
+          "$ref": "#/definitions/v30resource"
+        },
+        "config": {
+          "$ref": "#/definitions/config"
+        },
+        "command": {
+          "$ref": "#/definitions/command"
+        }
+      },
+      "required": [
+        "packagingVersion",
+        "name",
+        "version",
+        "releaseVersion",
+        "maintainer",
+        "description",
+        "tags"
+      ],
+      "additionalProperties": false
     }
 
 
@@ -495,7 +619,8 @@
       "items": {
         "oneOf": [
           { "$ref": "#/definitions/v20Package" },
-          { "$ref": "#/definitions/v30Package" }
+          { "$ref": "#/definitions/v30Package" },
+          { "$ref": "#/definitions/v40Package" }
         ]
       }
     }

--- a/repo/meta/schema/v3-repo-schema.json
+++ b/repo/meta/schema/v3-repo-schema.json
@@ -603,7 +603,9 @@
         "releaseVersion",
         "maintainer",
         "description",
-        "tags"
+        "tags",
+        "upgradesFrom",
+        "downgradesTo"
       ],
       "additionalProperties": false
     }

--- a/repo/meta/schema/v3-repo-schema.json
+++ b/repo/meta/schema/v3-repo-schema.json
@@ -525,14 +525,14 @@
           "items": {
             "type": "string"
           },
-          "description": "List of versions that can upgrade to this package. If the property is a list containing '*', any version can upgrade to this package. If the property is the empty list, no version can upgrade to this package."
+          "description": "List of versions that can upgrade to this package. If the property is a list containing the string '*', any version can upgrade to this package. If the property is not set or the empty list, no version can upgrade to this package."
         },
         "downgradesTo": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "List of versions that this package can downgrade to. If the property is a list containing '*', this package can downgrade to any version. If the property is the empty list, this package cannot downgrade."
+          "description": "List of versions that this package can downgrade to. If the property is a list containing the string '*', this package can downgrade to any version. If the property is not set or the empty list, this package cannot downgrade."
         },
         "preInstallNotes": {
           "type": "string",
@@ -604,8 +604,6 @@
         "maintainer",
         "description",
         "tags",
-        "upgradesFrom",
-        "downgradesTo",
         "minDcosReleaseVersion"
       ],
       "additionalProperties": false

--- a/scripts/validate-packages.py
+++ b/scripts/validate-packages.py
@@ -58,8 +58,8 @@ def _validate_revision(given_package, revision, path):
     packaging_version = package_json.get("packagingVersion", "2.0")
 
     # validate upgrades version
-    min_dcos_version = package_json.get("minDcosReleaseVersion")
-    if packaging_version == "4.0" and LooseVersion(min_dcos_version) < LooseVersion("1.10"):
+    min_dcos_release_version = package_json.get("minDcosReleaseVersion")
+    if packaging_version == "4.0" and LooseVersion(min_dcos_release_version) < LooseVersion("1.10"):
         sys.exit("\tERROR\n\nminDcosReleaseVersion must be greater than or equal to 1.10")
 
     # validate command.json

--- a/scripts/validate-packages.py
+++ b/scripts/validate-packages.py
@@ -57,6 +57,15 @@ def _validate_revision(given_package, revision, path):
 
     packaging_version = package_json.get("packagingVersion", "2.0")
 
+    # validate upgrades version
+    if packaging_version is "4.0":
+        min_dcos_version = package_json.get("minDcosReleaseVersion").split('.')
+        major = int(min_dcos_version[0])
+        minor = int(min_dcos_version[1])
+
+        if major < 1 or (major == 1 and minor < 10):
+            sys.exit("\tERROR\n\nminDcosReleaseVersion must be greater than or equal to 1.10")
+
     # validate command.json
     command_json_path = os.path.join(path, 'command.json')
     command_json = None

--- a/scripts/validate-packages.py
+++ b/scripts/validate-packages.py
@@ -58,13 +58,9 @@ def _validate_revision(given_package, revision, path):
     packaging_version = package_json.get("packagingVersion", "2.0")
 
     # validate upgrades version
-    if packaging_version == "4.0":
-        min_dcos_version = package_json.get("minDcosReleaseVersion").split('.')
-        major = int(min_dcos_version[0])
-        minor = int(min_dcos_version[1])
-
-        if major < 1 or (major == 1 and minor < 10):
-            sys.exit("\tERROR\n\nminDcosReleaseVersion must be greater than or equal to 1.10")
+    min_dcos_version = package_json.get("minDcosReleaseVersion")
+    if packaging_version == "4.0" and LooseVersion(min_dcos_version) < LooseVersion("1.10"):
+        sys.exit("\tERROR\n\nminDcosReleaseVersion must be greater than or equal to 1.10")
 
     # validate command.json
     command_json_path = os.path.join(path, 'command.json')

--- a/scripts/validate-packages.py
+++ b/scripts/validate-packages.py
@@ -59,8 +59,14 @@ def _validate_revision(given_package, revision, path):
 
     # validate upgrades version
     min_dcos_release_version = package_json.get("minDcosReleaseVersion")
-    if packaging_version == "4.0" and LooseVersion(min_dcos_release_version) < LooseVersion("1.10"):
-        sys.exit("\tERROR\n\nminDcosReleaseVersion must be greater than or equal to 1.10")
+    upgrades_from = package_json.get("upgradesFrom")
+    downgrades_to = package_json.get("downgradesTo")
+    if (packaging_version == "4.0" and
+            (upgrades_from or downgrades_to) and
+                LooseVersion(min_dcos_release_version) < LooseVersion("1.10")):
+        sys.exit("\tERROR\n\nIf upgradesFrom or downgradesTo fields are set to a "
+                 "non-empty list, then minDcosReleaseVersion must be greater "
+                 "than or equal to 1.10")
 
     # validate command.json
     command_json_path = os.path.join(path, 'command.json')

--- a/scripts/validate-packages.py
+++ b/scripts/validate-packages.py
@@ -58,7 +58,7 @@ def _validate_revision(given_package, revision, path):
     packaging_version = package_json.get("packagingVersion", "2.0")
 
     # validate upgrades version
-    if packaging_version is "4.0":
+    if packaging_version == "4.0":
         min_dcos_version = package_json.get("minDcosReleaseVersion").split('.')
         major = int(min_dcos_version[0])
         minor = int(min_dcos_version[1])


### PR DESCRIPTION
We are adding updates to packages. As part of this effort we are adding a new package specification which encodes upgrade information. Specifically we are adding a field that shows for a given package `A`, what other packages `upgrades=[B, C, D]` are able to upgrade to `A`.