### PR TITLE
tunnel-cli: Bump to 1.0.1

### DIFF
--- a/repo/packages/T/tunnel-cli/6/package.json
+++ b/repo/packages/T/tunnel-cli/6/package.json
@@ -1,0 +1,9 @@
+{
+  "packagingVersion": "3.0",
+  "name": "tunnel-cli",
+  "version": "1.0.0",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.8",
+  "description": "Proxy and VPN access to your DC/OS cluster",
+  "tags": [ "mesosphere", "subcommand", "proxy", "vpn", "socks", "http", "cli" ]
+}

--- a/repo/packages/T/tunnel-cli/6/package.json
+++ b/repo/packages/T/tunnel-cli/6/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "tunnel-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "maintainer": "support@mesosphere.io",
   "minDcosReleaseVersion": "1.8",
   "description": "Proxy and VPN access to your DC/OS cluster",

--- a/repo/packages/T/tunnel-cli/6/resource.json
+++ b/repo/packages/T/tunnel-cli/6/resource.json
@@ -1,0 +1,30 @@
+{
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "f7edfbcd6e1e381f45923f512016d6c6888c269f13e112aac6fadf5e286b96bc"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/1.0.0/dcos-tunnel.zip"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "b389d5726175eba088c902619ce77ef0beafd16ce9ddfab40cfee39c090beba6"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/1.0.0/dcos-tunnel.zip"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/T/tunnel-cli/6/resource.json
+++ b/repo/packages/T/tunnel-cli/6/resource.json
@@ -6,11 +6,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "f7edfbcd6e1e381f45923f512016d6c6888c269f13e112aac6fadf5e286b96bc"
+                            "value": "08e21a20898bd87afedf64f0e0c8bc242f83af2eda82e01eeaa7cd9ab0dff02e"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/1.0.0/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/1.0.1/dcos-tunnel.zip"
                 }
             },
             "linux": {
@@ -18,11 +18,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "b389d5726175eba088c902619ce77ef0beafd16ce9ddfab40cfee39c090beba6"
+                            "value": "69cfd86f3939bc9479242252ac68a073687796242b05ad76783a279d667e2152"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/1.0.0/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/1.0.1/dcos-tunnel.zip"
                 }
             }
         }


### PR DESCRIPTION
Finally fixed the LD_LIBRARY_PATH bug plaguing the linux binary.