### PR TITLE
MariaDB: switch to official image and package improvements

### DIFF
--- a/repo/packages/M/mariadb/3/config.json
+++ b/repo/packages/M/mariadb/3/config.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "The name of the MariaDB service instance",
+          "type": "string",
+          "default": "mariadb"
+        }
+      }
+    },
+    "mariadb": {
+      "additionalProperties": false,
+      "description": "MariaDB service configuration properties",
+      "properties": {
+        "cpus": {
+          "description": "CPU shares to allocate to each MariaDB node.",
+          "type": "number",
+          "default": 0.5,
+          "minimum": 0.5
+        },
+        "mem": {
+          "description": "Memory to allocate to each MariaDB node.",
+          "type": "number",
+          "default": 1024.0,
+          "minimum": 512.0
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "description": "MariaDB database configuration properties",
+      "properties": {
+        "name": {
+          "description": "The name of a database to be created on startup.",
+          "type": "string",
+          "default": "defaultdb"
+        },
+        "username": {
+          "description": "The username of a user to be created with superuser access to this database only.",
+          "type": "string",
+          "default": "admin"
+        },
+        "password": {
+          "description": "The password for a user to be created with superuser access to this database only.",
+          "type": "string",
+          "default": "password"
+        },
+        "root_password": {
+          "description": "Specifies the password that will be set for the MariaDB root superuser account.",
+          "type": "string",
+          "default": "root"
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "description": "MariaDB storage configuration properties",
+      "properties": {
+        "host_volume": {
+          "description": "If using non-persistent volumes (local volumes), this sets the location of a volume on the host to be used for the service. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/service_name`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents. NOTE: if you don't change the default /tmp value, YOUR DATA WILL NOT BE SAVED IN ANY WAY.",
+          "type": "string",
+          "default": "/tmp"
+        }
+      }
+    },
+    "networking": {
+      "type": "object",
+      "description": "MariaDB networking configuration properties",
+      "properties": {
+        "host_mode": {
+          "description": "Enable or disable host networking mode. NOTE: this requires the default port to be available on the target host. This also forces to have a single instance per node.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/M/mariadb/3/config.json
+++ b/repo/packages/M/mariadb/3/config.json
@@ -112,6 +112,22 @@
           "description": "Enable or disable host networking mode. NOTE: this requires the default port to be available on the target host. This also forces to have a single instance per node.",
           "type": "boolean",
           "default": false
+        },
+        "external_access": {
+          "type": "object",
+          "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+          "properties": {
+            "enable": {
+              "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+              "type": "boolean",
+              "default": false
+            },
+            "external_access_port": {
+              "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+              "type": "number",
+              "default": 13306
+            }
+          }
         }
       }
     }

--- a/repo/packages/M/mariadb/3/config.json
+++ b/repo/packages/M/mariadb/3/config.json
@@ -64,6 +64,43 @@
           "description": "If using non-persistent volumes (local volumes), this sets the location of a volume on the host to be used for the service. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/service_name`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents. NOTE: if you don't change the default /tmp value, YOUR DATA WILL NOT BE SAVED IN ANY WAY.",
           "type": "string",
           "default": "/tmp"
+        },
+        "persistence": {
+          "type": "object",
+          "description": "Enable persistent storage.",
+          "properties": {
+            "enable": {
+              "description": "Enable or disable persistent storage.",
+              "type": "boolean",
+              "default": false
+            },
+            "volume_size": {
+              "description": "If a new volume is to be created, this controls its size in MBs.",
+              "type": "number",
+              "default": 256
+            },
+            "external": {
+              "type": "object",
+              "description": "External persistent storage properties",
+              "properties": {
+                "enable": {
+                  "description": "Enable or disable external persistent storage. The `persistence` option must also be selected. Please note that for these to work, your DC/OS cluster MUST have been installed with the right options in `config.yaml`. Also, please note this requires a working configuration file for the driver (e.g. `rexray.yaml`).",
+                  "type": "boolean",
+                  "default": false
+                },
+                "volume_name": {
+                  "description": "Name that your volume driver uses to look up your external volume. When your task is staged on an agent, the volume driver queries the storage service for a volume with this name. If one does not exist, it is created implicitly. Otherwise, the existing volume is reused.",
+                  "type": "string",
+                  "default": "mysql"
+                },
+                "driver": {
+                  "description": "Volume driver to use for storage. The default value should be correct for most use cases.",
+                  "type": "string",
+                  "default": "rexray"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/repo/packages/M/mariadb/3/marathon.json.mustache
+++ b/repo/packages/M/mariadb/3/marathon.json.mustache
@@ -12,8 +12,26 @@
   "container": {
     "type": "DOCKER",
     "volumes": [{
-      "containerPath": "/var/lib/mysql/",
+      {{^storage.persistence.enable}}
+      "containerPath": "/var/lib/mysql",
       "hostPath": "{{storage.host_volume}}/{{service.name}}",
+      {{/storage.persistence.enable}}
+      {{#storage.persistence.enable}}
+      {{^storage.persistence.external.enable}}
+      "containerPath": "/var/lib/mysql",
+      "persistent": {
+        "size": {{storage.persistence.volume_size}}
+      },
+      {{/storage.persistence.external.enable}}
+      {{#storage.persistence.external.enable}}
+      "containerPath": "/var/lib/mysql",
+      "external": {
+        "name": "{{storage.persistence.external.volume_name}}",
+        "provider": "dvdi",
+        "options": { "dvdi/driver": "{{storage.persistence.external.driver}}" }
+      },
+      {{/storage.persistence.external.enable}}
+      {{/storage.persistence.enable}}
       "mode": "RW"
     }],
     "docker": {

--- a/repo/packages/M/mariadb/3/marathon.json.mustache
+++ b/repo/packages/M/mariadb/3/marathon.json.mustache
@@ -1,0 +1,75 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{mariadb.cpus}},
+  "mem": {{mariadb.mem}},
+  "instances": 1,
+  "env": {
+    "MYSQL_DATABASE": "{{database.name}}",
+    "MYSQL_USER": "{{database.username}}",
+    "MYSQL_PASSWORD": "{{database.password}}",
+    "MYSQL_ROOT_PASSWORD": "{{database.root_password}}"
+  },
+  "container": {
+    "type": "DOCKER",
+    "volumes": [{
+      "containerPath": "/var/lib/mysql/",
+      "hostPath": "{{storage.host_volume}}/{{service.name}}",
+      "mode": "RW"
+    }],
+    "docker": {
+      "image": "{{resource.assets.container.docker.mariadb-docker}}",
+      {{#networking.host_mode}}
+      "network": "HOST",
+      {{/networking.host_mode}}
+      {{^networking.host_mode}}
+      "network": "BRIDGE",
+      "portMappings": [
+        {
+          "containerPort": 3306,
+          "hostPort": 0,
+          "protocol": "tcp",
+          "name": "mysql",
+          "labels": {
+            "VIP_0": "/{{service.name}}:{{networking.port}}"
+          }
+        }
+      ]
+      {{/networking.host_mode}}
+    }
+  },
+  {{#networking.host_mode}}
+  "portDefinitions": [{
+      "protocol": "tcp",
+      "port": 3306,
+      "name": "mysql",
+      "labels": {
+        "VIP_0": "/{{service.name}}:{{networking.port}}"
+      }
+  }],
+  "requirePorts": true,
+  "constraints": [["hostname", "UNIQUE"]],
+  {{/networking.host_mode}}
+  "healthChecks": [{
+    "protocol": "TCP",
+    {{#networking.host_mode}}
+    "port": 3306,
+    {{/networking.host_mode}}
+    {{^networking.host_mode}}
+    "portIndex": 0,
+    {{/networking.host_mode}}
+    "gracePeriodSeconds": 300,
+    "intervalSeconds": 60,
+    "timeoutSeconds": 20,
+    "maxConsecutiveFailures": 3
+  }],
+  "labels": {
+    "DCOS_PACKAGE_VERSION": "10.1.21",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP":"true",
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/M/mariadb/3/marathon.json.mustache
+++ b/repo/packages/M/mariadb/3/marathon.json.mustache
@@ -45,6 +45,9 @@
         {
           "containerPort": 3306,
           "hostPort": 0,
+          {{#networking.external_access.enable}}
+          "servicePort": {{networking.external_access.external_access_port}},
+          {{/networking.external_access.enable}}
           "protocol": "tcp",
           "name": "mysql",
           "labels": {
@@ -57,8 +60,11 @@
   },
   {{#networking.host_mode}}
   "portDefinitions": [{
-      "protocol": "tcp",
       "port": 3306,
+      {{#networking.external_access.enable}}
+      "servicePort": {{networking.external_access.external_access_port}},
+      {{/networking.external_access.enable}}
+      "protocol": "tcp",
       "name": "mysql",
       "labels": {
         "VIP_0": "/{{service.name}}:{{networking.port}}"
@@ -83,6 +89,9 @@
   "labels": {
     "DCOS_PACKAGE_VERSION": "10.1.21",
     "DCOS_SERVICE_NAME": "{{service.name}}",
+    {{#networking.external_access.enable}}
+    "HAPROXY_GROUP": "external",
+    {{/networking.external_access.enable}}
     "MARATHON_SINGLE_INSTANCE_APP":"true",
     "DCOS_PACKAGE_IS_FRAMEWORK": "false"
   },

--- a/repo/packages/M/mariadb/3/marathon.json.mustache
+++ b/repo/packages/M/mariadb/3/marathon.json.mustache
@@ -87,7 +87,7 @@
     "maxConsecutiveFailures": 3
   }],
   "labels": {
-    "DCOS_PACKAGE_VERSION": "10.1.21",
+    "DCOS_PACKAGE_VERSION": "10.1.22",
     "DCOS_SERVICE_NAME": "{{service.name}}",
     {{#networking.external_access.enable}}
     "HAPROXY_GROUP": "external",

--- a/repo/packages/M/mariadb/3/package.json
+++ b/repo/packages/M/mariadb/3/package.json
@@ -1,0 +1,20 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.8",
+  "name": "mariadb",
+  "version": "10.1.22",
+  "scm": "https://github.com/MariaDB/server.git",
+  "maintainer": "kevin@fat.sh",
+  "website": "https://mariadb.org",
+  "description": "MariaDB is one of the most popular database servers in the world. It’s made by the original developers of MySQL and guaranteed to stay open source. Notable users include Wikipedia, Facebook and Google. MariaDB is developed as open source software and as a relational database it provides an SQL interface for accessing data. The latest versions of MariaDB also include GIS and JSON features.",
+  "tags": ["database", "mysql", "mariadb", "sql"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production! In order for MariaDB service to start successfully it requires atleast 1 CPU and 1024MB of RAM including ports.\n\nIf you didn't provide a value for `host_volume` in the CLI,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n",
+  "postInstallNotes": "Service installed.\n\nDefault login: `admin`/`password`.",
+  "postUninstallNotes": "MariaDB has been uninstalled. Note that any data persisted to a NFS share still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "GNU GENERAL PUBLIC LICENSE",
+      "url": "https://github.com/MariaDB/server/blob/10.1/COPYING"
+    }
+  ]
+}

--- a/repo/packages/M/mariadb/3/resource.json
+++ b/repo/packages/M/mariadb/3/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://cloud.githubusercontent.com/assets/410147/17726269/936fd07a-646f-11e6-8ffa-ff3d0a1b4b15.png",
+    "icon-medium": "https://cloud.githubusercontent.com/assets/410147/17726265/919cbaf6-646f-11e6-8f3c-114245c4b7f4.png",
+    "icon-large": "https://cloud.githubusercontent.com/assets/410147/17726266/919d81ca-646f-11e6-8c7c-7bc91c11d1f5.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "mariadb-docker": "mariadb:10.1.21"
+      }
+    }
+  }
+}

--- a/repo/packages/M/mariadb/3/resource.json
+++ b/repo/packages/M/mariadb/3/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "mariadb-docker": "mariadb:10.1.21"
+        "mariadb-docker": "mariadb:10.1.22"
       }
     }
   }


### PR DESCRIPTION
Hi guys,

What I've done:
- [x] Use official MariaDB docker image
- [x] MariaDB version ~~10.1.21~~ 10.1.22
- [x] Cleanup configuration (based on MySQL)
- [x] Persistant volume
- [x] External access

What is coming in another PR:
- [Galera cluster](https://github.com/tuxity/universe/compare/mariadb-10.1.21...tuxity:mariadb-galera?expand=1) 

I'm using it since few weeks now, and it's working well. I hope I didn't forget something.