### PR TITLE
Update resource URL's

### DIFF
--- a/repo/packages/V/vamp/3/package.json
+++ b/repo/packages/V/vamp/3/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "3.0",
   "minDcosReleaseVersion": "1.8",
   "name": "vamp",
-  "version": "0.9.3-0.0.1",
+  "version": "0.9.3-0.0.2",
   "website": "http://vamp.io/",
   "scm": "https://github.com/magneticio/vamp.git",
   "maintainer": "vamp@magnetic.io",

--- a/repo/packages/V/vamp/3/resource.json
+++ b/repo/packages/V/vamp/3/resource.json
@@ -1,10 +1,10 @@
 {
   "images": {
-    "icon-small": "http://vamp.io/images/dcos_universe/icon-vamp-small.png",
-    "icon-medium": "http://vamp.io/images/dcos_universe/icon-vamp-medium.png",
-    "icon-large": "http://vamp.io/images/dcos_universe/icon-vamp-large.png",
+    "icon-small": "https://raw.githubusercontent.com/magneticio/vamp.io/master/images/dcos_universe/icon-vamp-small.png",
+    "icon-medium": "https://raw.githubusercontent.com/magneticio/vamp.io/master/images/dcos_universe/icon-vamp-medium.png",
+    "icon-large": "https://raw.githubusercontent.com/magneticio/vamp.io/master/images/dcos_universe/icon-vamp-large.png",
     "screenshots": [
-      "http://vamp.io/images/dcos_universe/screenshot-vamp-dcos.png"
+      "https://raw.githubusercontent.com/magneticio/vamp.io/master/images/dcos_universe/screenshot-vamp-dcos.png"
     ]
   },
   "assets": {

--- a/repo/packages/V/vamp/3/resource.json
+++ b/repo/packages/V/vamp/3/resource.json
@@ -1,10 +1,10 @@
 {
   "images": {
-    "icon-small": "https://raw.githubusercontent.com/magneticio/vamp.io/master/images/dcos_universe/icon-vamp-small.png",
-    "icon-medium": "https://raw.githubusercontent.com/magneticio/vamp.io/master/images/dcos_universe/icon-vamp-medium.png",
-    "icon-large": "https://raw.githubusercontent.com/magneticio/vamp.io/master/images/dcos_universe/icon-vamp-large.png",
+    "icon-small": "https://raw.githubusercontent.com/magneticio/vamp.io/master/static/images/dcos_universe/icon-vamp-small.png",
+    "icon-medium": "https://raw.githubusercontent.com/magneticio/vamp.io/master/static/images/dcos_universe/icon-vamp-medium.png",
+    "icon-large": "https://raw.githubusercontent.com/magneticio/vamp.io/master/static/images/dcos_universe/icon-vamp-large.png",
     "screenshots": [
-      "https://raw.githubusercontent.com/magneticio/vamp.io/master/images/dcos_universe/screenshot-vamp-dcos.png"
+      "https://raw.githubusercontent.com/magneticio/vamp.io/master/static/images/dcos_universe/screenshot-vamp-dcos.png"
     ]
   },
   "assets": {


### PR DESCRIPTION
Pointing the URL's to the raw.githubusercontent.com instead as it has
HTTPS enabled. Doing this will prevent browsers from displaying
warnings about accessing mixed content when people are browsing the
Universe through the DC/OS UI and have HTTPS enabled.