### PR TITLE
Update package.json

### DIFF
--- a/repo/packages/M/marathon/8/package.json
+++ b/repo/packages/M/marathon/8/package.json
@@ -2,7 +2,7 @@
   "packagingVersion" : "3.0",
   "name" : "marathon",
   "version" : "1.4.1",
-  "minDcosReleaseVersion" : "1.8",
+  "minDcosReleaseVersion" : "1.9",
   "scm" : "https://github.com/mesosphere/marathon.git",
   "maintainer" : "support@mesosphere.io",
   "description" : "A container orchestration platform for Mesos and DCOS.",


### PR DESCRIPTION
Marathon 1.4.1 should be only available on dc/os 1.9 or newer to ensure PODs are working correctly