### PR TITLE
Shorten description for Jenkins

### DIFF
--- a/repo/packages/J/jenkins/9/package.json
+++ b/repo/packages/J/jenkins/9/package.json
@@ -6,7 +6,7 @@
   "maintainer": "support@mesosphere.io",
   "website": "https://jenkins.io",
   "framework": true,
-  "description": "Jenkins is an award-winning, cross-platform, continuous integration and continuous delivery application that increases your productivity. Use Jenkins to build and test your software projects continuously making it easier for developers to integrate changes to the project, and making it easier for users to obtain a fresh build. It also allows you to continuously deliver your software by providing powerful ways to define your build pipelines and integrating with a large number of testing and deployment technologies.",
+  "description": "Continuous integration server (https://jenkins.io)",
   "tags": ["continuous-integration", "ci", "jenkins"],
   "preInstallNotes": "WARNING: If you didn't provide a value for `host-volume` in the CLI,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n",
   "postInstallNotes": "Jenkins has been installed.",


### PR DESCRIPTION
so it doesn't blow out the length of the description field when doing `dcos package list` -- e.g.:

```
$ dcos package list
NAME               VERSION       APP                 COMMAND     DESCRIPTION
flight-director    1.14.0        /flight-director    ---         Ethos platform API for container deployments


httpbin            1.0.0         /httpbin            ---         HTTP Request & Response Service


iam-role-iptables  1.0.1         /iam-role-iptables  ---         AWS IAM role proxy IPTABLES


iam-role-proxy     1.3.0.1       /iam-role-proxy     ---         AWS IAM role proxy utility


jenkins            3.0.2-2.32.2  /jenkins            ---         Jenkins is an award-winning, cross-platform, continuous integration and continuous delivery application that increases your productivity. Use Jenkins to build and test your software projects continuously making it easier for developers to integrate changes to the project, and making it easier for users to obtain a fresh build. It also allows you to continuously deliver your software by providing powerful ways to define your build pipelines and integrating with a large number of testing and deployment technologies.
```