### PR TITLE
Add content_type file generation to gen_universe.py

### DIFF
--- a/scripts/gen-universe.py
+++ b/scripts/gen-universe.py
@@ -109,20 +109,22 @@ def render_content_type_file_by_version(outdir, version):
 
 
 def create_content_type_file(path, universe_version):
-    """
+    """ Creates a file with universe repo version `universe_version` content-type
+    as its contents.
 
-    :param path:
-    :param universe_version:
-    :return:
+    :param path: the name of the content-type file
+    :type path: str
+    :param universe_version: Universe content type version: "v3" or "v4"
+    :type universe_version: str
+    :rtype: None
     """
     with path.open('w', encoding='utf-8') as ct_file:
         content_type = format_universe_repo_content_type(universe_version)
         ct_file.write(content_type)
 
 
-
 def format_universe_repo_content_type(universe_version):
-    """
+    """ Formats a universe repo content-type of version `universe-version`
 
     :param universe_version: Universe content type version: "v3" or "v4"
     :type universe_version: str

--- a/scripts/gen-universe.py
+++ b/scripts/gen-universe.py
@@ -59,7 +59,7 @@ def main():
     ct_universe_path = args.outdir / 'universe.content_type'
     with ct_universe_path.open('w', encoding='utf-8') as ct_universe_file:
         ct_universe_file.write(
-            "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v4"
+            format_universe_repo_content_type("v4")
         )
 
     # Render empty json
@@ -70,7 +70,7 @@ def main():
     ct_empty_path = args.outdir / 'repo-empty-v3.content_type'
     with ct_empty_path.open('w', encoding='utf-8') as ct_empty_file:
         ct_empty_file.write(
-            "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3"
+            format_universe_repo_content_type("v3")
         )
 
     # create universe-by-version files for `dcos_versions`
@@ -111,14 +111,26 @@ def render_content_type_file_by_version(outdir, version):
 
     universe_version = \
         "v3" if LooseVersion(version) < LooseVersion("1.10") else "v4"
-    content_type = "application/" \
-                   "vnd.dcos.universe.repo+json;" \
-                   "charset=utf-8;version=" \
-                   + universe_version
+    content_type = format_universe_repo_content_type(universe_version)
     ct_file_path = \
         outdir / 'repo-up-to-{}.content_type'.format(version)
     with ct_file_path.open('w', encoding='utf-8') as ct_file:
         ct_file.write(content_type)
+
+
+def format_universe_repo_content_type(universe_version):
+    """
+
+    :param universe_version: Universe content type version: "v3" or "v4"
+    :type universe_version: str
+    :return: content-type of the universe repo version `universe_version`
+    :rtype: str
+    """
+    content_type = "application/" \
+                   "vnd.dcos.universe.repo+json;" \
+                   "charset=utf-8;version=" \
+                   + universe_version
+    return content_type
 
 
 def render_json_by_version(outdir, packages, version):

--- a/scripts/gen-universe.py
+++ b/scripts/gen-universe.py
@@ -55,23 +55,15 @@ def main():
     universe_path = args.outdir / 'universe.json'
     with universe_path.open('w', encoding='utf-8') as universe_file:
         json.dump({'packages': packages}, universe_file)
-
     ct_universe_path = args.outdir / 'universe.content_type'
-    with ct_universe_path.open('w', encoding='utf-8') as ct_universe_file:
-        ct_universe_file.write(
-            format_universe_repo_content_type("v4")
-        )
+    create_content_type_file(ct_universe_path, "v4")
 
     # Render empty json
     empty_path = args.outdir / 'repo-empty-v3.json'
     with empty_path.open('w', encoding='utf-8') as universe_file:
         json.dump({'packages': []}, universe_file)
-
     ct_empty_path = args.outdir / 'repo-empty-v3.content_type'
-    with ct_empty_path.open('w', encoding='utf-8') as ct_empty_file:
-        ct_empty_file.write(
-            format_universe_repo_content_type("v3")
-        )
+    create_content_type_file(ct_empty_path, "v3")
 
     # create universe-by-version files for `dcos_versions`
     dcos_versions = ["1.6.1", "1.7", "1.8", "1.9", "1.10"]
@@ -111,11 +103,22 @@ def render_content_type_file_by_version(outdir, version):
 
     universe_version = \
         "v3" if LooseVersion(version) < LooseVersion("1.10") else "v4"
-    content_type = format_universe_repo_content_type(universe_version)
     ct_file_path = \
         outdir / 'repo-up-to-{}.content_type'.format(version)
-    with ct_file_path.open('w', encoding='utf-8') as ct_file:
+    create_content_type_file(ct_file_path, universe_version)
+
+
+def create_content_type_file(path, universe_version):
+    """
+
+    :param path:
+    :param universe_version:
+    :return:
+    """
+    with path.open('w', encoding='utf-8') as ct_file:
+        content_type = format_universe_repo_content_type(universe_version)
         ct_file.write(content_type)
+
 
 
 def format_universe_repo_content_type(universe_version):

--- a/scripts/gen-universe.py
+++ b/scripts/gen-universe.py
@@ -59,7 +59,7 @@ def main():
     ct_universe_path = args.outdir / 'universe.content_type'
     with ct_universe_path.open('w', encoding='utf-8') as ct_universe_file:
         ct_universe_file.write(
-            "application/nd.dcos.universe.repo+json;charset=utf-8;version=v4"
+            "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v4"
         )
 
     # Render empty json
@@ -70,7 +70,7 @@ def main():
     ct_empty_path = args.outdir / 'repo-empty-v3.content_type'
     with ct_empty_path.open('w', encoding='utf-8') as ct_empty_file:
         ct_empty_file.write(
-            "application/nd.dcos.universe.repo+json;charset=utf-8;version=v3"
+            "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3"
         )
 
     # create universe-by-version files for `dcos_versions`

--- a/scripts/gen-universe.py
+++ b/scripts/gen-universe.py
@@ -56,10 +56,22 @@ def main():
     with universe_path.open('w', encoding='utf-8') as universe_file:
         json.dump({'packages': packages}, universe_file)
 
+    ct_universe_path = args.outdir / 'universe.content_type'
+    with ct_universe_path.open('w', encoding='utf-8') as ct_universe_file:
+        ct_universe_file.write(
+            "application/nd.dcos.universe.repo+json;charset=utf-8;version=v4"
+        )
+
     # Render empty json
     empty_path = args.outdir / 'repo-empty-v3.json'
     with empty_path.open('w', encoding='utf-8') as universe_file:
         json.dump({'packages': []}, universe_file)
+
+    ct_empty_path = args.outdir / 'repo-empty-v3.content_type'
+    with ct_empty_path.open('w', encoding='utf-8') as ct_empty_file:
+        ct_empty_file.write(
+            "application/nd.dcos.universe.repo+json;charset=utf-8;version=v3"
+        )
 
     # create universe-by-version files for `dcos_versions`
     dcos_versions = ["1.6.1", "1.7", "1.8", "1.9", "1.10"]
@@ -84,6 +96,29 @@ def render_universe_by_version(outdir, packages, version):
         render_zip_universe_by_version(outdir, packages, version)
     else:
         render_json_by_version(outdir, packages, version)
+        render_content_type_file_by_version(outdir, version)
+
+
+def render_content_type_file_by_version(outdir, version):
+    """Render content type file for `version`
+
+    :param outdir: Path to the directory to use to store all universe objects
+    :type outdir: str
+    :param version: DC/OS version
+    :type version: str
+    :rtype: None
+    """
+
+    universe_version = \
+        "v3" if LooseVersion(version) < LooseVersion("1.10") else "v4"
+    content_type = "application/" \
+                   "vnd.dcos.universe.repo+json;" \
+                   "charset=utf-8;version=" \
+                   + universe_version
+    ct_file_path = \
+        outdir / 'repo-up-to-{}.content_type'.format(version)
+    with ct_file_path.open('w', encoding='utf-8') as ct_file:
+        ct_file.write(content_type)
 
 
 def render_json_by_version(outdir, packages, version):


### PR DESCRIPTION
This PR will make it so that for each universe json file we generate, we also generate a corresponding `.content_type` file of the same name, but with the extension `.content_type`. These content type files will hold the content type of the universe json file. For example the universe json file `repo-up-to-1.9.json`, will have a corresponding `repo-up-to-1.9.content_type` file with contents `application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3`.