### PR TITLE
Add v4 package documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ Every package in Universe must have a `package.json` file which specifies the hi
 Currently, a package can specify one of three values for `.packagingVersion`
 either `2.0` or `3.0` or `4.0`; which version is declared
 will dictate which other files are required for the complete package as well as the schema(s) all the files must
-adhere to. Below is a snippet that represents a version `2.0` package.
+adhere to. Below is a snippet that represents a version `4.0` package.
 
 See [`repo/meta/schema/package-schema.json`](repo/meta/schema/package-schema.json) for the full json schema outlining
 what properties are available for each corresponding version of a package.
 
 ```json
 {
-  "packagingVersion": "2.0",
+  "packagingVersion": "4.0",
   "name": "foo",
   "version": "1.2.3",
   "tags": ["mesosphere", "framework"],
@@ -101,6 +101,9 @@ what properties are available for each corresponding version of a package.
   "scm": "https://github.com/bar/foo.git",
   "website": "http://bar.io/foo",
   "framework": true,
+  "upgradesFrom": ["1.2.2"],
+  "downgradesTo": ["1.2.2"],
+  "minDcosReleaseVersion": "1.10",
   "postInstallNotes": "Have fun foo-ing and baz-ing!"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -78,10 +78,12 @@ the package.
 |-----------------|---|
 |2.0|required|
 |3.0|required|
+|4.0|required|
 
 Every package in Universe must have a `package.json` file which specifies the high level metadata about the package.
 
-Currently, a package can specify one of two values for `.packagingVersion` either `2.0` or `3.0`; which version is declared
+Currently, a package can specify one of three values for `.packagingVersion`
+either `2.0` or `3.0` or `4.0`; which version is declared
 will dictate which other files are required for the complete package as well as the schema(s) all the files must
 adhere to. Below is a snippet that represents a version `2.0` package.
 
@@ -110,6 +112,7 @@ For the first version of the package, add this line to the beginning of `preInst
 |-----------------|---|
 |2.0|not supported|
 |3.0|optional|
+|4.0|optional|
 
 Introduced in `packagingVersion` `3.0`, `.minDcosReleaseVersion` can be specified as a property of `package.json`.
 When `.minDcosReleaseVersion` is specified the package will only be made available to DC/OS clusters with a DC/OS
@@ -117,11 +120,38 @@ Release Version greater than or equal to (`>=`) the value specified.
 
 For example, `"minDcosReleaseVersion" : "1.8"` will prevent the package from being installed on clusters older than DC/OS 1.8.
 
+###### `.upgradesFrom`
+|Packaging Version|   |
+|-----------------|---|
+|2.0|not supported|
+|3.0|not supported|
+|4.0|optional|
+
+Introduced in `packagingVersion` `4.0`, `.upgradesFrom` can be specified as a property of `package.json`.
+When `.upgradesFrom` is specified this indicates to users that the package is able to upgrade from any of
+the versions listed in the property. It is the resposibility of the package creator to make sure that this
+is indeed the case. If this property is set then `minDcosReleaseVersion` must be set to `1.10`
+or higher.
+
+###### `.downgradeTo`
+|Packaging Version|   |
+|-----------------|---|
+|2.0|not supported|
+|3.0|not supported|
+|4.0|optional|
+
+Introduced in `packagingVersion` `4.0`, `.downgradeTo` can be specified as a property of `package.json`.
+When `.downgradeTo` is specified this indicates to users that the package is able to downgrade to any of
+the versions listed in the property. It is the resposibility of the package creator to make sure that this
+is indeed the case. If this property is set then `minDcosReleaseVersion` must be set to `1.10`
+or higher.
+
 #### `config.json`
 |Packaging Version|   |
 |-----------------|---|
 |2.0|optional|
 |3.0|optional|
+|4.0|optional|
 
 This file describes the configuration properties supported by the package, represented as a
 [json-schema](http://spacetelescope.github.io/understanding-json-schema/). Each property can specify whether or not it
@@ -160,6 +190,7 @@ DC/OS UI (since DC/OS 1.7).
 |-----------------|---|
 |2.0|required|
 |3.0|optional|
+|4.0|optional|
 
 This file is a [mustache template](http://mustache.github.io/) that when rendered will create a
 [Marathon](http://github.com/mesosphere/marathon) app definition capable of running your service.
@@ -207,6 +238,7 @@ for more detailed instruction on app definitions.
 |-----------------|---|
 |2.0|optional|
 |3.0|optional **[Deprecated]**|
+|4.0|not supported|
 
 As of `packagingVersion` `3.0`, `command.json` is deprecated in favor of the `.cli` property of `resource.json`.
 See [CLI Resources](#cli-resources) for details.
@@ -227,6 +259,7 @@ format of a Pip requirements file where each element in the array is a line in t
 |-----------------|---|
 |2.0|optional|
 |3.0|optional|
+|4.0|optional|
 
 This file contains all of the externally hosted resources (E.g. Docker images, HTTP objects and
 images) needed to install the application.
@@ -286,6 +319,7 @@ alternate image named `icon-cassandra-small@2x.png`.
 |-----------------|---|
 |2.0|not supported|
 |3.0|optional|
+|4.0|optional|
 
 The new `.cli` property allows for a package to configure native CLI subcommands for several platforms and
 architectures.

--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ For example, `"minDcosReleaseVersion" : "1.8"` will prevent the package from bei
 Introduced in `packagingVersion` `4.0`, `.upgradesFrom` can be specified as a property of `package.json`.
 When `.upgradesFrom` is specified this indicates to users that the package is able to upgrade from any of
 the versions listed in the property. It is the resposibility of the package creator to make sure that this
-is indeed the case. If this property is set then `minDcosReleaseVersion` must be set to `1.10`
-or higher.
+is indeed the case.
 
 ###### `.downgradeTo`
 |Packaging Version|   |
@@ -146,8 +145,7 @@ or higher.
 Introduced in `packagingVersion` `4.0`, `.downgradeTo` can be specified as a property of `package.json`.
 When `.downgradeTo` is specified this indicates to users that the package is able to downgrade to any of
 the versions listed in the property. It is the resposibility of the package creator to make sure that this
-is indeed the case. If this property is set then `minDcosReleaseVersion` must be set to `1.10`
-or higher.
+is indeed the case.
 
 #### `config.json`
 |Packaging Version|   |
@@ -256,6 +254,9 @@ format of a Pip requirements file where each element in the array is a line in t
   ]
 }
 ```
+
+Packaging version 4.0 does not support command.json. The presence of command.json in the
+directory will fail the universe validation.
 
 #### `resource.json`
 |Packaging Version|   |


### PR DESCRIPTION
DCOS 1.10 will support a new universe version (v4). Which contains a new packaging format (v4). This PR updates the universe readme with information about this new packaging format. 

This is here for review purposes only. We do not intend to merge this until DC/OS 1.10 is released.