### PR TITLE
Make server return correct content type for DC/OS 1.10

### DIFF
--- a/docker/local-universe/default.conf
+++ b/docker/local-universe/default.conf
@@ -14,6 +14,12 @@ server {
 
   if ($http_accept = "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3") {
     set $serve_json true;
+    set $universe_version v3;
+  }
+
+  if ($http_accept = "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v4") {
+    set $serve_json true;
+    set $universe_version v4;
   }
 
   if ($http_user_agent ~ ".*dcos\/1\.8.*") {
@@ -50,15 +56,34 @@ server {
 
   location = /repo {
     types {
-      "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3" json;
       application/zip zip;
     }
 
-    if ($serve_json = true) {
-      rewrite ^/repo$ /repo-up-to-$dcos_release_version.json break;
+    if ($universe_version = v3) {
+      rewrite ^/repo$ /v3;
+    }
+
+    if ($universe_version = v4) {
+      rewrite ^/repo$ /v4;
     }
 
     rewrite ^/repo$ /repo-up-to-$dcos_release_version.zip break;
+  }
+
+  location = /v3 {
+    internal;
+    types {
+      "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3" json;
+    }
+    rewrite ^/v3$ /repo-up-to-$dcos_release_version.json break;
+  }
+
+  location = /v4 {
+    internal;
+    types {
+      "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v4" json;
+    }
+    rewrite ^/v4$ /repo-up-to-$dcos_release_version.json break;
   }
 
 }

--- a/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
+++ b/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
@@ -69,6 +69,7 @@ server {
   }
 
   location = /v3 {
+    internal;
     types {
       "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3" json;
     }
@@ -76,6 +77,7 @@ server {
   }
 
   location = /v4 {
+    internal;
     types {
       "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v4" json;
     }

--- a/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
+++ b/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
@@ -12,6 +12,12 @@ server {
 
   if ($http_accept = "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3") {
     set $serve_json true;
+    set $universe_version v3;
+  }
+
+  if ($http_accept = "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v4") {
+    set $serve_json true;
+    set $universe_version v4;
   }
 
   if ($http_user_agent ~ ".*dcos\/1\.8.*") {
@@ -48,15 +54,32 @@ server {
 
   location = /repo {
     types {
-      "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3" json;
       application/zip zip;
     }
 
-    if ($serve_json = true) {
-      rewrite ^/repo$ /repo-up-to-$dcos_release_version.json break;
+    if ($universe_version = v3) {
+      rewrite ^/repo$ /v3;
+    }
+
+    if ($universe_version = v4) {
+      rewrite ^/repo$ /v4;
     }
 
     rewrite ^/repo$ /repo-up-to-$dcos_release_version.zip break;
+  }
+
+  location = /v3 {
+    types {
+      "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3" json;
+    }
+    rewrite ^/v3$ /repo-up-to-$dcos_release_version.json break;
+  }
+
+  location = /v4 {
+    types {
+      "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v4" json;
+    }
+    rewrite ^/v4$ /repo-up-to-$dcos_release_version.json break;
   }
 
 }


### PR DESCRIPTION
This PR updates the nginx conf for the universe-server. The universe-server is a docker image that we generate on every PR, so that package developers can have a test universe with their package in it.

This change is necessary so that the universe server returns the correct universe version for DCOS clusters of version 1.10. In 1.10 we have created a new packaging format, which means a new universe version. (v4)