### PR TITLE
Add dcos-autoscaler package

### DIFF
--- a/repo/packages/D/dcos-autoscaler/0/config.json
+++ b/repo/packages/D/dcos-autoscaler/0/config.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "cpu": {
+      "type": "integer",
+      "description": "cpu to allocate to the container",
+      "minimum": 0.3,
+      "maximum": 16,
+      "default": 1
+    },
+    "memory": {
+      "type": "integer",
+      "description": "Memory to allocate",
+      "minimum": 500,
+      "maximum": 9999,
+      "default": 1024
+    }
+  }
+}

--- a/repo/packages/D/dcos-autoscaler/0/marathon.json.mustache
+++ b/repo/packages/D/dcos-autoscaler/0/marathon.json.mustache
@@ -1,0 +1,12 @@
+{
+  "id": "/dcos-autoscaler",
+  "cpus": "{{cpu}}",
+  "mem": "{{memory}}",
+  "instances": "1",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.23b1cfe8e04a}}"
+    }
+  }
+}

--- a/repo/packages/D/dcos-autoscaler/0/package.json
+++ b/repo/packages/D/dcos-autoscaler/0/package.json
@@ -1,11 +1,13 @@
 {
   "packagingVersion": "3.0",
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production!",
   "name": "dcos-autoscaler",
   "version": "1.0.0",
   "maintainer": "ahmadhassan612@gmail.com",
-  "description": "Adds autoscaling to your application based on cpu and memory metrics",
+  "description": "Autoscaling to your application based on cpu and memory metrics. Through marathon labels this package enables setting multiple rules to scale services up or down based on cpu/memory utilization.",
   "scm": "https://github.com/Ahmadposten/DC-OS-Marathon-autoscaling",
-  "framework": true,
-  "tags": ["autoscaling", "mesosphere", "dcos"],
+  "framework": false,
+  "tags": ["autoscaling", "dcos"],
+  "license": "BSD3",
   "postInstallNotes": "Thank you for installing dcos autoscaler, Consult github.com/Ahmadposten/DC-OS-Marathon-autoscaling for more more info on usage and tuning configurations"
 }

--- a/repo/packages/D/dcos-autoscaler/0/package.json
+++ b/repo/packages/D/dcos-autoscaler/0/package.json
@@ -1,0 +1,11 @@
+{
+  "packagingVersion": "3.0",
+  "name": "dcos-autoscaler",
+  "version": "1.0.0",
+  "maintainer": "ahmadhassan612@gmail.com",
+  "description": "Adds autoscaling to your application based on cpu and memory metrics",
+  "scm": "https://github.com/Ahmadposten/DC-OS-Marathon-autoscaling",
+  "framework": true,
+  "tags": ["autoscaling", "mesosphere", "dcos"],
+  "postInstallNotes": "Thank you for installing dcos autoscaler, Consult github.com/Ahmadposten/DC-OS-Marathon-autoscaling for more more info on usage and tuning configurations"
+}

--- a/repo/packages/D/dcos-autoscaler/0/resource.json
+++ b/repo/packages/D/dcos-autoscaler/0/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "23b1cfe8e04a": "ahmadposten/dcos-autoscaler"
+        "23b1cfe8e04a": "ahmadposten/dcos-autoscaler:1.0.0"
       }
     }
   }

--- a/repo/packages/D/dcos-autoscaler/0/resource.json
+++ b/repo/packages/D/dcos-autoscaler/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://drive.google.com/open?id=0BxADtivbfBMNd0VBbThQNmtkcUE",
+    "icon-medium": "https://drive.google.com/open?id=0BxADtivbfBMNd0VBbThQNmtkcUE",
+    "icon-large": "https://drive.google.com/open?id=0BxADtivbfBMNd0VBbThQNmtkcUE"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "23b1cfe8e04a": "ahmadposten/dcos-autoscaler"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adding package dcos-autoscaler to universe.

This package provides service autoscaling based on cpu or memory. Every app autoscaling behavior is configurable using labels similar to how marathon load balancer works.