### PR TITLE
tunnel-cli: Bump to version 2.0.0

### DIFF
--- a/repo/packages/T/tunnel-cli/8/package.json
+++ b/repo/packages/T/tunnel-cli/8/package.json
@@ -1,0 +1,9 @@
+{
+  "packagingVersion": "3.0",
+  "name": "tunnel-cli",
+  "version": "1.0.2",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.8",
+  "description": "Proxy and VPN access to your DC/OS cluster",
+  "tags": [ "mesosphere", "subcommand", "proxy", "vpn", "socks", "http", "cli" ]
+}

--- a/repo/packages/T/tunnel-cli/8/package.json
+++ b/repo/packages/T/tunnel-cli/8/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "tunnel-cli",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "maintainer": "support@mesosphere.io",
   "minDcosReleaseVersion": "1.8",
   "description": "Proxy and VPN access to your DC/OS cluster",

--- a/repo/packages/T/tunnel-cli/8/resource.json
+++ b/repo/packages/T/tunnel-cli/8/resource.json
@@ -1,0 +1,30 @@
+{
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "315b75e63dfaefe95f4240b36ca5f5b1e0680736a630a733df89b0691e0ad841"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/1.0.2/dcos-tunnel.zip"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "077964f307ec44d668b850159a19c443ebf896629f75beef1c1f3f35d02f8635"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/1.0.2/dcos-tunnel.zip"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/T/tunnel-cli/8/resource.json
+++ b/repo/packages/T/tunnel-cli/8/resource.json
@@ -6,11 +6,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "315b75e63dfaefe95f4240b36ca5f5b1e0680736a630a733df89b0691e0ad841"
+                            "value": "1ad7b01849eb3c6fc0249a55551555158378c2e4f4ded2c51ea4dcc7bd770cc8"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/1.0.2/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/2.0.0/dcos-tunnel.zip"
                 }
             },
             "linux": {
@@ -18,11 +18,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "077964f307ec44d668b850159a19c443ebf896629f75beef1c1f3f35d02f8635"
+                            "value": "e1dd0821f75b1ba6c9638b2f3007b00c755d28a299357c9a786c419656f80cf4"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/1.0.2/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/2.0.0/dcos-tunnel.zip"
                 }
             }
         }


### PR DESCRIPTION
This includes changes that allow dcos-tunnel to work with DC/OS 1.9
octarine while retaining backwards compatibility with DC/OS 1.8