### PR TITLE
Remove LD_LIBRARY_PATH variable and reduce the minVersion back to 1.8.

### DIFF
--- a/repo/packages/J/jenkins/17/marathon.json.mustache
+++ b/repo/packages/J/jenkins/17/marathon.json.mustache
@@ -39,7 +39,7 @@
            "image": "{{advanced.docker-image}}",
        {{/advanced.docker-image}}
        {{^advanced.docker-image}}
-           "image": "{{resource.assets.container.docker.jenkins-302-2322}}",
+           "image": "{{resource.assets.container.docker.jenkins-303-2323}}",
        {{/advanced.docker-image}}
            "network" : "HOST"
        },

--- a/repo/packages/J/jenkins/17/marathon.json.mustache
+++ b/repo/packages/J/jenkins/17/marathon.json.mustache
@@ -19,7 +19,6 @@
           "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
           "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
       {{/security.secret-name}}
-      "LD_LIBRARY_PATH": "/libmesos-bundle/lib:/libmesos-bundle/lib/mesos",
       "JENKINS_CONTEXT": "/service/{{service.name}}",
       "JENKINS_MESOS_MASTER": "{{advanced.mesos-master}}",
       {{#networking.virtual-host}}

--- a/repo/packages/J/jenkins/17/package.json
+++ b/repo/packages/J/jenkins/17/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "jenkins",
-  "version": "3.0.3-2.32.2",
+  "version": "3.0.3-2.32.3",
   "minDcosReleaseVersion": "1.8",
   "scm": "https://github.com/mesosphere/dcos-jenkins-service.git",
   "maintainer": "support@mesosphere.io",

--- a/repo/packages/J/jenkins/17/package.json
+++ b/repo/packages/J/jenkins/17/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "3.0",
   "name": "jenkins",
   "version": "3.0.3-2.32.2",
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.8",
   "scm": "https://github.com/mesosphere/dcos-jenkins-service.git",
   "maintainer": "support@mesosphere.io",
   "website": "https://jenkins.io",

--- a/repo/packages/J/jenkins/17/resource.json
+++ b/repo/packages/J/jenkins/17/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "jenkins-302-2322": "mesosphere/jenkins:3.0.2-2.32.2"
+        "jenkins-302-2322": "mesosphere/jenkins:3.0.3-2.32.3"
       }
     }
   }

--- a/repo/packages/J/jenkins/17/resource.json
+++ b/repo/packages/J/jenkins/17/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "jenkins-302-2322": "mesosphere/jenkins:3.0.3-2.32.3"
+        "jenkins-303-2323": "mesosphere/jenkins:3.0.3-2.32.3"
       }
     }
   }


### PR DESCRIPTION
This solves a bug where the executor's LD_LIBRARY_PATH on DC/OS 1.8.8 would be improperly overwritten by the variable we had set in the marathon.json for Jenkins. This would cause Jenkins to fail to start on operating systems where libssl was not present in the system's PATH (e.g. CentOS but not CoreOS). 

This variable is no longer necessary - it is a legacy configuration option that we exposed to allow users to run this Jenkins package on non DC/OS Mesos clusters. Given that the Universe does not support non DC/OS clusters anymore, this is not a use case we need to support anymore.

Merge after: https://github.com/mesosphere/dcos-jenkins-service/pull/138 is merged and a new version of the Jenkins Docker image is released.