### PR TITLE
Improve support for Schema Registry in DC/OS

### DIFF
--- a/repo/packages/C/confluent-schema-registry/6/config.json
+++ b/repo/packages/C/confluent-schema-registry/6/config.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "registry": {
+      "properties": {
+        "name": {
+          "default": "schema-registry",
+          "description": "Service name for the schema-registry instance(s)",
+          "type": "string"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run (currently limited to 1).",
+          "minimum": 1,
+          "maximum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each schema-registry instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 512,
+          "description": "Memory (MB) to allocate to each schema-registry instance.",
+          "minimum": 320,
+          "type": "number"
+        },
+        "heap": {
+          "default": 256,
+          "description": "JVM heap allocation (in MB) for connect worker task; should be no greater than ~64MB less than total memory for the instance.",
+          "minimum": 256,
+          "type": "number"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy schema-registry only on nodes with this role.",
+          "type": "string"
+        },
+        "zookeeper-master": {
+          "default": "master.mesos:2181",
+          "description": "Zookeeper Connect string for service cluster. Format limited to single target: <zk-host>:<zkport>",
+          "type": "string"
+        },
+        "kafkastore": {
+          "default": "dcos-service-confluent-kafka",
+          "description": "Name of the Kafka service hosting the storage for this Schema Registry edition.",
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-schema-registry/6/marathon.json.mustache
+++ b/repo/packages/C/confluent-schema-registry/6/marathon.json.mustache
@@ -1,0 +1,56 @@
+{
+  "id": "/{{registry.name}}",
+  "instances": {{registry.instances}},
+  "cpus": {{registry.cpus}},
+  "mem": {{registry.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.image}}",
+      "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [ {
+          "containerPort": 8081,
+          "hostPort": 0,
+          "protocol": "tcp",
+          "labels": {
+            "VIP_0": "{{registry.name}}:8081"
+          }
+      } ]
+    }
+  },
+  "portDefinitions": [ {
+    "name": "{{registry.name}}",
+    "port": 8081,
+    "protocol": "tcp",
+    "labels": {
+      "VIP_0": "{{registry.name}}:8081"
+    }
+  } ],
+  "env": {
+    "SCHEMA_REGISTRY_HEAP_OPTS": "-Xmx{{registry.heap}}M",
+    "SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL": "{{registry.zookeeper-master}}/{{registry.kafkastore}}",
+    "SCHEMA_REGISTRY_SCHEMA_REGISTRY_ZK_NAMESPACE": "{{registry.kafkastore}}/{{registry.name}}"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "acceptedResourceRoles": [
+    "{{registry.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{registry.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-schema-registry/6/package.json
+++ b/repo/packages/C/confluent-schema-registry/6/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "confluent-schema-registry",
-  "version": "0.9.8-3.2.0.1",
+  "version": "0.9.9-3.2.0",
   "scm": "https://github.com/confluentinc/schema-registry",
   "description": "Confluent Schema Registry service\n\n\tDocumentation: http://docs.confluent.io/3.2.0/schema-registry/docs/intro.html",
   "maintainer": "partner-support@confluent.io",

--- a/repo/packages/C/confluent-schema-registry/6/package.json
+++ b/repo/packages/C/confluent-schema-registry/6/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "confluent-schema-registry",
+  "version": "0.9.8-3.2.0.1",
+  "scm": "https://github.com/confluentinc/schema-registry",
+  "description": "Confluent Schema Registry service\n\n\tDocumentation: http://docs.confluent.io/3.2.0/schema-registry/docs/intro.html",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "schema", "registry"],
+  "preInstallNotes": "Preparing to install confluent-schema-registry",
+  "postInstallNotes": "confluent-schema-registry has been installed.",
+  "postUninstallNotes": "confluent-schema-registry was uninstalled successfully.",
+  "minDcosReleaseVersion" : "1.8",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/schema-registry/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-schema-registry/6/resource.json
+++ b/repo/packages/C/confluent-schema-registry/6/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "image": "confluentinc/cp-schema-registry:3.2.0"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}


### PR DESCRIPTION
Properly co-locate Schema Registry zookeeper info
in the namespace of the Confluent Kafka service
to which the zookeeper is deployed.   Original version did not do this ... so
multiple schema registry services against different Confluent clusters in the
same DC/OS environment could conflict with each other.

No change to resource.json necessary (Docker image remains the same).

** changes for new version **
<pre>
diff --git a/HEAD:./5/config.json b/HEAD:./6/config.json
index 6763573..a5f43e3 100644
--- a/HEAD:./5/config.json
+++ b/HEAD:./6/config.json
@@ -38,9 +38,14 @@
           "description": "Deploy schema-registry only on nodes with this role.",
           "type": "string"
         },
-        "kafkastore-connection-url": {
-          "default": "master.mesos:2181/dcos-service-confluent-kafka",
-          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+        "zookeeper-master": {
+          "default": "master.mesos:2181",
+          "description": "Zookeeper Connect string for service cluster. Format limited to single target: <zk-host>:<zkport>",
+          "type": "string"
+        },
+        "kafkastore": {
+          "default": "dcos-service-confluent-kafka",
+          "description": "Name of the Kafka service hosting the storage for this Schema Registry edition.",
           "type": "string"
         }
       },

diff --git a/HEAD:./5/marathon.json.mustache b/HEAD:./6/marathon.json.mustache
index ff5bc78..f09ebbe 100644
--- a/HEAD:./5/marathon.json.mustache
+++ b/HEAD:./6/marathon.json.mustache
@@ -30,7 +30,8 @@
   } ],
   "env": {
     "SCHEMA_REGISTRY_HEAP_OPTS": "-Xmx{{registry.heap}}M",
-    "SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL": "{{registry.kafkastore-connection-url}}"
+    "SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL": "{{registry.zookeeper-master}}/{{registry.kafkastore}}",
+    "SCHEMA_REGISTRY_SCHEMA_REGISTRY_ZK_NAMESPACE": "{{registry.kafkastore}}/{{registry.name}}"
   },
   "healthChecks": [
     {

diff --git a/HEAD:./5/package.json b/HEAD:./6/package.json
index 7e970be..655a52f 100644
--- a/HEAD:./5/package.json
+++ b/HEAD:./6/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "confluent-schema-registry",
-  "version": "0.9.8-3.2.0",
+  "version": "0.9.8-3.2.0.1",
   "scm": "https://github.com/confluentinc/schema-registry",
   "description": "Confluent Schema Registry service\n\n\tDocumentation: http://docs.confluent.io/3.2.0/schema-registry/docs/intro.html",
   "maintainer": "partner-support@confluent.io",

</pre>