### PR TITLE
Add Clair package

### DIFF
--- a/repo/packages/C/clair/0/config.json
+++ b/repo/packages/C/clair/0/config.json
@@ -1,0 +1,150 @@
+{
+  "properties": {
+    "service": {
+      "description": "The clair service for DC/OS settings",
+      "properties": {
+        "name": {
+          "description": "The name of the service.",
+          "type": "string",
+          "default": "clair"
+        },
+        "cpus": {
+          "default": 0.5,
+          "description": "CPU (shares) to allocate to the clair service.",
+          "minimum": 0.25,
+          "maximum": 2.0,
+          "type": "number"
+        },
+        "mem": {
+          "default": 1024.0,
+          "description": "Memory (MB) to allocate to the clair service.",
+          "minimum": 1024.0,
+          "maximum": 4096.0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "cpus",
+        "mem"
+      ],
+      "type": "object"
+    },
+    "basic": {
+      "description": "The basic of the clair DC/OS service.",
+      "properties": {
+        "update_interval": {
+          "description": "The interval in hours in which the vulnerability database is updated.",
+          "type": "number",
+          "default": 2
+        },
+        "api_timeout": {
+          "description": "The API timeout in seconds.",
+          "type": "number",
+          "default": 900
+        },
+        "cache_size": {
+          "description": "The cache size (number of elements in the cache).",
+          "type": "number",
+          "default": 16384
+        }
+      },
+      "required": [
+        "update_interval",
+        "api_timeout",
+        "cache_size"
+      ],
+      "type": "object"
+    },
+    "networking": {
+      "description": "The networking settings for the clair DC/OS service.",
+      "properties": {
+        "enable_external": {
+          "description": "If the clair service should be exposed to the public via marathon-lb.",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_host": {
+          "description": "The virtual host name under which clair should be exposed via marathon-lb.",
+          "type": "string"
+        },
+        "port": {
+          "description": "The port under which clair should be exposed via marathon-lb.",
+          "type": "number",
+          "default": 6060
+        }
+      },
+      "required": [
+        "enable_external"
+      ],
+      "type": "object"
+    },
+    "postgres": {
+      "description": "The Postgres settings for the clair DC/OS service.",
+      "properties": {
+        "user": {
+          "description": "The user name to connect to the Postgres instance.",
+          "type": "string"
+        },
+        "password": {
+          "description": "The password to connect to the Postgres instance.",
+          "type": "string"
+        },
+        "database": {
+          "description": "The database name to use to connect to the Postgres instance.",
+          "type": "string",
+          "default": "clair"
+        },
+        "host": {
+          "description": "The host name/ip address of the Postgres instance.",
+          "type": "string",
+          "default": "postgresql.marathon.l4lb.thisdcos.directory"
+        },
+        "port": {
+          "description": "The host port of the Postgres instance.",
+          "type": "number",
+          "default": 5432
+        },
+        "timeout_seconds": {
+          "description": "The name of the service.",
+          "type": "number",
+          "default": 30
+        }
+      },
+      "required": [
+        "user",
+        "password",
+        "database",
+        "port"
+      ],
+      "type": "object"
+    },
+    "notifier": {
+      "description": "The notification settings for the clair DC/OS service.",
+      "properties": {
+        "endpoint_url": {
+          "description": "The endpoint url to send the notifications to.",
+          "type": "string"
+        },
+        "attempts": {
+          "description": "The number of attempts to connect to the endpoint url.",
+          "type": "number",
+          "default": 3
+        },
+        "renotify_interval": {
+          "description": "Duration in hours before a failed notification is retried.",
+          "type": "number",
+          "default": 3
+        }
+      },
+      "type": "object"
+    }
+  },
+  "required": [
+    "service",
+    "networking",
+    "postgres",
+    "basic"
+  ],
+  "type": "object"
+}

--- a/repo/packages/C/clair/0/marathon.json.mustache
+++ b/repo/packages/C/clair/0/marathon.json.mustache
@@ -1,0 +1,73 @@
+{
+    "id": "{{service.name}}",
+    "cpus": {{service.cpus}},
+    "mem": {{service.mem}},
+    "instances": 1,
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.clair}}",
+            "network": "HOST",
+            "forcePullImage": true
+        }
+    },
+    "env": {
+        {{#basic.update_interval}}
+        "UPDATE_INTERVAL_HOURS": "{{basic.update_interval}}",
+        {{/basic.update_interval}}
+        {{#basic.api_timeout}}
+        "API_TIMEOUT_SECONDS": "{{basic.api_timeout}}",
+        {{/basic.api_timeout}}
+        {{#basic.cache_size}}
+        "CACHE_SIZE": "{{basic.cache_size}}",
+        {{/basic.cache_size}}
+        {{#notifier.endpoint_url}}
+        "NOTIFIER_ENDPOINT": "{{notifier.endpoint_url}}",
+        {{/notifier.endpoint_url}}
+        {{#notifier.attempts}}
+        "NOTIFIER_ATTEMPTS": "{{notifier.attempts}}",
+        {{/notifier.attempts}}
+        {{#notifier.renotify_interval}}
+        "NOTIFIER_RENOTIFY_INTERVAL_HOURS": "{{notifier.renotify_interval}}",
+        {{/notifier.renotify_interval}}
+        "POSTGRES_USER": "{{postgres.user}}",
+        "POSTGRES_PASSWORD": "{{postgres.password}}",
+        "POSTGRES_DATABASE": "{{postgres.database}}",
+        "POSTGRES_HOST": "{{postgres.host}}",
+        "POSTGRES_PORT": "{{postgres.port}}",
+        "POSTGRES_TIMEOUT_SECONDS": "{{postgres.timeout_seconds}}"
+    },
+    {{#networking.enable_external}}
+    "labels": {
+        "HAPROXY_GROUP": "external",
+        "HAPROXY_0_VHOST": "{{networking.virtual_host}}"
+        "HAPROXY_0_PORT": "{{networking.port}}"
+    },
+    {{/networking.enable_external}}
+    "portDefinitions": [
+        {
+            "port": 0,
+            "protocol": "tcp",
+            "name": "http",
+            "labels": {
+                "VIP_0": "clair:80"
+            }
+        },
+        {
+            "port": 0,
+            "protocol": "tcp",
+            "name": "health-check"
+        }
+    ],
+    "requirePorts": false,
+    "healthChecks": [
+        {
+            "protocol": "HTTP",
+            "portIndex": 1,
+            "path": "/health",
+            "gracePeriodSeconds": 5,
+            "intervalSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ]
+}

--- a/repo/packages/C/clair/0/marathon.json.mustache
+++ b/repo/packages/C/clair/0/marathon.json.mustache
@@ -40,7 +40,7 @@
     {{#networking.enable_external}}
     "labels": {
         "HAPROXY_GROUP": "external",
-        "HAPROXY_0_VHOST": "{{networking.virtual_host}}"
+        "HAPROXY_0_VHOST": "{{networking.virtual_host}}",
         "HAPROXY_0_PORT": "{{networking.port}}"
     },
     {{/networking.enable_external}}

--- a/repo/packages/C/clair/0/marathon.json.mustache
+++ b/repo/packages/C/clair/0/marathon.json.mustache
@@ -50,7 +50,7 @@
             "protocol": "tcp",
             "name": "http",
             "labels": {
-                "VIP_0": "clair:80"
+                "VIP_0": "clair:6060"
             }
         },
         {

--- a/repo/packages/C/clair/0/package.json
+++ b/repo/packages/C/clair/0/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "clair",
+  "version": "0.1.0",
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion" : "1.8",
+  "tags": ["clair", "vulnerability", "scanning", "docker", "containers", "images"],
+  "maintainer": "tobilg@gmail.com",
+  "description": "With clair, you can inspect Docker images for common vulnerabilities.",
+  "scm": "https://github.com/tobilg/clair-dcos.git",
+  "website": "https://github.com/tobilg/clair-dcos",
+  "framework": false,
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. This will install clair... Scan your containers for vulnerabilities!",
+  "postInstallNotes": "Thanks for installing! Have fun scanning your containers with clair!.",
+  "postUninstallNotes": "clair was successfully unistalled.",
+  "licenses": [{
+    "name": "Apache License 2.0",
+    "url": "https://github.com/tobilg/clair-dcos/blob/master/LICENSE"
+  }]
+}

--- a/repo/packages/C/clair/0/resource.json
+++ b/repo/packages/C/clair/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "clair": "tobilg/clair-dcos:latest"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://files.serv.sh/packages/clair/icons/clair_48x48.png",
+    "icon-medium": "https://files.serv.sh/packages/clair/icons/clair_96x96.png",
+    "icon-large": "https://files.serv.sh/packages/clair/icons/clair_256x256.png"
+  }
+}

--- a/repo/packages/C/clair/0/resource.json
+++ b/repo/packages/C/clair/0/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "clair": "tobilg/clair-dcos:latest"
+        "clair": "tobilg/clair-dcos:v2.0.0-rc.0"
       }
     }
   },

--- a/repo/packages/C/clair/0/resource.json
+++ b/repo/packages/C/clair/0/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "clair": "tobilg/clair-dcos:v2.0.0-rc.0"
+        "clair": "tobilg/clair-dcos:v1.2.6"
       }
     }
   },


### PR DESCRIPTION
This adds a Universe package for https://github.com/coreos/clair, the container vulnerability scanning tool from CoreOS/quay.io.

An example for [dcos/examples](https://github.com/dcos/examples) will be prepared asap. Do not merge until then.