### PR TITLE
updated grafana to use the newest version 4.2.0

### DIFF
--- a/repo/packages/G/grafana/1/config.json
+++ b/repo/packages/G/grafana/1/config.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service":{
+            "type":"object",
+            "description": "DC/OS service configuration properties",
+            "properties":{
+                "name" : {
+                    "description":"Name of this service instance.",
+                    "type":"string",
+                    "default":"grafana"
+                }
+            }
+        },
+        "grafana":{
+            "type": "object",
+            "description": "grafana service configuration properties",
+            "properties": {
+                "cpus": {
+                    "description": "CPU shares to allocate to each service instance.",
+                    "type": "number",
+                    "default": 0.3,
+                    "minimum": 0.3
+                },
+                "mem": {
+                    "description":  "Memory to allocate to each service instance.",
+                    "type": "number",
+                    "default": 512.0,
+                    "minimum": 512.0
+                },
+                "admin_password": {
+                    "description": "Admin password.",
+                    "type": "string",
+                    "default": "admin"
+                }
+            },
+            "required": [
+                "cpus",
+                "mem"
+            ]
+        },
+        "networking":{
+            "type": "object",
+            "description": "Grafana networking configuration properties",
+            "properties": {
+                "external_access": {
+                    "type": "object",
+                    "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+                    "properties": {    
+                        "enable": {
+                            "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+                            "type": "boolean",
+                            "default": true                    
+                        },
+                        "external_access_port": {
+                            "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+                            "type": "number",
+                            "default": 13000
+                        },
+                        "virtual_host": {
+                            "description": "For external access, Virtual Host URL to be used in the external load balancer.",
+                            "type": "string",
+                            "default": "grafana.example.org"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/G/grafana/1/marathon.json.mustache
+++ b/repo/packages/G/grafana/1/marathon.json.mustache
@@ -1,0 +1,47 @@
+{
+    "id": "{{service.name}}",
+    "cpus": {{grafana.cpus}},
+    "mem": {{grafana.mem}},
+    "instances": 1,
+    "env": {
+        "GF_SECURITY_ADMIN_PASSWORD": "{{grafana.admin_password}}"
+    },
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.grafana-docker}}",
+            "forcePullImage": false,
+            "network": "BRIDGE",
+            "portMappings": [
+            {
+                "containerPort": 3000,
+                "hostPort": 0,
+                {{#networking.external_access.enable}}
+                "servicePort": {{networking.external_access.external_access_port}},
+                {{/networking.external_access.enable}}
+                "protocol": "tcp"
+            }
+            ]
+        }
+    },
+    "healthChecks": [
+        {
+            "protocol": "HTTP",
+            "path": "/",
+            "portIndex": 0,
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ],
+    "labels": {
+        "DCOS_PACKAGE_VERSION": "3.1.1-0.1",
+        "DCOS_SERVICE_NAME": "{{service.name}}",
+        {{#networking.external_access.enable}}
+        "HAPROXY_GROUP": "external",
+        "HAPROXY_0_VHOST": "{{networking.external_access.virtual_host}}",
+        {{/networking.external_access.enable}}        
+        "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+    }
+}

--- a/repo/packages/G/grafana/1/marathon.json.mustache
+++ b/repo/packages/G/grafana/1/marathon.json.mustache
@@ -36,7 +36,7 @@
         }
     ],
     "labels": {
-        "DCOS_PACKAGE_VERSION": "3.1.1-0.1",
+        "DCOS_PACKAGE_VERSION": "4.2.0-0.2",
         "DCOS_SERVICE_NAME": "{{service.name}}",
         {{#networking.external_access.enable}}
         "HAPROXY_GROUP": "external",

--- a/repo/packages/G/grafana/1/package.json
+++ b/repo/packages/G/grafana/1/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "grafana",
-  "version": "4.2.0-0.1",
+  "version": "4.2.0-0.2",
   "scm": "https://github.com/grafana/grafana",
   "maintainer": "https://dcos.io/community",
   "website": "https://grafana.net/",

--- a/repo/packages/G/grafana/1/package.json
+++ b/repo/packages/G/grafana/1/package.json
@@ -1,0 +1,22 @@
+{
+  "packagingVersion": "3.0",
+  "name": "grafana",
+  "version": "4.2.0-0.1",
+  "scm": "https://github.com/grafana/grafana",
+  "maintainer": "https://dcos.io/community",
+  "website": "https://grafana.net/",
+  "description": "Grafana is a leading open source application for visualizing large-scale measurement data. It provides a powerful and elegant way to create, share, and explore data and dashboards from your disparate metric databases, either with your team or the world. Grafana is most commonly used for Internet infrastructure and application analytics, but many use it in other domains including industrial sensors, home automation, weather, and process control. Grafana features pluggable panels and data sources allowing easy extensibility. There is currently rich support for Graphite, InfluxDB and OpenTSDB. There is also experimental support for KairosDB, and SQL is on the roadmap. Grafana has a variety of panels, including a fully featured graph panel with rich visualization options.\n\nThis package can be used alongside the DC/OS 'cadvisor' and 'influxdb' packages for a cluster-wide monitoring solution.\n\nInstallation Documentation: https://github.com/dcos/examples/tree/master/cadvisor-influxdb-grafana\n\n",
+  "tags": [
+    "grafana",
+    "monitoring",
+    "visualization"
+    ],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\n```Advanced Installation options notes```\n\nnetworking / *external_access*: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / *external_access_port*: port to be used in Marathon-LB for accessing the service.",
+  "postInstallNotes": "Service installed.\n\nIt is recommended to access this service through the endpoint created in Marathon-LB.\n\nDefault login: `admin`/`admin`.",
+  "licenses": [
+    {
+      "name": "Apache License",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ]
+}

--- a/repo/packages/G/grafana/1/resource.json
+++ b/repo/packages/G/grafana/1/resource.json
@@ -1,0 +1,18 @@
+{
+  "images": {
+    "icon-small": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-grafana-small.png",
+    "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-grafana-medium.png",
+    "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-grafana-large.png",
+   "screenshots": [
+     "http://grafana.org/assets/img/blog/v3.0/wP-Screenshot-dash-web.png",
+     "https://prometheus.io/assets/grafana_prometheus-cbb943f0bb3.png"
+   ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "grafana-docker": "grafana/grafana:4.2.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
I updated grafana package to use the newest version, I have been testing this version in dcos 1.9 and work better then 3.1.1 version. Was not 100 sure if i setup the new version write with the directory, let me know if it is not correct or if i need to do more to contribute this new version.