### PR TITLE
Ceph -- bump to ceph-on-mesos 0.2.11

### DIFF
--- a/repo/packages/C/ceph/2/config.json
+++ b/repo/packages/C/ceph/2/config.json
@@ -1,0 +1,84 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service":{
+            "type":"object",
+            "description": "DC/OS service configuration properties",
+            "properties":{
+                "name" : {
+                    "description":"Name of this service instance.",
+                    "type":"string",
+                    "default":"ceph"
+                }
+            }
+        },
+        "ceph":{
+            "type": "object",
+            "description": "ceph service configuration properties",
+            "properties": {
+                "cpus": {
+                    "description": "CPU shares to allocate to each service instance.",
+                    "type": "number",
+                    "default": 1,
+                    "minimum": 0.5
+                },
+                "mem": {
+                    "description":  "Memory to allocate to each service instance.",
+                    "type": "number",
+                    "default": 2048,
+                    "minimum": 1024
+                }
+            },
+            "required": [
+                "cpus",
+                "mem"
+            ]
+        },
+        "networking":{
+            "type": "object",
+            "description": "Ceph networking configuration properties",
+            "properties": {
+                 "cluster_network":{
+                    "description": "Network where the Ceph nodes are allowed to live. This is usually the host network where the DC/OS nodes live. This network is assumed to be trusted. NOTE: by default, ALL networks are allowed.",
+                    "type": "string",
+                    "default": "0.0.0.0/0"
+                },
+                "public_network":{
+                    "description": "Network that the Ceph services are exposed on, where the Ceph clients/consumers are allowed to connect from. This is often the same as cluster_network unless Ceph is to be exposed outside the cluster. NOTE: by default, ALL networks are allowed.",
+                    "type": "string",
+                    "default": "0.0.0.0/0"
+                },
+                "ceph_api_port":{
+                    "description": "The port where the Ceph API is listening on.",
+                    "type": "number",
+                    "default": 5000
+                },
+                "external_access": {
+                    "type": "object",
+                    "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+                    "properties": {    
+                        "enable": {
+                            "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+                            "type": "boolean",
+                            "default": true                    
+                        },
+                        "external_access_port": {
+                            "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+                            "type": "number",
+                            "default": 5000
+                        },
+                        "virtual_host": {
+                            "description": "For external access, Virtual Host URL to be used in the external load balancer.",
+                            "type": "string",
+                            "default": "ceph.example.org"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "cluster_network",
+                "public_network"
+            ]
+        }
+    }
+}

--- a/repo/packages/C/ceph/2/marathon-lb-secret-options.json
+++ b/repo/packages/C/ceph/2/marathon-lb-secret-options.json
@@ -1,0 +1,6 @@
+{
+     "marathon-lb": {
+         "secret_name": "marathon-lb",
+         "cpus": 1
+     }
+}

--- a/repo/packages/C/ceph/2/marathon.json.mustache
+++ b/repo/packages/C/ceph/2/marathon.json.mustache
@@ -1,0 +1,70 @@
+{
+    "id": "{{service.name}}",
+    "cpus": {{ceph.cpus}},
+    "mem": {{ceph.mem}},
+    "disk": 0,
+    "instances": 1,
+    "env": {
+        "MESOS_ROLE": "{{service.name}}-role",
+        "MESOS_PRINCIPAL": "{{service.name}}-principal",        
+        "CLUSTER_NETWORK": "{{networking.cluster_network}}",
+        "PUBLIC_NETWORK": "{{networking.public_network}}",
+        "ZOOKEEPER": "leader.mesos:2181",
+        "API_HOST": "0.0.0.0",
+        "MESOS_MASTER": "leader.mesos:5050"        
+    },
+    "uris": ["https://dl.bintray.com/vivint-smarthome/ceph-on-mesos/ceph-on-mesos-0.2.10.tgz"],
+    "cmd": "cd /mnt/mesos/sandbox/ceph-on-mesos-*\nbin/ceph-on-mesos --api-port=$PORT0",
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.ceph-docker}}",
+            "forcePullImage": false,
+            "privileged": false,
+            "network": "HOST"
+        },
+        "volumes": [{
+            "containerPath": "/dev/random",
+            "hostPath": "/dev/urandom",
+            "mode": "RO"
+        }]
+    },
+    "healthChecks": [
+        {
+            "protocol": "TCP",
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ],
+    "portDefinitions": [{
+      "protocol": "tcp",
+      "port": {{networking.ceph_api_port}},
+      {{#networking.external_access.enable}}
+      "servicePort": {{networking.external_access.external_access_port}},
+      {{/networking.external_access.enable}}
+      "labels": {
+        "VIP_0": "/{{service.name}}:{{networking.ceph_api_port}}"
+      },
+      "name": "api"
+    }],
+    "labels": {
+        "MARATHON_SINGLE_INSTANCE_APP": "true",
+        "DCOS_PACKAGE_VERSION": "0.2.10-0.3",
+        "DCOS_SERVICE_NAME": "{{service.name}}",
+        {{#networking.external_access.enable}}
+        "HAPROXY_GROUP": "external",
+        "HAPROXY_0_VHOST": "{{networking.external_access.virtual_host}}",
+        {{/networking.external_access.enable}}        
+        "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+    },
+    "acceptedResourceRoles": [
+        "*",
+        "slave_public"
+    ],
+    "upgradeStrategy": {
+        "minimumHealthCapacity": 0,
+        "maximumOverCapacity": 0
+    }
+}

--- a/repo/packages/C/ceph/2/marathon.json.mustache
+++ b/repo/packages/C/ceph/2/marathon.json.mustache
@@ -12,7 +12,7 @@
         "ZOOKEEPER": "leader.mesos:2181",
         "API_HOST": "0.0.0.0",
         "MESOS_MASTER": "leader.mesos:5050",
-        "CEPH_MON_INIT_PORT": 6789        
+        "CEPH_MON_INIT_PORT": "6789"        
     },
     "uris": ["https://dl.bintray.com/vivint-smarthome/ceph-on-mesos/ceph-on-mesos-0.2.10.tgz"],
     "cmd": "cd /mnt/mesos/sandbox/ceph-on-mesos-*\nbin/ceph-on-mesos --api-port=$PORT0",

--- a/repo/packages/C/ceph/2/marathon.json.mustache
+++ b/repo/packages/C/ceph/2/marathon.json.mustache
@@ -14,7 +14,7 @@
         "MESOS_MASTER": "leader.mesos:5050",
         "CEPH_MON_INIT_PORT": "6789"        
     },
-    "uris": ["https://dl.bintray.com/vivint-smarthome/ceph-on-mesos/ceph-on-mesos-0.2.10.tgz"],
+    "uris": ["https://dl.bintray.com/vivint-smarthome/ceph-on-mesos/ceph-on-mesos-0.2.11.tgz"],
     "cmd": "cd /mnt/mesos/sandbox/ceph-on-mesos-*\nbin/ceph-on-mesos --api-port=$PORT0",
     "container": {
         "type": "DOCKER",
@@ -52,7 +52,7 @@
     }],
     "labels": {
         "MARATHON_SINGLE_INSTANCE_APP": "true",
-        "DCOS_PACKAGE_VERSION": "0.2.10-0.3",
+        "DCOS_PACKAGE_VERSION": "0.2.11-0.3",
         "DCOS_SERVICE_NAME": "{{service.name}}",
         {{#networking.external_access.enable}}
         "HAPROXY_GROUP": "external",

--- a/repo/packages/C/ceph/2/marathon.json.mustache
+++ b/repo/packages/C/ceph/2/marathon.json.mustache
@@ -11,7 +11,8 @@
         "PUBLIC_NETWORK": "{{networking.public_network}}",
         "ZOOKEEPER": "leader.mesos:2181",
         "API_HOST": "0.0.0.0",
-        "MESOS_MASTER": "leader.mesos:5050"        
+        "MESOS_MASTER": "leader.mesos:5050",
+        "CEPH_MON_INIT_PORT": 6789        
     },
     "uris": ["https://dl.bintray.com/vivint-smarthome/ceph-on-mesos/ceph-on-mesos-0.2.10.tgz"],
     "cmd": "cd /mnt/mesos/sandbox/ceph-on-mesos-*\nbin/ceph-on-mesos --api-port=$PORT0",

--- a/repo/packages/C/ceph/2/package.json
+++ b/repo/packages/C/ceph/2/package.json
@@ -1,0 +1,22 @@
+{
+  "packagingVersion": "3.0",
+  "name": "ceph",
+  "version": "0.2.10-0.3",
+  "scm": "https://github.com/ceph",
+  "maintainer": "https://dcos.io/community",
+  "website": "https://www.ceph.org",
+  "description": "Ceph, a free-software storage platform, implements object storage on a single distributed computer cluster, and provides interfaces for object-, block- and file-level storage. Ceph aims primarily for completely distributed operation without a single point of failure, scalable to the exabyte level, and freely available.\n\nCeph replicates data and makes it fault-tolerant, using commodity hardware and requiring no specific hardware support. As a result of its design, the system is both self-healing and self-managing, aiming to minimize administration time and other costs.",
+  "tags": [
+    "ceph",
+    "storage",
+    "filesystem"
+    ],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\n NOTE: By default, this package does not enforce network security, meaning that members and clients of the cluster can be in any network. If you'd like to enforce network security, please make sure to set correctly the `cluster_network` and `public_network` fields in the Advanced Installation menu.\n\nMake sure to check the service tutorial at https://github.com/dcos/examples/tree/master/1.8/ceph",
+  "postInstallNotes": "Service installed.\n\nPlease access the UI through the endpoint created in Marathon-LB.",
+  "licenses": [
+    {
+      "name": "Apache License",
+      "url": "https://raw.githubusercontent.com/vivint-smarthome/ceph-on-mesos/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/ceph/2/package.json
+++ b/repo/packages/C/ceph/2/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "ceph",
-  "version": "0.2.10-0.3",
+  "version": "0.2.11-0.3",
   "scm": "https://github.com/ceph",
   "maintainer": "https://dcos.io/community",
   "website": "https://www.ceph.org",

--- a/repo/packages/C/ceph/2/resource.json
+++ b/repo/packages/C/ceph/2/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-ceph-small.png",
+    "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-ceph-medium.png",
+    "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-ceph-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "ceph-docker": "fernandosanchez/ceph-on-mesos:0.3"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds predictable port assignment for Ceph monitors, defaults to 6789.