### PR TITLE
Remove 'shared' requirement from /opt

### DIFF
--- a/repo/packages/P/portworx/1/marathon.json.mustache
+++ b/repo/packages/P/portworx/1/marathon.json.mustache
@@ -32,7 +32,7 @@
 			},
 			{
 			    "key": "volume",
-			    "value": "/opt/pwx/bin:/export_bin:shared"
+			    "value": "/opt/pwx/bin:/export_bin"
 			},
 			{
 			    "key": "volume",


### PR DESCRIPTION
Shared mount propagation is not required for /opt and breaks some installs.