### PR TITLE
New version with explicit variable for confluent license.

### DIFF
--- a/repo/packages/C/confluent-control-center/6/config.json
+++ b/repo/packages/C/confluent-control-center/6/config.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "control-center": {
+      "properties": {
+        "name": {
+          "default": "control-center",
+          "description": "Name for this control-center application",
+          "type": "string"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 2,
+          "description": "CPU shares to allocate to each control-center instance.",
+          "minimum": 2,
+          "type": "number"
+        },
+        "mem": {
+          "default": 4096,
+          "description": "Memory (MB) to allocate to each control-center task.",
+          "minimum": 2048,
+          "type": "number"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy control-center only on nodes with this role.",
+          "type": "string"
+        },
+        "kafka-service": {
+          "default": "confluent-kafka",
+          "description": "Target Apache Kafka by Confluent service to which these tasks will connect. ",
+          "type": "string"
+        },
+        "connect-service": {
+          "default": "connect",
+          "description": "Service name of Kafka Connect Workers to which this instance will deploy connectors.",
+          "type": "string"
+        },
+        "confluent-controlcenter-internal-topics-partitions": {
+          "default": 3,
+          "description": "Parition count for internal control-center kafka topics",
+          "type": "number"
+        },
+        "confluent-controlcenter-internal-topics-replication": {
+          "default": 2,
+          "description": "Replication factor for internal control-center kafka topics",
+          "type": "number"
+        },
+        "confluent-monitoring-interceptor-topic-partitions": {
+          "default": 3,
+          "description": "Parition count for kafka topics used to store data from the interceptor classes",
+          "type": "number"
+        },
+        "confluent-monitoring-interceptor-topic-replication": {
+          "default": 2,
+          "description": "Replication factor for kafka topics used to store data from the interceptor classes",
+          "type": "number"
+        },
+        "confluent-license": {
+          "default": "",
+          "description": "License key for Confluent Enterprise (default is 30-day trial)",
+          "type": "string"
+        },
+        "zookeeper-connect": {
+          "default": "master.mesos:2181/dcos-service-confluent-kafka",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-control-center/6/marathon.json.mustache
+++ b/repo/packages/C/confluent-control-center/6/marathon.json.mustache
@@ -1,0 +1,49 @@
+{
+  "id": "/{{control-center.name}}",
+  "instances": {{control-center.instances}},
+  "cpus": {{control-center.cpus}},
+  "mem": {{control-center.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.image}}",
+	  "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [ {
+          "containerPort": 9021,
+          "hostPort": 0,
+          "protocol": "tcp"
+      } ]
+    }
+  },
+  "env": {
+    "CONTROL_CENTER_BOOTSTRAP_SERVERS": "broker.{{control-center.kafka-service}}.l4lb.thisdcos.directory:9092",
+    "CONTROL_CENTER_CONNECT_CLUSTER": "{{control-center.connect-service}}.marathon.l4lb.thisdcos.directory:8083",
+    "CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS": "{{control-center.confluent-controlcenter-internal-topics-partitions}}",
+    "CONTROL-CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS": "{{control-center.confluent-monitoring-interceptor-topic-partitions}}",
+    "CONTROL_CENTER_REPLICATION_FACTOR": "{{control-center.confluent-controlcenter-internal-topics-replication}}",
+    "CONTROL_CENTER_LICENSE": "{{control-center.confluent-license}}",
+    "CONTROL_CENTER_ZOOKEEPER_CONNECT": "{{control-center.zookeeper-connect}}"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{control-center.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{control-center.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-control-center/6/package.json
+++ b/repo/packages/C/confluent-control-center/6/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "confluent-control-center",
+  "version": "0.9.8-3.2.0e",
+  "scm": "https://github.com/confluentinc/control-center",
+  "description": "Confluent Control Center service\n\n\tDocumentation: http://docs.confluent.io/3.2.0/control-center/docs/userguide.html\n\tDC/OS Specifics: https://www.confluent.io/whitepaper/deploying-confluent-platform-with-mesosphere",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "control", "center"],
+  "preInstallNotes": "Preparing to install confluent-control-center",
+  "postInstallNotes": "confluent-control-center has been installed.",
+  "postUninstallNotes": "confluent-control-center was uninstalled successfully.",
+  "minDcosReleaseVersion" : "1.8",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/control-center/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-control-center/6/package.json
+++ b/repo/packages/C/confluent-control-center/6/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "confluent-control-center",
-  "version": "0.9.8-3.2.0e",
+  "version": "0.9.9-3.2.0",
   "scm": "https://github.com/confluentinc/control-center",
   "description": "Confluent Control Center service\n\n\tDocumentation: http://docs.confluent.io/3.2.0/control-center/docs/userguide.html\n\tDC/OS Specifics: https://www.confluent.io/whitepaper/deploying-confluent-platform-with-mesosphere",
   "maintainer": "partner-support@confluent.io",

--- a/repo/packages/C/confluent-control-center/6/resource.json
+++ b/repo/packages/C/confluent-control-center/6/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "image": "confluentinc/cp-enterprise-control-center:3.2.0"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}


### PR DESCRIPTION
A simple change to explicitly allow users to enter their confluent license during deployment rather than having to add an environment variable after the deployment.

<pre>
diff --git a/HEAD:./5/config.json b/HEAD:./6/config.json
index e170c44..5684de7 100644
--- a/HEAD:./5/config.json
+++ b/HEAD:./6/config.json
@@ -61,6 +61,11 @@
           "description": "Replication factor for kafka topics used to store data from the interceptor classes",
           "type": "number"
         },
+        "confluent-license": {
+          "default": "",
+          "description": "License key for Confluent Enterprise (default is 30-day trial)",
+          "type": "string"
+        },
         "zookeeper-connect": {
           "default": "master.mesos:2181/dcos-service-confluent-kafka",
           "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",

diff --git a/HEAD:./5/marathon.json.mustache b/HEAD:./6/marathon.json.mustache
index 6352a24..29f56ac 100644
--- a/HEAD:./5/marathon.json.mustache
+++ b/HEAD:./6/marathon.json.mustache
@@ -23,6 +23,7 @@
     "CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS": "{{control-center.confluent-controlcenter-intern
al-topics-partitions}}",
     "CONTROL-CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS": "{{control-center.confluent-monitor
ing-interceptor-topic-partitions}}",     "CONTROL_CENTER_REPLICATION_FACTOR": "{{control-center.confluent-controlcenter-internal-topics-replication}}",
+    "CONTROL_CENTER_LICENSE": "{{control-center.confluent-license}}",
     "CONTROL_CENTER_ZOOKEEPER_CONNECT": "{{control-center.zookeeper-connect}}"
   },
   "healthChecks": [

diff --git a/HEAD:./5/package.json b/HEAD:./6/package.json
index 2ce77a6..1a6afe5 100644
--- a/HEAD:./5/package.json
+++ b/HEAD:./6/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "confluent-control-center",
-  "version": "0.9.8-3.2.0",
+  "version": "0.9.8-3.2.0e",
   "scm": "https://github.com/confluentinc/control-center",
   "description": "Confluent Control Center service\n\n\tDocumentation: http://docs.confluent.io/3.2.0/control-center/docs/userguide.html\n\tDC/OS Specifics: https://www.confluent.io/whitepaper/deploying-confluent-platform-with-mesosphere",
   "maintainer": "partner-support@confluent.io",
</pre>