### PR TITLE
Updating Dockerfile.base Nginx to 1.12.0-1~jessie

### DIFF
--- a/docker/local-universe/Dockerfile.base
+++ b/docker/local-universe/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM registry:2.4.1
 
-ENV NGINX_VERSION 1.10.3-1~jessie
+ENV NGINX_VERSION 1.12.0-1~jessie
 
 RUN apt-key adv --keyserver hkp://pgp.mit.edu:80 --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62 \
   && echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list \


### PR DESCRIPTION
Newer Nginx packages currently break offline Universe scripts.  Updating Nginx should resolve this.