### PR TITLE
Add a requirements file (jsonschema is needed for building)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema==2.6.0


### PR DESCRIPTION
Build script fails on macOS with system python because the jsonschema utility (from the jsonschema package) is not installed by default. Other Unixes may experience similar issues. The package has other dependencies that were removed from the requirements file using pip-chill.