### PR TITLE
Eremetic 0.27.0 Universe Package

### DIFF
--- a/repo/packages/E/eremetic/0/config.json
+++ b/repo/packages/E/eremetic/0/config.json
@@ -1,0 +1,51 @@
+{
+  "type": "object",
+  "description": "Eremetic DC/OS Service properties",
+  "properties": {
+    "eremetic": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "framework-name": {
+          "description": "The name of the Eremetic scheduler and service instance",
+          "type": "string",
+          "default": "eremetic"
+        },
+        "cpus": {
+          "description": "Number of cores allocated to Eremetic instance",
+          "type": "number",
+          "default": 0.2,
+          "minimum": 0.2
+        },
+        "mem": {
+          "description": "Amount of memory in MiBs allocated to Eremetic instance",
+          "type": "integer",
+          "default": 100,
+          "minimum": 100
+        },
+        "auth-uri": {
+          "description": "URI to file for private Docker registry authentication",
+          "type": "string"
+        },
+        "log-level": {
+          "description": "Logging level of framework",
+          "type": "string",
+          "enum": ["DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"],
+          "default": "INFO"
+        },
+        "queue-size": {
+          "description": "Maximum queue size for tasks",
+          "type": "integer",
+          "default": 10000
+        }
+      },
+      "required": [
+        "framework-name",
+        "cpus",
+        "mem",
+        "log-level",
+        "queue-size"
+      ]
+    }
+  }
+}

--- a/repo/packages/E/eremetic/0/marathon.json.mustache
+++ b/repo/packages/E/eremetic/0/marathon.json.mustache
@@ -48,9 +48,9 @@
 	},
  	"labels": {
 		"DCOS_PACKAGE_FRAMEWORK_NAME": "{{eremetic.framework-name}}",
-        "DCOS_SERVICE_NAME": "{{eremetic.framework-name}}",
-        "DCOS_SERVICE_PORT_INDEX": "0",
-        "DCOS_SERVICE_SCHEME": "http",
+		"DCOS_SERVICE_NAME": "{{eremetic.framework-name}}",
+		"DCOS_SERVICE_PORT_INDEX": "0",
+		"DCOS_SERVICE_SCHEME": "http",
 		"traefik.portIndex": "0"
 	}
 	{{#eremetic.auth-uri}}

--- a/repo/packages/E/eremetic/0/marathon.json.mustache
+++ b/repo/packages/E/eremetic/0/marathon.json.mustache
@@ -1,0 +1,59 @@
+{
+    "id": "{{eremetic.framework-name}}",
+    "cpus": {{eremetic.cpus}},
+    "mem": {{eremetic.mem}},
+    "instances": 1,
+    "constraints": [[ "hostname", "UNIQUE"]],
+	"container": {
+		"type": "DOCKER",
+		"docker": {
+			"image": "{{resource.assets.container.docker.eremetic}}",
+			"network": "BRIDGE",
+			"portMappings": [
+			{
+				"containerPort": 8000,
+				"hostPort": 0,
+				"servicePort": 0,
+				"protocol": "tcp",
+				"labels": {
+				    "VIP_0": "/{{eremetic.framework-name}}:8000"
+				}
+			},
+			{
+				"containerPort": 11419,
+				"hostPort": 11419
+			}],
+			"forcePullImage": false
+		}
+	},
+	"healthChecks": [{
+		"path": "/version/",
+		"portIndex": 0,
+		"protocol": "HTTP",
+		"gracePeriodSeconds": 10,
+		"intervalSeconds": 10,
+		"maxConsecutiveFailures": 3,
+		"timeoutSeconds": 10
+	}],
+	"env": {
+		"ADDRESS": "0.0.0.0",
+		"PORT": "8000",
+		"MASTER": "zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos",
+		"DATABASE": "zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/{{eremetic.framework-name}}",
+		"DATABASE_DRIVER": "zk",
+		"LOGLEVEL": "{{eremetic.log-level}}",
+		"QUEUE_SIZE": "{{eremetic.queue-size}}",
+		"FRAMEWORK_ID": "{{eremetic.framework-name}}1",
+		"URL_PREFIX": "/service/eremetic"
+	},
+ 	"labels": {
+		"DCOS_PACKAGE_FRAMEWORK_NAME": "{{eremetic.framework-name}}",
+        "DCOS_SERVICE_NAME": "{{eremetic.framework-name}}",
+        "DCOS_SERVICE_PORT_INDEX": "0",
+        "DCOS_SERVICE_SCHEME": "http",
+		"traefik.portIndex": "0"
+	}
+	{{#eremetic.auth-uri}}
+	"fetch": [{ "uri": "{{eremetic.auth-uri}}" }],
+	{{/eremetic.auth-uri}}
+}

--- a/repo/packages/E/eremetic/0/package.json
+++ b/repo/packages/E/eremetic/0/package.json
@@ -1,12 +1,19 @@
 {
-  "description": "Eremetic is a Mesos Framework to run one-shot tasks. The vision is to provide a bridge between Applications that need to run tasks and Mesos. That way a developer creating an application that needs to launch tasks into a cluster wouldn't need to manage Mesos resource offers directly.",
+  "description": "Eremetic is a Mesos Framework to run one-shot tasks. The vision is to provide a bridge between Applications that need to run tasks and Mesos. That way a developer creating an application that needs to launch tasks into a cluster wouldn't need to manage Mesos resource offers directly.\n\nNew User Tutorial: https://github.com/dcos/examples/tree/master/eremetic",
   "framework": true,
   "scm" : "https://github.com/klarna/eremetic",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/klarna/eremetic/blob/master/LICENSE"
+    }
+  ],
   "maintainer" : "dcos-support@appliedis.com",
   "minDcosReleaseVersion": "1.8",
   "name": "eremetic",
   "packagingVersion": "3.0",
-  "postInstallNotes": "DC/OS Eremetic service has been installed. You can access the API within the cluster at http://eremetic.marathon.l4lb.thisdcos.directory:8000 or outside the cluster at https://<master-hostname>/service/eremetic/.",
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production!",
+  "postInstallNotes": "DC/OS Eremetic service has been installed. You can access the API within the cluster at http://eremetic.marathon.l4lb.thisdcos.directory:8000 or outside the cluster at https://<dcos-master>/service/eremetic/.\n\nNew User Tutorial: https://github.com/dcos/examples/tree/master/eremetic",
   "postUninstallNotes": "DC/OS Eremetic service has been uninstalled.",
   "selected": false,
   "tags": [
@@ -15,5 +22,5 @@
     "task",
     "job"
   ],
-  "version": "0.0.1-0.27.0"
+  "version": "0.27.0-0.0.1"
 }

--- a/repo/packages/E/eremetic/0/package.json
+++ b/repo/packages/E/eremetic/0/package.json
@@ -6,7 +6,7 @@
   "minDcosReleaseVersion": "1.8",
   "name": "eremetic",
   "packagingVersion": "3.0",
-  "postInstallNotes": "DC/OS Eremetic service has been installed. You can access the API within the cluster at http://eremetic.marathon.l4lb.thisdcos.directory:11419 or outside the cluster at https://<master-hostname>/service/eremetic/.",
+  "postInstallNotes": "DC/OS Eremetic service has been installed. You can access the API within the cluster at http://eremetic.marathon.l4lb.thisdcos.directory:8000 or outside the cluster at https://<master-hostname>/service/eremetic/.",
   "postUninstallNotes": "DC/OS Eremetic service has been uninstalled.",
   "selected": false,
   "tags": [

--- a/repo/packages/E/eremetic/0/package.json
+++ b/repo/packages/E/eremetic/0/package.json
@@ -1,0 +1,19 @@
+{
+  "description": "Eremetic is a Mesos Framework to run one-shot tasks. The vision is to provide a bridge between Applications that need to run tasks and Mesos. That way a developer creating an application that needs to launch tasks into a cluster wouldn't need to manage Mesos resource offers directly.",
+  "framework": true,
+  "scm" : "https://github.com/klarna/eremetic",
+  "maintainer" : "dcos-support@appliedis.com",
+  "minDcosReleaseVersion": "1.8",
+  "name": "eremetic",
+  "packagingVersion": "3.0",
+  "postInstallNotes": "DC/OS Eremetic service has been installed. You can access the API within the cluster at http://eremetic.marathon.l4lb.thisdcos.directory:11419 or outside the cluster at https://<master-hostname>/service/eremetic/.",
+  "postUninstallNotes": "DC/OS Eremetic service has been uninstalled.",
+  "selected": false,
+  "tags": [
+    "eremetic",
+    "one-shot",
+    "task",
+    "job"
+  ],
+  "version": "0.0.1-0.27.0"
+}

--- a/repo/packages/E/eremetic/0/resource.json
+++ b/repo/packages/E/eremetic/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "images" : {
+    "icon-small" : "https://raw.githubusercontent.com/gisjedi/eremetic/master/dcos/icon-eremetic-small.png",
+    "icon-medium" : "https://raw.githubusercontent.com/gisjedi/eremetic/master/dcos/icon-eremetic-medium.png",
+    "icon-large" : "https://raw.githubusercontent.com/gisjedi/eremetic/master/dcos/icon-eremetic-large.png"
+  },
+  "assets" : {
+    "container" : {
+      "docker" : {
+        "eremetic": "alde/eremetic:0.27.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Eremetic is a Mesos Framework to run one-shot tasks. The vision is to provide a bridge between Applications that need to run tasks and Mesos. That way a developer creating an application that needs to launch tasks into a cluster wouldn't need to manage Mesos resource offers directly.

As opposed to DCOS Jobs service, which is more focused on scheduled jobs, Eremetic has no concept of future scheduling. Eremetic will launch the task as soon as Mesos offers resources to satisfy the task requirements.

Support is provided for exposure of the web interface for Task creation behind Admin Router at `/service/eremetic`