### PR TITLE
Gitlab 9 1 0 version update

### DIFF
--- a/repo/packages/G/gitlab/6/config.json
+++ b/repo/packages/G/gitlab/6/config.json
@@ -1,0 +1,242 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "description": "GitLab service properties",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of this DC/OS service.",
+          "type": "string",
+          "default": "gitlab"
+        },
+        "cpus": {
+          "description": "CPU shares to allocate to GitLab.",
+          "type": "number",
+          "default": 1.0,
+          "minimum": 0.1
+        },
+        "mem": {
+          "description": "Memory to allocate to GitLab.",
+          "type": "number",
+          "default": 2048.0,
+          "minimum": 2048.0
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy GitLab only on nodes with this role.",
+          "type": "string"
+        },
+        "host-volume": {
+          "description": "The location of a volume on the host to be used for persisting GitLab configuration and data.",
+          "type": "string",
+          "default": "/srv/gitlab"
+        },
+        "host-shared-volume": {
+          "description": "The location of a volume on the host to be used for persisting shared GitLab configuration and data. This directory MUST be mounted on all DC/OS agents if deploying GitLab in highly available configuration.",
+          "type": "string",
+          "default": "/srv/gitlab-data"
+        }
+      },
+      "required": [
+        "name",
+        "cpus",
+        "mem",
+        "host-volume",
+        "host-shared-volume"
+      ]
+    },
+    "routing": {
+      "description": "GitLab routing properties for use with Marathon-lb.",
+      "type": "object",
+      "properties": {
+        "https-redirect": {
+          "description": "Whether Marathon-lb should redirect HTTP traffic to HTTPS. This requires 'virtual-host' to be set. By default, this is false.",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual-host": {
+          "description": "The virtual host address to configure for integration with Marathon-lb.",
+          "type": "string"
+        },
+        "ssh-port": {
+          "description": "The port that ssh clients will connect to against the virtual-host.",
+          "type": "integer",
+          "default": 22222,
+          "minimum": 1024
+        },
+        "registry-port": {
+          "description": "The port that docker clients will connect to against the virtual-host.",
+          "type": "integer",
+          "default": 50000,
+          "minimum": 1024
+        }
+      }
+    },
+    "email": {
+      "description": "GitLab SMTP email config.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether to use external SMTP email server. By default, this is false.",
+          "type": "boolean",
+          "default": false
+        },
+        "address": {
+          "description": "Address of the SMTP server",
+          "type": "string"
+        },
+        "port": {
+          "description": "Port to access the SMTP server on",
+          "type": "integer",
+          "default": 25
+        },
+        "username": {
+          "description": "If your mail server requires authentication, set the username in this setting.",
+          "type": "string"
+        },
+        "password": {
+          "description": "If your mail server requires authentication, set the password in this setting.",
+          "type": "string"
+        },
+        "domain": {
+          "description": "SMTP HELO domain.",
+          "type": "string"
+        },
+        "authentication": {
+          "description": "If your mail server requires authentication, you need to specify the authentication type here. ('plain', 'login', 'cram_md5')",
+          "type": "string",
+          "default": "login"
+        },
+        "enable-starttls-auto": {
+          "description": "Detects if STARTTLS is enabled in your SMTP server and starts to use it. Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "openssl-verify-mode": {
+          "description": "When using TLS, you can set how OpenSSL checks the certificate. ('none', 'peer', 'client_once', 'fail_if_no_peer_cert')",
+          "type": "string",
+          "default": "peer"
+        },
+        "tls": {
+          "description": "Enables the SMTP connection to use SMTP/TLS. Default to false.",
+          "type": "boolean",
+          "default": false
+        },
+        "email-from-address": {
+          "description": "From Address used in email headers",
+          "type": "string"
+        },
+        "email-reply-to-address": {
+          "description": "Reply-to-Address used in email headers",
+          "type": "string"
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "high-availability": {
+      "description": "GitLab high availability properties. If enabled, single-node properties WILL NOT be used.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether to use external Postgres and Redis servers to enable a highly available deployment of GitLab. By default, this is false.",
+          "type": "boolean",
+          "default": false
+        },
+        "postgres": {
+          "description": "Postgres connection properties",
+          "type": "object",
+          "properties": {
+            "host": {
+              "description": "Postgres host",
+              "type": "string"
+            },
+            "database": {
+              "description": "Postgres database",
+              "type": "string"
+            },
+            "user": {
+              "description": "Postgres user",
+              "type": "string"
+            },
+            "password": {
+              "description": "Postgres password",
+              "type": "string"
+            }
+          }
+        },
+        "redis": {
+          "description": "Redis connection properties",
+          "type": "object",
+          "properties": {
+            "host": {
+              "description": "Redis host",
+              "type": "string"
+            }
+          }
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "single-node": {
+      "description": "Configuration related to running a single instance version of GitLab. If high availability is enabled, these settings will be ignored.",
+      "type": "object",
+      "properties": {
+        "local-volumes": {
+          "description": "Local volumes configuration (only used if external persistent volumes are disabled). Local volumes are created on the machine with the hostname specified and Marathon will attempt to re-launch the task on the same machine. Note that if the machine is lost, your data may also be lost.",
+          "type": "object",
+          "properties": {
+            "pinned-hostname": {
+                "description": "An optional DC/OS agent hostname to run this GitLab instance on (e.g. 10.0.0.1). If this is not specified then the task may relaunch on another node than the one it originally ran on.",
+                "type" : "string"
+            }
+          }
+        },
+        "external-volumes": {
+          "description": "External persistent volumes configuration. External persistent volumes are a DC/OS feature that allow your data to be migrated with your task.",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Whether to use DC/OS external volumes to persist GitLab state. By default, this is false.",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "enabled"
+          ]
+        }
+      },
+      "required": [
+        "local-volumes",
+        "external-volumes"
+      ]
+    },
+    "enterprise": {
+      "description": "Optionally check to install Enterprise Edition. (For use if you have a license file from GitLab Inc)",
+      "type": "object",
+      "properties": {
+        "enterprise-edition": {
+          "description": "Whether to deploy the EE edition of the software. Defaults to false.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "enterprise-edition"
+      ]
+    }
+  },
+  "required": [
+    "service",
+    "routing",
+    "email",
+    "high-availability",
+    "single-node",
+    "enterprise"
+  ]
+}

--- a/repo/packages/G/gitlab/6/marathon.json.mustache
+++ b/repo/packages/G/gitlab/6/marathon.json.mustache
@@ -1,0 +1,94 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "instances": 1,
+  "env": {
+      "GITLAB_OMNIBUS_CONFIG": "{{#routing.virtual-host}}external_url 'http://{{routing.virtual-host}}/'; registry_external_url 'http://{{routing.virtual-host}}:{{routing.registry-port}}/'; gitlab_rails['gitlab_ssh_host'] = '{{routing.virtual-host}}:{{routing.ssh-port}}'; {{/routing.virtual-host}}{{#high-availability.enabled}} postgresql['enable']=false; gitlab_rails['db_host'] = '{{high-availability.postgres.host}}'; gitlab_rails['db_password']='{{high-availability.postgres.password}}'; gitlab_rails['db_username']='{{high-availability.postgres.user}}'; gitlab_rails['db_database']='{{high-availability.postgres.database}}'; redis['enable'] = false; gitlab_rails['redis_host']='{{high-availability.redis.host}}';{{/high-availability.enabled}}{{#email.enabled}}gitlab_rails['smtp_enable'] = true; gitlab_rails['smtp_address'] = '{{email.address}}'; gitlab_rails['smtp_port'] = {{email.port}}; gitlab_rails['smtp_user_name'] = '{{email.username}}'; gitlab_rails['smtp_password'] = '{{email.password}}'; gitlab_rails['smtp_domain'] = '{{email.domain}}'; gitlab_rails['smtp_authentication'] = '{{email.authentication}}'; gitlab_rails['smtp_enable_starttls_auto'] = {{email.enable-starttls-auto}}; gitlab_rails['smtp_openssl_verify_mode'] = '{{email.openssl-verify-mode}}'; gitlab_rails['smtp_tls'] = '{{email.tls}}'; gitlab_rails['gitlab_email_from'] = '{{email.email-from-address}}'; gitlab_rails['gitlab_email_reply_to'] = '{{email.email-reply-to-address}}';{{/email.enabled}} unicorn['worker_processes'] = 2; manage_accounts['enable'] = true; user['home'] = '/gitlab-data/home'; git_data_dir '/gitlab-data/git-data'; gitlab_rails['shared_path'] = '/gitlab-data/shared'; gitlab_rails['uploads_directory'] = '/gitlab-data/uploads'; gitlab_ci['builds_directory'] = '/gitlab-data/builds';"
+  },
+  "container": {
+       "type": "DOCKER",
+       "docker": {
+           "image": "{{#enterprise.enterprise-edition}}{{resource.assets.container.docker.gitlab-ee}}{{/enterprise.enterprise-edition}}{{^enterprise.enterprise-edition}}{{resource.assets.container.docker.gitlab-ce}}{{/enterprise.enterprise-edition}}",
+           "network" : "BRIDGE",
+           "portMappings": [
+             { "hostPort": 0, "containerPort": 80, "protocol": "tcp" },
+             { "hostPort": 0, "containerPort": 443, "protocol": "tcp" },
+             { "hostPort": 0, "containerPort": 22, "servicePort": {{routing.ssh-port}}, "protocol": "tcp" },
+             { "hostPort": 0, "containerPort": {{routing.registry-port}}, "servicePort": {{routing.registry-port}}, "protocol": "tcp" }
+           ]
+       },
+       "volumes": [
+           {
+               "containerPath": "/var/opt/gitlab",
+               "hostPath": "{{service.host-volume}}/{{service.name}}/opt",
+               "mode": "RW"
+           },
+           {
+               "containerPath": "/var/log/gitlab",
+               "hostPath": "{{service.host-volume}}/{{service.name}}/log",
+               "mode": "RW"
+           },
+           {{^single-node.external-volumes.enabled}}
+           {
+               "containerPath": "/etc/gitlab",
+               "hostPath": "{{service.host-shared-volume}}/{{service.name}}/config",
+               "mode": "RW"
+           },
+           {
+               "containerPath": "/gitlab-data",
+               "hostPath": "{{service.host-shared-volume}}/{{service.name}}/data",
+               "mode": "RW"
+           }
+           {{/single-node.external-volumes.enabled}}
+           {{#single-node.external-volumes.enabled}}
+           {
+               "containerPath": "/etc/gitlab",
+               "external": {
+                  "name": "{{service.name}}-config",
+                  "provider": "dvdi",
+                  "options": { "dvdi/driver": "rexray" }
+               },
+               "mode": "RW"
+           },
+           {
+               "containerPath": "/gitlab-data",
+               "external": {
+                  "name": "{{service.name}}-data",
+                  "provider": "dvdi",
+                  "options": { "dvdi/driver": "rexray" }
+               },
+               "mode": "RW"
+           }
+           {{/single-node.external-volumes.enabled}}
+       ]
+   },
+   "acceptedResourceRoles": [ "{{service.role}}" ],
+  "healthChecks": [
+    {
+      "protocol": "COMMAND",
+      "command": { "value": "/opt/gitlab/bin/gitlab-healthcheck --fail > /dev/null" },
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 5
+    }
+  ],
+  "labels": {
+    {{^high-availability.enabled}}
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    {{/high-availability.enabled}}
+    {{#routing.virtual-host}}
+    "HAPROXY_GROUP":"external",
+    "HAPROXY_0_VHOST":"{{routing.virtual-host}}",
+    "HAPROXY_0_REDIRECT_TO_HTTPS": "{{routing.https-redirect}}",
+    {{/routing.virtual-host}}
+    "DCOS_SERVICE_NAME": "{{service.name}}"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }{{^high-availability.enabled}}{{^single-node.external-volumes.enabled}},
+  "constraints": [["hostname", "CLUSTER", "{{single-node.local-volumes.pinned-hostname}}"]]
+  {{/single-node.external-volumes.enabled}}{{/high-availability.enabled}}
+}

--- a/repo/packages/G/gitlab/6/package.json
+++ b/repo/packages/G/gitlab/6/package.json
@@ -1,0 +1,26 @@
+{
+  "packagingVersion": "3.0",
+  "name": "gitlab",
+  "version": "1.0-9.0.0",
+  "minDcosReleaseVersion" : "1.8",
+  "scm": "https://gitlab.com/gitlab-org/gitlab-ce",
+  "maintainer": "support@gitlab.com",
+  "website": "https://about.gitlab.com/",
+  "framework": false,
+  "description": "Collaboration and source control management: code, test, and deploy together! Installation Guide: https://github.com/dcos/examples/tree/master/1.8/gitlab",
+  "tags": ["continuous-integration", "ci", "vcs", "version-control-software"],
+  "preInstallNotes": "Having Marathon-lb installed and setting a virtual host in the config is required for being able to access GitLab. Setting the pinned hostname is required if using the single-node install (the default).",
+  "postInstallNotes": "GitLab has been installed.",
+  "postUninstallNotes": "GitLab has been uninstalled. Note that any data persisted to a NFS share still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "MIT License",
+      "url": "https://gitlab.com/gitlab-org/gitlab-ce/raw/master/LICENSE"
+    },
+    {
+      "name": "EE License",
+      "url": "https://gitlab.com/gitlab-org/gitlab-ee/raw/master/LICENSE"
+    }
+  ],
+  "selected": true
+}

--- a/repo/packages/G/gitlab/6/package.json
+++ b/repo/packages/G/gitlab/6/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "gitlab",
-  "version": "1.0-9.0.0",
+  "version": "1.0-9.1.0",
   "minDcosReleaseVersion" : "1.8",
   "scm": "https://gitlab.com/gitlab-org/gitlab-ce",
   "maintainer": "support@gitlab.com",

--- a/repo/packages/G/gitlab/6/resource.json
+++ b/repo/packages/G/gitlab/6/resource.json
@@ -1,0 +1,15 @@
+{
+  "images": {
+    "icon-small": "https://secure.gravatar.com/avatar/6edd0acaf80f784fab3dd2c31d604e74.jpg?s=40&r=g&d=mm",
+    "icon-medium": "https://secure.gravatar.com/avatar/6edd0acaf80f784fab3dd2c31d604e74.jpg?s=80&r=g&d=mm",
+    "icon-large": "https://secure.gravatar.com/avatar/6edd0acaf80f784fab3dd2c31d604e74.jpg?s=200&r=g&d=mm"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "gitlab-ce": "gitlab/gitlab-ce:9.0.0-ce.0",
+        "gitlab-ee": "gitlab/gitlab-ee:9.0.0-ee.0"
+      }
+    }
+  }
+}

--- a/repo/packages/G/gitlab/6/resource.json
+++ b/repo/packages/G/gitlab/6/resource.json
@@ -7,8 +7,8 @@
   "assets": {
     "container": {
       "docker": {
-        "gitlab-ce": "gitlab/gitlab-ce:9.0.0-ce.0",
-        "gitlab-ee": "gitlab/gitlab-ee:9.0.0-ee.0"
+        "gitlab-ce": "gitlab/gitlab-ce:9.1.0-ce.0",
+        "gitlab-ee": "gitlab/gitlab-ee:9.1.0-ee.0"
       }
     }
   }


### PR DESCRIPTION
This update adds the features introduced in GitLab 9.1 

 - Service Desk (EE only)
 - Canary Deployments (EE only)
 - Burndown Charts (EE only)
 - Protected Tags
 - Discussions in Merge Requests and Issues
 - Microsoft Teams Integration
 - Easier File Templates
 - Auto-cancel Redundant Pipelines
 - Scheduled Pipelines Triggers
 - Improved Support for Jobs with Large Log Sizes

See https://about.gitlab.com/2017/04/22/gitlab-9-1-released/ for more changes and features.

This upgrade contains the security fixes included in  9.0.2

 - Changing a subgroup's path breaks links to files uploaded in projects within that subgroup
 - Private group name disclosure via nested groups parent_id in new/update

See https://about.gitlab.com/2017/03/29/gitlab-9-dot-0-dot-2-released/ for more information.

This update includes several bug fixes for regressions. Details on these bug fixes can be found here:
https://about.gitlab.com/2017/03/28/gitlab-9-dot-0-dot-1-released/
https://about.gitlab.com/2017/04/05/gitlab-9-dot-0-dot-3-released/
https://about.gitlab.com/2017/04/10/gitlab-9-dot-0-dot-5-released/
https://about.gitlab.com/2017/04/21/gitlab-9-dot-0-dot-6-released/