### PR TITLE
Check for existance of assets before attempting to fetch containers under it

### DIFF
--- a/scripts/local-universe.py
+++ b/scripts/local-universe.py
@@ -324,11 +324,12 @@ def prepare_repository(package, package_path, source_repo, dest_repo, http_root,
                                 pathlib.Path(uri).name)))
 
         # Add the local docker repo prefix.
-        if 'container' in resource["assets"]:
-            resource["assets"]["container"]["docker"] = {
-                n: format_image_name(DOCKER_ROOT, image_name)
-                for n, image_name in resource["assets"]["container"].get(
-                    "docker", {}).items()}
+        if 'assets' in resource:
+            if 'container' in resource["assets"]:
+                resource["assets"]["container"]["docker"] = {
+                    n: format_image_name(DOCKER_ROOT, image_name)
+                    for n, image_name in resource["assets"]["container"].get(
+                        "docker", {}).items()}
 
         json.dump(resource, dest_file, indent=4)
 


### PR DESCRIPTION
If you try to include a package in local universe that does not have `asset` in `resource.json` (e.g. tunnel-cli) it fails with the following 

```
Traceback (most recent call last):
  File "/root/universe/docker/local-universe/../../scripts/local-universe.py", line 369, in <module>
    sys.exit(main())
  File "/root/universe/docker/local-universe/../../scripts/local-universe.py", line 131, in main
    args.selected)):
  File "/usr/lib/python3.5/concurrent/futures/_base.py", line 556, in result_iterator
    yield future.result()
  File "/usr/lib/python3.5/concurrent/futures/_base.py", line 405, in result
    return self.__get_result()
  File "/usr/lib/python3.5/concurrent/futures/_base.py", line 357, in __get_result
    raise self._exception
  File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/root/universe/docker/local-universe/../../scripts/local-universe.py", line 108, in handle_package
    args.nonlocal_cli,
  File "/root/universe/docker/local-universe/../../scripts/local-universe.py", line 327, in prepare_repository
    if 'container' in resource["assets"]:
KeyError: 'assets'
Makefile:18: recipe for target 'local-universe' failed
make: *** [local-universe] Error 1
```

This is check avoids this