### PR TITLE
Fix version  suffix for flink package

### DIFF
--- a/repo/packages/F/flink/1/package.json
+++ b/repo/packages/F/flink/1/package.json
@@ -2,7 +2,7 @@
     "packagingVersion": "3.0",
 
     "name": "flink",
-    "version": "1.2.0-1.0",
+    "version": "1.2.0-1.4",
     "description": "Apache Flink® is an open source platform for distributed stream and batch data processing. Further information can be found here: https://github.com/dcos/examples/tree/master/1.8/flink",
     "framework": true,
     "website": "http://flink.apache.org/",


### PR DESCRIPTION
Makes it the same with the dcos image suffix