### PR TITLE
minio: Fix storage and networking defaults

### DIFF
--- a/repo/packages/M/minio/5/config.json
+++ b/repo/packages/M/minio/5/config.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service": {
+            "type": "object",
+            "description": "Service properties for Minio on DC/OS",
+            "properties": {
+                "name": {
+                    "description": "Name of this service instance",
+                    "type": "string"
+                },
+                "cpus": {
+                    "description": "CPU shares to allocate to service instance",
+                    "type": "number",
+                    "default": 1,
+                    "minimum": 0.5
+                },
+                "mem": {
+                    "description": "Memory to allocate to service instance",
+                    "type": "number",
+                    "default": 2048,
+                    "minimum": 2048
+                }
+            },
+            "required": [
+                "name",
+                "cpus",
+                "mem"
+            ]
+        },
+        "storage": {
+            "type": "object",
+            "description": "Storage properties for Minio on DC/OS",
+            "properties": {
+                "data-size": {
+                    "type": "number",
+                    "description": "Size of data volume in MiB"
+                },
+                "config-size": {
+                    "type": "number",
+                    "description": "Size of config volume in MiB"
+                }
+            },
+            "required": [
+                "data-size",
+                "config-size"
+            ]
+
+        },
+        "credentials": {
+            "type": "object",
+            "description": "Credentials to authenticate with Minio server",
+            "properties": {
+                "access-key": {
+                    "type": "string",
+                    "description": "Access Key",
+                    "default": "minio"
+                },
+                "secret-key": {
+                    "type": "string",
+                    "description": "Secret Key",
+                    "default": "minio123"
+                }
+            }
+        },
+        "networking": {
+            "description": "Networking properties for Minio on DC/OS",
+            "type": "object",
+            "properties": {
+                "service-port": {
+                    "description": "Minio service port",
+                    "type": "number"
+                },
+                "https-redirect": {
+                    "description": "If true Marathon-LB redirects HTTP traffic to HTTPS",
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "required": [
+                "service-port"
+            ]
+        }
+    }
+}

--- a/repo/packages/M/minio/5/marathon.json.mustache
+++ b/repo/packages/M/minio/5/marathon.json.mustache
@@ -1,0 +1,85 @@
+{
+   "id":"{{service.name}}",
+   "cpus":{{service.cpus}},
+   "mem":{{service.mem}},
+   "instances":1,
+   "maxLaunchDelaySeconds":36000,
+   "args":[
+      "server",
+      "-C",
+      "/config",
+      "/export"
+   ],
+   "container":{
+      "type":"DOCKER",
+      "volumes": [
+        {
+            "containerPath": "miniodata",
+            "mode": "RW",
+            "persistent": {
+            "type": "root",
+            "size" : {{storage.data-size}}
+            }
+        },
+        {
+            "containerPath": "minioconfig",
+            "mode": "RW",
+            "persistent": {
+            "type": "root",
+            "size" : {{storage.config-size}}
+            }
+        },
+        {
+            "containerPath": "/export",
+            "hostPath": "miniodata",
+            "mode": "RW"
+        },
+        {
+            "containerPath": "/config",
+            "hostPath": "minioconfig",
+            "mode": "RW"
+        }
+      ],
+      "docker":{
+         "image":"minio/minio:RELEASE.2017-05-05T01-14-51Z",
+         "network":"BRIDGE",
+         "portMappings":[
+            {
+               "containerPort":9000,
+               "hostPort":0,
+               "servicePort":{{networking.service-port}}
+            }
+         ],
+         "privileged":true,
+         "parameters":[
+
+         ],
+         "forcePullImage":true
+      }
+   },
+   "healthChecks": [
+        {
+            "protocol": "HTTP",
+            "path": "/minio/index.html",
+            "portIndex": 0,
+
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+   ],
+   "env": {
+          "MINIO_ACCESS_KEY": "{{credentials.access-key}}",
+          "MINIO_SECRET_KEY": "{{credentials.secret-key}}"
+   },
+   "labels":{
+    "HAPROXY_GROUP":"external",
+    "HAPROXY_0_REDIRECT_TO_HTTPS":"{{networking.https-redirect}}"
+   },
+   "upgradeStrategy":{
+      "minimumHealthCapacity": 0,
+      "maximumOverCapacity": 0
+    }
+}
+

--- a/repo/packages/M/minio/5/package.json
+++ b/repo/packages/M/minio/5/package.json
@@ -1,0 +1,26 @@
+{
+  "packagingVersion": "3.0",
+  "name": "minio",
+  "version": "0.0.6-RELEASE.2017-05-05T01-14-51Z",
+  "minDcosReleaseVersion": "1.8",
+  "scm": "https://github.com/minio/minio.git",
+  "maintainer": "dev@minio.io",
+  "website": "https://www.minio.io",
+  "framework": false,
+  "description": "Minio is an object storage server compatible with Amazon S3. It is best suited for storing unstructured data such as photos, videos, log files, backups and container / VM images.",
+  "tags": [
+    "data",
+    "storage",
+    "filesystem"
+  ],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Experimental packages should never be used in production!",
+  "postInstallNotes": "Minio DC/OS service has been successfully installed.\nSee https://docs.minio.io/ for documentation.",
+  "postUninstallNotes": "Minio DC/OS service has been successfully uninstalled and will no longer run.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/minio/minio/blob/master/LICENSE"
+    }
+  ],
+  "selected": false
+}

--- a/repo/packages/M/minio/5/resource.json
+++ b/repo/packages/M/minio/5/resource.json
@@ -1,0 +1,22 @@
+{
+  "images": {
+    "icon-small": "https://minio.io/img/icons/minio/minio_dark_sm_ic.png",
+    "icon-medium": "https://minio.io/img/icons/minio/minio_dark_md_ic.png",
+    "icon-large": "https://minio.io/img/icons/minio/minio_dark_lg_ic.png",
+    "screenshots": [
+      "https://minio.io/img/browser/1.png",
+      "https://minio.io/img/browser/2.png",
+      "https://minio.io/img/browser/3.png",
+      "https://minio.io/img/browser/4.png",
+      "https://minio.io/img/browser/5.png",
+      "https://minio.io/img/browser/6.png"
+    ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "minio-docker-RELEASE": "minio/minio:RELEASE.2017-05-05T01-14-51Z"
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Make service name mandatory
* Make data and configuration volumes sticky to a Minio service instance
* Make Minio service externally available on the given service-port
* Allow credentials to be set during installation
* Update package to use latest minio server release image.

The following UI changes are visible during package installation.
1. Each minio instance needs to be named (uniquely)
2. Data and Minio configuration volume size (in MiB) should be provided
3. Service port for Minio should be provided for access via public IP
4. Minio credentials are set to "minio", "minio123" by default.
   I.e, there is no need to find the credentials after installing the
   package.