### PR TITLE
added jre to elastic in universe

### DIFF
--- a/repo/packages/C/ceph/2/marathon.json.mustache
+++ b/repo/packages/C/ceph/2/marathon.json.mustache
@@ -14,7 +14,7 @@
         "MESOS_MASTER": "leader.mesos:5050",
         "CEPH_MON_INIT_PORT": "6789"        
     },
-    "uris": ["https://dl.bintray.com/vivint-smarthome/ceph-on-mesos/ceph-on-mesos-0.2.11.tgz"],
+    "uris": ["{{resource.assets.uris.ceph-tgz}}"],
     "cmd": "cd /mnt/mesos/sandbox/ceph-on-mesos-*\nbin/ceph-on-mesos --api-port=$PORT0",
     "container": {
         "type": "DOCKER",

--- a/repo/packages/C/ceph/2/resource.json
+++ b/repo/packages/C/ceph/2/resource.json
@@ -5,6 +5,9 @@
     "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-ceph-large.png"
   },
   "assets": {
+    "uris": {
+      "ceph-tgz": "https://dl.bintray.com/vivint-smarthome/ceph-on-mesos/ceph-on-mesos-0.2.11.tgz"
+    },
     "container": {
       "docker": {
         "ceph-docker": "fernandosanchez/ceph-on-mesos:0.3"

--- a/repo/packages/E/elastic/5/marathon.json.mustache
+++ b/repo/packages/E/elastic/5/marathon.json.mustache
@@ -26,6 +26,7 @@
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
 
     {{#service.secret_name}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },

--- a/repo/packages/E/elastic/5/marathon.json.mustache
+++ b/repo/packages/E/elastic/5/marathon.json.mustache
@@ -28,6 +28,10 @@
     "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
 
+    "ELASTICSEARCH_URI": "{{resource.assets.uris.elasticsearch-tar-gz}}",
+    "X_PACK_URI": "{{resource.assets.uris.x-pack-zip}}",
+    "SUPPORT_DIAGNOSTICS_URI": "{{resource.assets.uris.support-diagnostics-zip}}",
+
     {{#service.secret_name}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
     "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
@@ -79,7 +83,12 @@
   "uris": [
     "{{resource.assets.uris.jre-tar-gz}}",
     "{{resource.assets.uris.scheduler-zip}}",
-    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "{{resource.assets.uris.elasticsearch-tar-gz}}",
+    "{{resource.assets.uris.x-pack-zip}}",
+    "{{resource.assets.uris.support-diagnostics-zip}}",
+    "{{resource.assets.uris.statsd-plugin-zip}}",
+    "{{resource.assets.uris.kibana-tar-gz}}"
   ],
   "upgradeStrategy":{
     "minimumHealthCapacity": 0,

--- a/repo/packages/E/elastic/5/resource.json
+++ b/repo/packages/E/elastic/5/resource.json
@@ -5,7 +5,12 @@
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.9.0-rc2-1.2.0-rc2-1.tar.gz",
       "executor-zip": "https://downloads.mesosphere.com/elastic/assets/1.0.8-5.2.2/executor.zip",
       "bootstrap-zip": "https://downloads.mesosphere.com/elastic/assets/1.0.8-5.2.2/bootstrap.zip",
-      "scheduler-zip": "https://downloads.mesosphere.com/elastic/assets/1.0.8-5.2.2/elastic-scheduler.zip"
+      "scheduler-zip": "file:///home/andrey/Projects/Ruv/dcos-commons/frameworks/elastic/build/distributions/elastic-scheduler.zip",
+      "elasticsearch-tar-gz": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.2.2.tar.gz",
+      "x-pack-zip": "https://artifacts.elastic.co/downloads/packs/x-pack/x-pack-5.2.2.zip",
+      "support-diagnostics-zip": "https://github.com/elastic/elasticsearch-support-diagnostics/releases/download/5.2/support-diagnostics-5.2-dist.zip",
+      "statsd-plugin-zip": "https://github.com/Automattic/elasticsearch-statsd-plugin/releases/download/5.2.2.0/elasticsearch-statsd-5.2.2.0.zip",
+      "kibana-tar-gz": "https://artifacts.elastic.co/downloads/kibana/kibana-5.2.2-linux-x86_64.tar.gz"
     }
   },
   "images": {


### PR DESCRIPTION
This fixes a fatal handling of the elastic package where it still refers to the default JRE, this won't work in a offline-repository