### PR TITLE
gestalt-framework: 1.2.0 release

### DIFF
--- a/repo/packages/G/gestalt-framework/4/config.json
+++ b/repo/packages/G/gestalt-framework/4/config.json
@@ -1,0 +1,220 @@
+{
+  "properties": {
+    "service": {
+      "description": "Gestalt framework-wide configuration properties",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the framework scheduler inside the base Marathon.",
+          "default": "gestalt-framework",
+          "pattern" : "^(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])$"
+        },
+        "accept-eula": {
+          "type": "string",
+          "description": "Must enter \"yes\"",
+          "default": "[empty]",
+          "pattern": "yes"
+        },
+        "marathon-url": {
+          "type": "string",
+          "description": "The base URL for accessing Marathon by the launcher.",
+          "default": "http://marathon.mesos:8080"
+        },
+        "lb-url": {
+           "type": "string",
+           "description": "The base URL for a marathon-lb instance, for accessing services by their assigned service ports.",
+           "default": ""
+        },
+        "tld": {
+          "type": "string",
+          "description": "Top-level domain for creating marathon-lb virtual hosts for framework services."
+        },
+        "framework-version": {
+          "type": "string",
+          "description": "Version of the Gestalt framework to install",
+          "default": "1.2.0"
+        },
+        "role": {
+          "description": "Deploy gestalt-framework-scheduler only on nodes with this role.",
+          "type": "string"
+        },
+        "debug-logging": {
+          "description": "Enable debug logging.",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "name",
+        "accept-eula",
+        "framework-version",
+        "marathon-url",
+        "debug-logging"
+      ],
+      "type": "object"
+    },
+    "meta": {
+      "description": "gestalt-framework metadata",
+      "properties": {
+        "company-name": {
+          "description": "Preconfigured company name",
+          "default": "A Galactic Fog Customer",
+          "type": "string",
+          "pattern": "^.+$"
+        }
+      },
+      "required": [
+        "company-name"
+      ],
+      "type": "object"
+    },
+    "database" : {
+      "description": "database configuration properties",
+      "properties": {
+        "provision": {
+          "type": "boolean",
+          "description": "Provision a database server for use by the framework services. Otherwise, requires a pre-existing database server.",
+          "default": true
+        },
+        "num-secondaries": {
+          "type": "integer",
+          "description": "When provisioning the database, number of redundant secondaries to be provisioned.",
+          "default": 0
+        },
+        "provisioned-size": {
+          "type": "integer",
+          "description": "When provisioning the database, size for the persistent volume in MB.",
+          "default": 100
+        },
+        "hostname": {
+          "type": "string",
+          "description": "The hostname for the database (only if pre-existing)."
+        },
+        "port": {
+          "type": "integer",
+          "description": "The port for the database (only if pre-existing).",
+          "minimum": 1,
+          "maximum": 32000
+        },
+        "username": {
+          "type": "string",
+          "description": "The username for the database (provisioned or pre-existing)",
+          "default": "gestaltdev"
+        },
+        "password": {
+          "type": "string",
+          "description": "The password for the database (provisioned or pre-existing)",
+          "default": "letmein"
+        },
+        "prefix": {
+          "type": "string",
+          "description": "A prefix for database names for the database (only if pre-existing)",
+          "default": "gestalt-"
+        }
+      },
+      "required": [
+        "provision",
+        "username",
+        "password",
+        "prefix"
+      ],
+      "type": "object"
+    },
+    "security" : {
+      "description": "gestalt-security configuration properties",
+      "properties": {
+        "admin-username": {
+          "type": "string",
+          "description": "The username for the bootstrapped admin account.",
+          "default": "gestalt-admin"
+        },
+        "admin-password": {
+          "type": "string",
+          "description": "The password for the bootstrapped admin account (leave blank for none/no-login).",
+          "default": "letmein"
+        }
+      },
+      "required": [
+        "admin-username",
+        "admin-password"
+      ],
+      "type": "object"
+    },
+    "laser" : {
+      "description": "gestalt-laser lambda scheduler configuration properties",
+      "properties": {
+        "min-cool-executors": {
+          "type": "integer",
+          "description": "Minimum number of cool executors.",
+          "default" : 1,
+          "minimum" : 1
+        },
+        "scale-down-timeout": {
+          "type": "integer",
+          "description": "Lambda executor scale down timeout (seconds)",
+          "default" : 15,
+          "minimum" : 1
+        },
+        "min-port-range": {
+          "type": "integer",
+          "description": "Minimum port number for scheduler listening sockets.",
+          "default" : 60000,
+          "minimum" : 1
+        },
+        "max-port-range": {
+          "type": "integer",
+          "description": "Maximum port number for scheduler listening sockets.",
+          "default" : 60500,
+          "minimum" : 1
+        },
+        "enable-js-runtime": {
+          "description": "Enable javascript lambda runtime.",
+          "type": "boolean",
+          "default": true
+        },
+        "enable-jvm-runtime": {
+          "description": "Enable Java/Scala lambda runtime.",
+          "type": "boolean",
+          "default": true
+        },
+        "enable-dotnet-runtime": {
+          "description": "Enable .NET CLR lambda runtime.",
+          "type": "boolean",
+          "default": true
+        },
+        "enable-golang-runtime": {
+          "description": "Enable Go lambda runtime.",
+          "type": "boolean",
+          "default": true
+        },
+        "enable-python-runtime": {
+          "description": "Enable Python lambda runtime.",
+          "type": "boolean",
+          "default": true
+        },
+        "enable-ruby-runtime": {
+          "description": "Enable Ruby lambda runtime.",
+          "type": "boolean",
+          "default": true
+        }
+      },
+      "required": [
+        "min-cool-executors",
+        "scale-down-timeout",
+        "min-port-range",
+        "max-port-range",
+        "enable-js-runtime",
+        "enable-jvm-runtime",
+        "enable-dotnet-runtime",
+        "enable-golang-runtime",
+        "enable-python-runtime",
+        "enable-ruby-runtime"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "service", "database", "security", "laser", "meta"
+  ],
+  "type": "object"
+}

--- a/repo/packages/G/gestalt-framework/4/marathon.json.mustache
+++ b/repo/packages/G/gestalt-framework/4/marathon.json.mustache
@@ -1,0 +1,42 @@
+{
+  "id": "/{{service.name}}/dcos-launcher",
+  "maintainer": "support@galacticfog.com",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "galacticfog/gestalt-dcos:{{service.framework-version}}",
+      "network": "HOST",
+      "forcePullImage": true
+    }
+  },
+  "env": {
+    "JVM_OPTS": "-Xmx384m",
+    "GESTALT_FRAMEWORK_VERSION": "{{service.framework-version}}"
+  },
+  "cmd": "./bin/gestalt-dcos -Dhttp.port=$PORT0 -Dmeta.company-name=\"{{meta.company-name}}\" -Dmarathon.url={{service.marathon-url}} -Dmarathon.app-group={{service.name}} -Dlaser.scale-down-timeout={{laser.scale-down-timeout}} -Dlaser.max-port-range={{laser.max-port-range}} -Dlaser.min-port-range={{laser.min-port-range}} -Dlaser.min-cool-executors={{laser.min-cool-executors}} -Dlaser.enable-js-runtime={{laser.enable-js-runtime}} -Dlaser.enable-jvm-runtime={{laser.enable-jvm-runtime}} -Dlaser.enable-dotnet-runtime={{laser.enable-dotnet-runtime}} -Dlaser.enable-golang-runtime={{laser.enable-golang-runtime}} -Dlaser.enable-python-runtime={{laser.enable-python-runtime}} -Dlaser.enable-ruby-runtime={{laser.enable-ruby-runtime}} -Dsecurity.username={{security.admin-username}} -Dsecurity.password=\"{{security.admin-password}}\" {{#service.debug-logging}}-Dlogger.resource=debug-logging.xml{{/service.debug-logging}} {{#service.lb-url}}-Dmarathon.lb-url={{service.lb-url}}{{/service.lb-url}} {{#service.tld}}-Dmarathon.tld={{service.tld}}{{/service.tld}} {{#database.hostname}}-Ddatabase.hostname={{database.hostname}}{{/database.hostname}} {{#database.num-secondaries}}-Ddatabase.num-secondaries={{database.num-secondaries}}{{/database.num-secondaries}} {{#database.port}}-Ddatabase.port={{database.port}}{{/database.port}} {{#database.prefix}}-Ddatabase.prefix={{database.prefix}}{{/database.prefix}} -Ddatabase.username={{database.username}} -Ddatabase.password=\"{{database.password}}\" -Ddatabase.provision={{database.provision}} {{#database.provisioned-size}}-Ddatabase.provisioned-size={{database.provisioned-size}}{{/database.provisioned-size}}",
+  "cpus": 0.5,
+  "mem": 512,
+  "instances": 1,
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  },
+  "requirePorts":true,
+  "ports": [
+    0
+  ],
+  {{#service.role}}
+     "acceptedResourceRoles": [
+       "{{service.role}}"
+     ],
+  {{/service.role}}
+  "healthChecks": [{
+    "protocol": "HTTP",
+    "path": "/_gfhealth",
+    "portIndex": 0,
+    "gracePeriodSeconds": 60,
+    "intervalSeconds": 30,
+    "maxConsecutiveFailures": 0
+  }]
+}

--- a/repo/packages/G/gestalt-framework/4/package.json
+++ b/repo/packages/G/gestalt-framework/4/package.json
@@ -1,0 +1,31 @@
+{
+  "description": "The Gestalt Framework is a solution for building enterprise-grade cloud-native applications using containers and lambdas.",
+  "framework": false,
+  "maintainer": "team@galacticfog.com",
+  "minDcosReleaseVersion": "1.8",
+  "name": "gestalt-framework",
+  "packagingVersion" : "3.0",
+  "preInstallNotes": "This DC/OS Service is currently in preview. Requires DC/OS 1.8.5 or later. Please see the Getting started guide at http://www.galacticfog.com/gestalt.html",
+  "postInstallNotes": "The Gestalt Framework is now running on your server.",
+  "postUninstallNotes": "The gestalt-framework launcher has been uninstalled.\nIf the framework services were not shutdown from the launcher, they will need to be manually removed from Marathon.",
+  "selected": false,
+  "tags": [
+    "gestalt-framework",
+    "orchestration",
+    "lambda",
+    "policy"
+  ],
+  "version" : "1.2.0",
+  "scm" : "https://github.com/GalacticFog/gestalt-dcos.git",
+  "website" : "http://www.galacticfog.com",
+  "licenses" : [ {
+      "name" : "Apache License Version 2.0",
+      "url" : "https://github.com/GalacticFog/gestalt-dcos/blob/develop/LICENSE"
+  }, {
+      "name" : "Commercial",
+      "url" : "http://www.galacticfog.com/contact.html"
+  }, {
+      "name" : "End User License Agreement",
+      "url" : "http://www.galacticfog.com/gestalt-eula.html"
+  } ]
+}

--- a/repo/packages/G/gestalt-framework/4/resource.json
+++ b/repo/packages/G/gestalt-framework/4/resource.json
@@ -1,0 +1,30 @@
+{
+  "images": {
+    "icon-large": "https://s3.amazonaws.com/gfi.misc/Gestalt-Icon-Large.png",
+    "icon-medium": "https://s3.amazonaws.com/gfi.misc/Gestalt-Icon-Medium.png",
+    "icon-small": "https://s3.amazonaws.com/gfi.misc/Gestalt-Icon-Small.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "gestalt-dcos":               "galacticfog/gestalt-dcos:1.2.0",
+        "rabbit":                     "galacticfog/rabbit:release-1.2.0",
+        "kong":                       "galacticfog/kong:release-1.2.0",
+        "data":                       "galacticfog/postgres_repl:release-1.2.0",
+        "api-gateway":                "galacticfog/gestalt-api-gateway:release-1.2.0",
+        "laser":                      "galacticfog/gestalt-laser:release-1.2.0",
+        "meta":                       "galacticfog/gestalt-meta:release-1.2.0",
+        "policy":                     "galacticfog/gestalt-policy:release-1.2.0",
+        "security":                   "galacticfog/gestalt-security:release-1.2.0",
+        "ui-react":                   "galacticfog/gestalt-ui-react:release-1.2.0",
+        "laser-ruby-executor":        "galacticfog/gestalt-laser-executor-ruby:release-1.2.0",
+        "laser-js-executor":          "galacticfog/gestalt-laser-executor-js:release-1.2.0",
+        "laser-golang-executor":      "galacticfog/gestalt-laser-executor-golang:release-1.2.0",
+        "laser-python-executor":      "galacticfog/gestalt-laser-executor-python:release-1.2.0",
+        "laser-jvm-executor":         "galacticfog/gestalt-laser-executor-jvm:release-1.2.0",
+        "laser-dotnet-executor":      "galacticfog/gestalt-laser-executor-dotnet:release-1.2.0"
+      }
+    },
+    "uris": {}
+  }
+}


### PR DESCRIPTION
# Changes from 1.1.x to 1.2.x

- gestalt-dcos/#33: use release-1.2.0 instead of separate dcos-1.2.0 and kube-1.2.0 as part of unified ensemble release convention
- gestalt-meta/gestalt-ui-react: add support for new gestalt-log logging aggregation service
- gestalt-meta: improved support for container PUT and PATCH for both DC/OS and Kubernetes CaaS providers
- gestalt-meta/gestalt-ui: new `container.promote` policy support

# Fixed issues
## gestalt-meta
* gestalt-meta#234 - Linked Providers should be persisted with `typeId` 
* gestalt-meta#205 - HAPROXY_GROUP should not happen by default 

## gestalt-ui-react
* gestalt-ui-react#42 - Provider’s screen has columns mislabeled, shows ‘Type’ on the user and timestamp column headings 
* gestalt-ui-react#35 - Logging UI 
* gestalt-ui-react#49 - Don't allow inline code lambdas for non-NodeJS types, since the other executors don't support inline yet 
* gestalt-ui-react#43 - Container Redeploy 
* gestalt-ui-react#45 - Entitlements view for Environment is mistakenly showing the entitlements for the parent workspace 
* gestalt-ui-react#41 - bad name for ApiEndpoint shows up during delete 

## gestalt-cli (provider provisioning)
* galacticfog/gestalt-cli#1 - cli does not provider networks for DCOS provider 
