### PR TITLE
fixed hdfs service name

### DIFF
--- a/repo/packages/B/beta-hdfs/2/marathon.json.mustache
+++ b/repo/packages/B/beta-hdfs/2/marathon.json.mustache
@@ -72,6 +72,7 @@
     "TASKCFG_ALL_NAME_NODE_RPC_PORT":"{{hdfs.name_node_rpc_port}}",
     "TASKCFG_ALL_NAME_NODE_HTTP_PORT":"{{hdfs.name_node_http_port}}",
     "TASKCFG_ALL_ZKFC_PORT": "{{hdfs.zkfc_port}}",
+    "TASKCFG_ALL_FRAMEWORK_NAME": "{{service.name}}",
     "TASKCFG_ALL_JOURNAL_NODE_RPC_PORT":"{{hdfs.journal_node_rpc_port}}",
     "TASKCFG_ALL_JOURNAL_NODE_HTTP_PORT":"{{hdfs.journal_node_http_port}}",
     "TASKCFG_ALL_DATA_NODE_RPC_PORT":"{{hdfs.data_node_rpc_port}}",


### PR DESCRIPTION
The used hdfs-site.xml does point to the incorrect URL for the hdfs-servers, that's because the template isn't filtered correctly. 
This PR should fix that. 