### PR TITLE
Fix spark history

### DIFF
--- a/repo/packages/S/spark-history/0/config.json
+++ b/repo/packages/S/spark-history/0/config.json
@@ -1,62 +1,73 @@
 {
-    "type": "object",
-    "properties": {
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
         "name": {
-            "default": "spark-history",
-            "description": "The app name for the Spark History Server.  The service will be available at http://<dcos_url>/service/<name>/",
-            "type": "string"
+          "default": "spark-history",
+          "description": "The app name for the Spark History Server.  The service will be available at http://<dcos_url>/service/<name>/",
+          "type": "string"
         },
         "cpus": {
-            "default": 1,
-            "description": "CPU shares",
-            "minimum": 0.0,
-            "type": "number"
+          "default": 1,
+          "description": "CPU shares",
+          "minimum": 0.0,
+          "type": "number"
         },
         "mem": {
-            "default": 1024.0,
-            "description": "Memory (MB)",
-            "minimum": 1024.0,
-            "type": "number"
+          "default": 1024.0,
+          "description": "Memory (MB)",
+          "minimum": 1024.0,
+          "type": "number"
         },
         "log-dir": {
-            "description": "Base directory to look for spark events.  Usually a networked directory like HDFS.  Note that this directory must exist prior to installing this package.",
-            "type": "string",
-            "default": "hdfs://hdfs/history"
+          "description": "Base directory to look for spark events.  Usually a networked directory like HDFS.  Note that this directory must exist prior to installing this package.",
+          "type": "string",
+          "default": "hdfs://hdfs/history"
         },
         "user": {
-            "description": "OS user",
-            "type": "string",
-            "default": "root"
+          "description": "OS user",
+          "type": "string",
+          "default": "root"
         },
         "docker-image": {
-            "description": "Docker image to run in.  See https://hub.docker.com/r/mesosphere/spark/tags/ for options.",
-            "type": "string",
-            "default": "mesosphere/spark:1.0.8-2.1.0-1-hadoop-2.6"
+          "description": "Docker image to run in.  See https://hub.docker.com/r/mesosphere/spark/tags/ for options.",
+          "type": "string",
+          "default": "mesosphere/spark:1.0.8-2.1.0-1-hadoop-2.6"
         },
         "hdfs-config-url": {
-            "type": "string",
-            "description": "URL which serves hdfs-site.xml and core-site.xml (i.e. <hdfs-config-url>/hdfs-site.xml should exist)"
-        },
-        "cleaner": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "description": "Specifies whether the Spark History Server should periodically clean up event logs from storage.",
-                    "type": "boolean",
-                    "default": false
-                },
-                "interval": {
-                    "default": "1d",
-                    "description": "Frequency the Spark History Server checks for files to delete.",
-                    "type": "string"
-                },
-                "max-age": {
-                    "default": "7d",
-                    "description": "History files older than this will be deleted.",
-                    "type": "string"
-                }
-            }
+          "type": "string",
+          "description": "URL which serves hdfs-site.xml and core-site.xml (i.e. <hdfs-config-url>/hdfs-site.xml should exist)"
         }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "hdfs-config-url"
+      ]
     },
-    "required": ["hdfs-config-url"]
+    "cleaner": {
+      "type": "object",
+      "description": "Cleaner configuration properties",
+      "properties": {
+        "enabled": {
+          "description": "Specifies whether the Spark History Server should periodically clean up event logs from storage.",
+          "type": "boolean",
+          "default": false
+        },
+        "interval": {
+          "default": "1d",
+          "description": "Frequency the Spark History Server checks for files to delete.",
+          "type": "string"
+        },
+        "max-age": {
+          "default": "7d",
+          "description": "History files older than this will be deleted.",
+          "type": "string"
+        }
+      }
+    }
+  }
 }

--- a/repo/packages/S/spark-history/0/marathon.json.mustache
+++ b/repo/packages/S/spark-history/0/marathon.json.mustache
@@ -1,11 +1,11 @@
 {
-    "id": "{{name}}",
-    "cpus": {{cpus}},
-    "mem": {{mem}},
+    "id": "{{service.name}}",
+    "cpus": {{service.cpus}},
+    "mem": {{service.mem}},
     "cmd": "SPARK_HISTORY_OPTS=\"-Dspark.history.ui.port=${PORT0} ${SPARK_HISTORY_OPTS}\" ./bin/spark-class org.apache.spark.deploy.history.HistoryServer",
     "env": {
-        "APPLICATION_WEB_PROXY_BASE": "/service/{{name}}",
-        "SPARK_HISTORY_OPTS": "-Dspark.history.fs.logDirectory={{log-dir}} -Dspark.history.fs.cleaner.enabled={{cleaner.enabled}} -Dspark.history.fs.cleaner.interval={{cleaner.interval}} -Dspark.history.fs.cleaner.maxAge={{cleaner.max-age}}"
+        "APPLICATION_WEB_PROXY_BASE": "/service/{{service.name}}",
+        "SPARK_HISTORY_OPTS": "-Dspark.history.fs.logDirectory={{service.log-dir}} -Dspark.history.fs.cleaner.enabled={{cleaner.enabled}} -Dspark.history.fs.cleaner.interval={{cleaner.interval}} -Dspark.history.fs.cleaner.maxAge={{cleaner.max-age}}"
     },
     "ports": [0],
     "container": {
@@ -16,15 +16,15 @@
             "parameters": [
                {
                  "key": "user",
-                 "value": "{{user}}"
+                 "value": "{{service.user}}"
                }
             ]
         }
     },
     "labels": {
-        "DCOS_SERVICE_NAME": "{{name}}",
+        "DCOS_SERVICE_NAME": "{{service.name}}",
         "DCOS_SERVICE_PORT_INDEX": "0",
         "DCOS_SERVICE_SCHEME": "http"
     },
-    "uris": ["{{hdfs-config-url}}/hdfs-site.xml", "{{hdfs-config-url}}/core-site.xml"]
+    "uris": ["{{service.hdfs-config-url}}/hdfs-site.xml", "{{service.hdfs-config-url}}/core-site.xml"]
 }

--- a/repo/packages/S/spark-history/0/marathon.json.mustache
+++ b/repo/packages/S/spark-history/0/marathon.json.mustache
@@ -11,7 +11,7 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "{{docker-image}}",
+            "image": "{{resource.assets.container.docker.spark_docker}}",
             "network": "HOST",
             "parameters": [
                {

--- a/repo/packages/S/spark-history/0/package.json
+++ b/repo/packages/S/spark-history/0/package.json
@@ -1,25 +1,27 @@
 {
-    "packagingVersion": "3.0",
-    "preInstallNotes": "This DC/OS Service is currently in preview.",
-    "postInstallNotes": "The Apache Spark History Server is being installed!",
-    "scm": "https://github.com/apache/spark.git",
-    "maintainer": "support@mesosphere.io",
-    "postUninstallNotes": "The Apache Spark History Server has been uninstalled and will no longer run.",
-    "name": "spark-history",
-    "description": "The Apache Spark History Server allows you to view the state of running and completed Spark jobs.",
-    "licenses": [
-        {
-            "name": "Apache License Version 2.0",
-            "url": "https://raw.githubusercontent.com/apache/spark/master/LICENSE"
-        }
-    ],
-    "tags": [
-        "bigdata",
-        "mapreduce",
-        "batch",
-        "analytics"
-    ],
-    "website": "https://docs.mesosphere.com/service-docs/spark/",
-    "version": "2.1.0-1",
-    "minDcosReleaseVersion": "1.7"
+  "description": "The Apache Spark History Server allows you to view the state of running and completed Spark jobs.",
+  "framework": false,
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.7",
+  "name": "spark-history",
+  "packagingVersion": "3.0",
+  "postInstallNotes": "The Apache Spark History Server is being installed!",
+  "postUninstallNotes": "The Apache Spark History Server has been uninstalled and will no longer run.",
+  "preInstallNotes": "This DC/OS Service is currently in preview.",
+  "selected": false,
+  "scm": "https://github.com/apache/spark.git",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/apache/spark/master/LICENSE"
+    }
+  ],
+  "tags": [
+    "bigdata",
+    "mapreduce",
+    "batch",
+    "analytics"
+  ],
+  "website": "https://docs.mesosphere.com/service-docs/spark/",
+  "version": "2.1.0-1"
 }

--- a/repo/packages/S/spark-history/0/resource.json
+++ b/repo/packages/S/spark-history/0/resource.json
@@ -1,0 +1,14 @@
+{
+    "assets": {
+        "container": {
+            "docker": {
+                "spark_docker": "mesosphere/spark:1.0.9-2.1.0-1-hadoop-2.6"
+            }
+        }
+    },
+    "images": {
+        "icon-medium": "https://downloads.mesosphere.io/spark/assets/icon-service-spark-medium.png",
+        "icon-small": "https://downloads.mesosphere.io/spark/assets/icon-service-spark-small.png",
+        "icon-large": "https://downloads.mesosphere.io/spark/assets/icon-service-spark-large.png"
+    }
+}

--- a/repo/packages/S/spark-history/0/resource.json
+++ b/repo/packages/S/spark-history/0/resource.json
@@ -1,14 +1,14 @@
 {
-    "assets": {
-        "container": {
-            "docker": {
-                "spark_docker": "mesosphere/spark:1.0.9-2.1.0-1-hadoop-2.6"
-            }
-        }
-    },
-    "images": {
-        "icon-medium": "https://downloads.mesosphere.io/spark/assets/icon-service-spark-medium.png",
-        "icon-small": "https://downloads.mesosphere.io/spark/assets/icon-service-spark-small.png",
-        "icon-large": "https://downloads.mesosphere.io/spark/assets/icon-service-spark-large.png"
+  "assets": {
+    "container": {
+      "docker": {
+        "spark_docker": "mesosphere/spark:1.0.9-2.1.0-1-hadoop-2.6"
+      }
     }
+  },
+  "images": {
+    "icon-medium": "https://downloads.mesosphere.io/spark/assets/icon-service-spark-medium.png",
+    "icon-small": "https://downloads.mesosphere.io/spark/assets/icon-service-spark-small.png",
+    "icon-large": "https://downloads.mesosphere.io/spark/assets/icon-service-spark-large.png"
+  }
 }


### PR DESCRIPTION
Fixes the spark history server to work in a Offline Repository environment. 
Especially since a build of a Offline Repository wasn't possible. 
It's also now possible to install the spark history server from the dcos ui, previously it's only been possible to do that via CLI