### PR TITLE
Spark thrift: remove redundant parameter and add configurable spark image

### DIFF
--- a/repo/packages/S/spark-thrift-server/0/config.json
+++ b/repo/packages/S/spark-thrift-server/0/config.json
@@ -68,11 +68,6 @@
 					"type": "string",
 					"default": "10"
 				},
-				"spark-max-executors": {
-					"description":  "Maximum number of executors for Spark.",
-					"type": "string",
-					"default": "10"
-				},
 				"spark-executor-docker-image": {
 					"description":  "Maximum number of executors for Spark.",
 					"type": "string",

--- a/repo/packages/S/spark-thrift-server/0/config.json
+++ b/repo/packages/S/spark-thrift-server/0/config.json
@@ -69,9 +69,9 @@
 					"default": "10"
 				},
 				"spark-executor-docker-image": {
-					"description":  "Maximum number of executors for Spark.",
+					"description":  "Name of the docker image to be used for Spark.",
 					"type": "string",
-					"default": "10"
+					"default": "mesosphere/spark:1.0.8-2.1.0-1-hadoop-2.7"
 				},
 				"external_access": {
 					"type": "object",


### PR DESCRIPTION
there is a repeated parameter in config.json "spark-max-executors", this is just the deletion of the redundancy.