### PR TITLE
Remove linkerd resource-roles parameter

### DIFF
--- a/repo/packages/L/linkerd/11/config.json
+++ b/repo/packages/L/linkerd/11/config.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "required": ["linkerd"],
+  "properties": {
+    "linkerd": {
+      "type": "object",
+      "required": ["admin-port", "cpus", "instances", "internal-port", "marathon-host", "marathon-port", "mem", "routing-port"],
+      "properties": {
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "admin-port": {
+          "default": 9990,
+          "description": "Admin port. Provides an administrative UI for this instance.",
+          "type": "integer"
+        },
+        "internal-port": {
+          "default": 4141,
+          "description": "Internal routing port.",
+          "type": "integer"
+        },
+        "routing-port": {
+          "default": 4140,
+          "description": "Routing port.",
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 0.25,
+          "description": "CPU shares to allocate to each linkerd instance.",
+          "minimum": 0.25,
+          "type": "number"
+        },
+        "mem": {
+          "default": 256.0,
+          "description": "Memory (MB) to allocate to each linkerd task.",
+          "minimum": 256.0,
+          "type": "number"
+        },
+        "marathon-host": {
+          "default": "leader.mesos",
+          "description": "DC/OS leader hostname, for Marathon API access.",
+          "type": "string"
+        },
+        "marathon-port": {
+          "default": 8080,
+          "description": "DC/OS leader port, for Marathon API access.",
+          "type": "integer"
+        },
+        "marathon-uri-prefix": {
+          "default": "",
+          "description": "Marathon API prefix. Typically left blank, or '/marathon'.",
+          "type": "string"
+        },
+        "secret_name": {
+          "default": "",
+          "description": "Enterprise Only. Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed. For more information see https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/L/linkerd/11/marathon.json.mustache
+++ b/repo/packages/L/linkerd/11/marathon.json.mustache
@@ -1,0 +1,57 @@
+{
+  "id": "linkerd",
+  "instances": {{linkerd.instances}},
+  "cpus": {{linkerd.cpus}},
+  "mem": {{linkerd.mem}},
+  "acceptedResourceRoles": ["*", "slave_public"],
+  "constraints": [["hostname", "UNIQUE"]],
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.linkerd-docker}}",
+      "network": "HOST",
+      "privileged": true
+    }
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/admin/ping"
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": {{linkerd.admin-port}},
+      "protocol": "tcp",
+      "name": "admin"
+    },
+    {
+      "port": {{linkerd.routing-port}},
+      "protocol": "tcp",
+      "name": "outgoing"
+    },
+    {
+      "port": {{linkerd.internal-port}},
+      "protocol": "tcp",
+      "name": "incoming"
+    }
+  ],
+  "requirePorts": true,
+  "labels": {
+    "DCOS_SERVICE_NAME": "linkerd",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  },
+  {{#linkerd.secret_name}}
+  "env": {
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" }
+  },
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{linkerd.secret_name}}"
+    }
+  },
+  {{/linkerd.secret_name}}
+  "cmd": "echo \"{\\\"admin\\\":{\\\"port\\\":{{linkerd.admin-port}}},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"{{linkerd.marathon-host}}\\\",\\\"port\\\":{{linkerd.marathon-port}},\\\"prefix\\\":\\\"/io.l5d.marathon\\\",\\\"uriPrefix\\\":\\\"{{linkerd.marathon-uri-prefix}}\\\"}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":{{linkerd.routing-port}},\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"outgoing\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"default\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.port\\\",\\\"port\\\":{{linkerd.internal-port}}}]}},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":{{linkerd.internal-port}},\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"incoming\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"default\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.localhost\\\"}]}}]}\"|/io.buoyant/linkerd/1.0.0/bundle-exec -- -"
+}

--- a/repo/packages/L/linkerd/11/package.json
+++ b/repo/packages/L/linkerd/11/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "linkerd",
+  "version": "1.0.0-0.2",
+  "scm": "https://github.com/linkerd/linkerd/",
+  "description": "A dynamic linker for microservices. Install, set your http proxy to $HOST:4140, and connect to your services via app name. linkerd will handle Marathon service discovery for you.",
+  "maintainer": "linkerd-users@googlegroups.com",
+  "website": "https://linkerd.io",
+  "tags": ["linkerd", "namerd", "buoyant", "loadbalancer", "service-discovery", "proxy", "microservices", "rpc"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. We recommend a minimum of 0.25 CPUs and 256 MB of RAM available for linkerd. We also recommend running linkerd on every host. To ensure this, set instances to the number of nodes in your cluster. Installation Documentation: https://github.com/dcos/examples/tree/master/linkerd",
+  "postInstallNotes": "linkerd DC/OS Service has been successfully installed!\nSee https://linkerd.io for documentation.",
+  "postUninstallNotes": "linkerd DC/OS Service has been uninstalled and will no longer run.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/linkerd/linkerd/blob/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/L/linkerd/11/resource.json
+++ b/repo/packages/L/linkerd/11/resource.json
@@ -1,0 +1,17 @@
+{
+  "images": {
+    "icon-small": "https://linkerd.io/images/dcos/linkerd-logo-small.png",
+    "icon-medium": "https://linkerd.io/images/dcos/linkerd-logo-medium.png",
+    "icon-large": "https://linkerd.io/images/dcos/linkerd-logo-large.png",
+    "screenshots": [
+      "https://linkerd.io/images/dcos/linkerd-screenshot.png"
+    ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "linkerd-docker": "buoyantio/linkerd:1.0.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Due to package management changes in DC/OS 1.10, an array of
strings cannot be correctly substituted into the Marathon
template file. Since the resource-roles parameter has a
reasonable default that is unlikely to need changes, this
commit hardcodes it into marathon.json.mustache and removes it
from config.json.

Diff of changes:
```
diff --git a/repo/packages/L/linkerd/10/config.json b/repo/packages/L/linkerd/10/config.json
index 46a5055d..acf5e8ed 100644
--- a/repo/packages/L/linkerd/10/config.json
+++ b/repo/packages/L/linkerd/10/config.json
@@ -5,7 +5,7 @@
   "properties": {
     "linkerd": {
       "type": "object",
-      "required": ["admin-port", "cpus", "instances", "internal-port", "marathon-host", "marathon-port", "mem", "resource-roles", "routing-port"],
+      "required": ["admin-port", "cpus", "instances", "internal-port", "marathon-host", "marathon-port", "mem", "routing-port"],
       "properties": {
         "instances": {
           "default": 1,
@@ -59,11 +59,6 @@
           "default": "",
           "description": "Enterprise Only. Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed. For more information see https://docs.mesosphere.com/1.8/administration/id-and-access-mgt/service-auth/custom-service-auth/",
           "type": "string"
-        },
-        "resource-roles": {
-          "default": "\"*\", \"slave_public\"",
-          "description": "The accepted resource roles (e.g. slave_public). By default, this will deploy to any agents with the \"*\" or \"slave_public\" roles.",
-          "type": "string"
         }
       }
     }
diff --git a/repo/packages/L/linkerd/10/marathon.json.mustache b/repo/packages/L/linkerd/10/marathon.json.mustache
index 9be7ed9b..3dea30b2 100644
--- a/repo/packages/L/linkerd/10/marathon.json.mustache
+++ b/repo/packages/L/linkerd/10/marathon.json.mustache
@@ -3,7 +3,7 @@
   "instances": {{linkerd.instances}},
   "cpus": {{linkerd.cpus}},
   "mem": {{linkerd.mem}},
-  "acceptedResourceRoles": [{{{linkerd.resource-roles}}}],
+  "acceptedResourceRoles": ["*", "slave_public"],
   "constraints": [["hostname", "UNIQUE"]],
   "container": {
     "type": "DOCKER",
diff --git a/repo/packages/L/linkerd/10/package.json b/repo/packages/L/linkerd/10/package.json
index 7e2acb25..cda13705 100644
--- a/repo/packages/L/linkerd/10/package.json
+++ b/repo/packages/L/linkerd/10/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "linkerd",
-  "version": "1.0.0-0.1",
+  "version": "1.0.0-0.2",
   "scm": "https://github.com/linkerd/linkerd/",
   "description": "A dynamic linker for microservices. Install, set your http proxy to $HOST:4140, and connect to your services via app name. linkerd will handle Marathon service discovery for you.",
   "maintainer": "linkerd-users@googlegroups.com",
```