### PR TITLE
Make --dcos_version parameter required for building local Universe

### DIFF
--- a/docker/local-universe/Makefile
+++ b/docker/local-universe/Makefile
@@ -5,16 +5,16 @@ static_image ?= universe-static:$(static_version)
 .PHONY: certs base clean
 
 certs:
-	mkdir certs && openssl req					\
-		-newkey rsa:4096 -nodes -sha256 -keyout certs/domain.key	\
-		-x509 -days 365 -out certs/domain.crt			\
+	mkdir certs && openssl req \
+		-newkey rsa:4096 -nodes -sha256 -keyout certs/domain.key \
+		-x509 -days 365 -out certs/domain.crt \
 		-subj "/CN=master.mesos"
 
 base: clean certs
 	docker build -t universe-base -f Dockerfile.base .
 
 clean:
-	rm -rf certs &&							\
+	rm -rf certs && \
 	rm -f local-universe.tar.gz || 0
 
 static-build:
@@ -28,8 +28,8 @@ static-base:
 	docker build -t universe-base -f Dockerfile.static.base .
 
 local-universe: clean
-	python3 $(REPO_BASE_DIR)/scripts/local-universe.py			\
-		--repository $(REPO_BASE_DIR)/repo/packages/	\
-		--selected &&							\
-	docker save -o local-universe.tar mesosphere/universe:latest &&		\
+	python3 $(REPO_BASE_DIR)/scripts/local-universe.py \
+		--repository $(REPO_BASE_DIR)/repo/packages/ \
+		--selected && \
+	docker save -o local-universe.tar mesosphere/universe:latest && \
 	gzip local-universe.tar

--- a/docker/local-universe/Makefile
+++ b/docker/local-universe/Makefile
@@ -30,6 +30,6 @@ static-base:
 local-universe: clean
 	python3 $(REPO_BASE_DIR)/scripts/local-universe.py \
 		--repository $(REPO_BASE_DIR)/repo/packages/ \
-		--selected && \
+		--selected --dcos_version $(DCOS_VERSION) && \
 	docker save -o local-universe.tar mesosphere/universe:latest && \
 	gzip local-universe.tar

--- a/docker/local-universe/README.md
+++ b/docker/local-universe/README.md
@@ -1,7 +1,7 @@
 
 ## Using
 
-1. For each of your masters, download the [local-universe](https://downloads.mesosphere.com/universe/public/local-universe.tar.gz) container to them.
+1. If you're using the latest stable release of DC/OS, then download the [local-universe](https://downloads.mesosphere.com/universe/public/local-universe.tar.gz) container to each of your masters. Otherwise, you'll need to build the container for your DC/OS version (see the "Building Your Own" section below) and copy it to each of your masters.
 
 1. Load the container into the local docker instance on each master:
 
@@ -60,7 +60,7 @@
 
 - I don't see the package I was looking for!
 
-    By default, we only bundle the `selected` packages. If you'd like to get something else, run the build your own instructions yourself.
+    By default, we only bundle the `selected` packages. If you'd like to include something else, please see the "Building Your Own" section below.
 
 ## Building Your Own
 
@@ -70,10 +70,10 @@
     $ sudo make base
     ```
 
-1. Once you've build the "universe-base" container, you'll be able to create a local-universe one. To keep size and time down, it is common to select only what you'd like to see. By default, `selected` applications are the only ones included. You can pass a list in if you'd like to see something more than that.
+1. Once you've built the "universe-base" container, you'll be able to create a local-universe one. To keep size and time down, it is common to select only what you'd like to see. By default, `selected` applications are the only ones included. You can pass a list in if you'd like to see something more than that.
 
     ```bash
-    $ sudo make local-universe
+    $ sudo make DCOS_VERSION=<your DC/OS version> local-universe
     ```
 
 ## Building Your Own, off a non-changing universe-static base image.
@@ -97,7 +97,7 @@ Mesosphere provides a `mesosphere/universe-static` Docker image, which has all o
 1. Add content (see above)
 
     ```bash
-    $ sudo make local-universe
+    $ sudo make DCOS_VERSION=<your DC/OS version> local-universe
     ```
 
 To generate your own static image, use and/or modify the make target `static-build` (e.g., `make static-build` instead of `make static-online`)
@@ -106,19 +106,19 @@ This leaves three total options:
 
 ```bash
 make base
-make local-universe
+make DCOS_VERSION=<your DC/OS version> local-universe
 ```
 
 ```bash
 make static-online
 make static-base
-make local-universe
+make DCOS_VERSION=<your DC/OS version> local-universe
 ```
 
 ```bash
 make static-build
 make static-base
-make local-universe
+make DCOS_VERSION=<your DC/OS version> local-universe
 ```
 
 ### Outside Resources

--- a/scripts/local-universe.py
+++ b/scripts/local-universe.py
@@ -65,18 +65,17 @@ def main():
         help='Set this to leave CLI resource URLs untouched.')
     parser.add_argument(
         '--dcos_version',
+        required=True,
         help='Set this to the version of DC/OS under which the local universe '
         'will operate. Ensures that only package versions compatible with '
-        'that DC/OS version are included. If unset, the latest version of '
-        'each package will be included.'
+        'that DC/OS version are included. This parameter is required.'
     )
 
     args = parser.parse_args()
 
     package_names = [name for name in args.include.split(',') if name != '']
 
-    dcos_version = distutils.version.LooseVersion(args.dcos_version) \
-        if args.dcos_version else None
+    dcos_version = distutils.version.LooseVersion(args.dcos_version)
 
     with tempfile.TemporaryDirectory() as dir_path, \
             run_docker_registry(dir_path / pathlib.Path("registry")):


### PR DESCRIPTION
Addresses [DCOS_OSS-1299](https://jira.mesosphere.com/browse/DCOS_OSS-1299).

This will ensure that all packages in a local Universe image are compatible with the cluster they will be used in.

I'll have a PR to update the DC/OS documentation shortly. We might want to wait to merge this until after the docs are updated.