### PR TITLE
enhances validations

### DIFF
--- a/scripts/validate-packages.py
+++ b/scripts/validate-packages.py
@@ -5,6 +5,7 @@ import jsonschema
 import os
 import sys
 from distutils.version import LooseVersion
+from urllib.parse import urlparse
 
 SCRIPTS_DIR = os.path.dirname(os.path.realpath(__file__))
 UNIVERSE_DIR = os.path.join(SCRIPTS_DIR, "..")
@@ -41,12 +42,13 @@ def main():
 
 def _validate_package(given_package, path):
     eprint("Validating {}...".format(given_package))
-    for rev in os.listdir(path):
+    revs = sorted(os.listdir(path), key=lambda s: int(s))
+    for rev in revs[0:-1]:
         _validate_revision(given_package, rev, os.path.join(path, rev))
+    _validate_revision(given_package, revs[-1], os.path.join(path, revs[-1]), True)
 
-
-def _validate_revision(given_package, revision, path):
-    eprint("\tValidating revision {}...".format(revision))
+def _validate_revision(given_package, revision, path, latest_revision=False):
+    eprint("\tValidating revision {} {}...".format(revision, '(LATEST)' if latest_revision else ''))
 
     # validate package.json
     package_json_path = os.path.join(path, 'package.json')
@@ -122,7 +124,10 @@ def _validate_revision(given_package, revision, path):
             resource_json = _validate_json(
                 resource_json_path,
                 V3_RESOURCE_JSON_SCHEMA)
-        eprint("\tOK")
+        if (not latest_revision or _validate_resource_assets(resource_json)):
+            eprint("\tOK")
+        else:
+            eprint("")
 
     # Validate that we don't drop information during the conversion
     oldPackage = LooseVersion(
@@ -133,6 +138,22 @@ def _validate_revision(given_package, revision, path):
                  'only supported when minDcosReleaseVersion is greater than '
                  '1.8.')
 
+def _validate_resource_assets(resource_json):
+    all_good = True
+    for (type, uri) in resource_json.get('assets',{}).get('uris',{}).items():
+
+        # Check for non-https assets
+        if (urlparse(uri).scheme != 'https'):
+            all_good = False
+            eprint("\n\t\t\tWARNING non-https link: {}".format(uri), end='')
+
+        # check for links on downloads downloads.mesosphere.com that do not point
+        # to a dedicated sub dir.
+        if (urlparse(uri).hostname == 'downloads.mesosphere.com' and not urlparse(uri).path.startswith('/universe/assets/') ):
+            all_good = False
+            eprint("\n\t\t\tWARNING downloads.mesosphere.com asset in stray directory: {}".format(uri), end='')
+
+    return all_good
 
 def _validate_json(path, schema):
         with open(path, encoding='utf-8') as f:


### PR DESCRIPTION
With this commit we will be able to run a certain set of validation
only against the most recent revision of a package. This is helpful to
not dig in historic, non-changeable files for (now) unsupported features.

Two checks are provided with this feature:
Check for non-https links and
validate that assets hosted on downloads.mesosphere.com are in a specific sub-directory.
The later only applies to packages hosted by mesosphere and we should use these WARNINGS
to lean up our distribution.
Suggestion: Go trough package by package and fix what is needed in a new revision each.

I am open for discussion on if and how we should proceed with this. 
Reference: https://jira.mesosphere.com/browse/QUALITY-1487