### PR TITLE
Updated package schema for stringent validation of service name

### DIFF
--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -27,7 +27,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[a-z]+[a-z0-9-_]+$",
+          "pattern": "^[a-z]+[a-z0-9-]*[a-z0-9]+$",
           "description": "The name of the package."
         },
         "version": {
@@ -122,7 +122,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[a-z]+[a-z0-9-_]+$",
+          "pattern": "^[a-z]+[a-z0-9-]*[a-z0-9]+$",
           "description": "The name of the package."
         },
         "version": {
@@ -222,7 +222,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[a-z]+[a-z0-9-_]+$",
+          "pattern": "^[a-z]+[a-z0-9-]*[a-z0-9]+$",
           "description": "The name of the package."
         },
         "version": {

--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -27,6 +27,7 @@
         },
         "name": {
           "type": "string",
+          "pattern": "^[a-z]+[a-z0-9-_]+$",
           "description": "The name of the package."
         },
         "version": {
@@ -121,6 +122,7 @@
         },
         "name": {
           "type": "string",
+          "pattern": "^[a-z]+[a-z0-9-_]+$",
           "description": "The name of the package."
         },
         "version": {
@@ -220,6 +222,7 @@
         },
         "name": {
           "type": "string",
+          "pattern": "^[a-z]+[a-z0-9-_]+$",
           "description": "The name of the package."
         },
         "version": {
@@ -334,4 +337,3 @@
   ]
 
 }
-

--- a/repo/meta/schema/package-schema.json
+++ b/repo/meta/schema/package-schema.json
@@ -27,7 +27,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[a-z]+[a-z0-9-]*[a-z0-9]+$",
+          "pattern": "^[a-z][a-z0-9-]*[a-z0-9]$",
           "description": "The name of the package."
         },
         "version": {
@@ -122,7 +122,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[a-z]+[a-z0-9-]*[a-z0-9]+$",
+          "pattern": "^[a-z][a-z0-9-]*[a-z0-9]$",
           "description": "The name of the package."
         },
         "version": {
@@ -222,7 +222,7 @@
         },
         "name": {
           "type": "string",
-          "pattern": "^[a-z]+[a-z0-9-]*[a-z0-9]+$",
+          "pattern": "^[a-z][a-z0-9-]*[a-z0-9]$",
           "description": "The name of the package."
         },
         "version": {


### PR DESCRIPTION
Current rules for validation are : 

- Starts with [a-z]
- each character can only be [a-z] or - or [0-9]