### PR TITLE
tunnel-cli: Bump to 2.0.2

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -8,6 +8,3 @@ UNIVERSE_DIR=$GIT_HOOKS_DIR/../..
 SCRIPTS_DIR=$UNIVERSE_DIR/scripts
 
 $SCRIPTS_DIR/build.sh
-
-# Fail if there are unstaged changes
-git diff --exit-code

--- a/repo/packages/T/tunnel-cli/9/package.json
+++ b/repo/packages/T/tunnel-cli/9/package.json
@@ -1,0 +1,9 @@
+{
+  "packagingVersion": "3.0",
+  "name": "tunnel-cli",
+  "version": "2.0.0",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.8",
+  "description": "Proxy and VPN access to your DC/OS cluster",
+  "tags": [ "mesosphere", "subcommand", "proxy", "vpn", "socks", "http", "cli" ]
+}

--- a/repo/packages/T/tunnel-cli/9/package.json
+++ b/repo/packages/T/tunnel-cli/9/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "tunnel-cli",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "maintainer": "support@mesosphere.io",
   "minDcosReleaseVersion": "1.8",
   "description": "Proxy and VPN access to your DC/OS cluster",

--- a/repo/packages/T/tunnel-cli/9/resource.json
+++ b/repo/packages/T/tunnel-cli/9/resource.json
@@ -1,0 +1,30 @@
+{
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "1ad7b01849eb3c6fc0249a55551555158378c2e4f4ded2c51ea4dcc7bd770cc8"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/2.0.0/dcos-tunnel.zip"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "e1dd0821f75b1ba6c9638b2f3007b00c755d28a299357c9a786c419656f80cf4"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/2.0.0/dcos-tunnel.zip"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/T/tunnel-cli/9/resource.json
+++ b/repo/packages/T/tunnel-cli/9/resource.json
@@ -6,11 +6,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "1ad7b01849eb3c6fc0249a55551555158378c2e4f4ded2c51ea4dcc7bd770cc8"
+                            "value": "37ef0b047e224e1e026d7fde3b93083840bef9f04ee7451d4ac01a044a34f07f"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/2.0.0/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/2.0.2/dcos-tunnel.zip"
                 }
             },
             "linux": {
@@ -18,11 +18,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "e1dd0821f75b1ba6c9638b2f3007b00c755d28a299357c9a786c419656f80cf4"
+                            "value": "549adb00abdef0e0251df1a993d6997a76935ab8cd1d054ab3ae593af1271514"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/2.0.0/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/2.0.2/dcos-tunnel.zip"
                 }
             }
         }


### PR DESCRIPTION
This updates to the latest dcoscli library so it is compatible with the
newest DC/OS CLI.