### PR TITLE
Update datadog package to 5.16.0

### DIFF
--- a/repo/packages/D/datadog/3/config.json
+++ b/repo/packages/D/datadog/3/config.json
@@ -1,0 +1,54 @@
+{
+    "properties": {
+        "datadog": {
+            "description": "Datadog specific configuration properties",
+            "properties": {
+                "api_key": {
+                    "description": "Your Datadog API key.",
+                    "type": "string"
+                },
+                "app_id": {
+                    "default": "datadog-agent",
+                    "description": "Marathon Application ID",
+                    "type": "string"
+                },
+                "cpus": {
+                    "default": 0.05,
+                    "description": "CPU shares to allocate to each Marathon instance.",
+                    "minimum": 0.0,
+                    "type": "number"
+                },
+                "instances": {
+                    "default": 1,
+                    "description": "Number of Marathon instances to run.",
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "mem": {
+                    "default": 256.0,
+                    "description": "Memory (MB) to allocate to each Marathon task.",
+                    "minimum": 256.0,
+                    "type": "number"
+                },
+                "statsd_port": {
+                    "default": 8125,
+                    "description": "statsD port",
+                    "type": "integer"
+                },
+                "supervisor_port": {
+                    "default": 9001,
+                    "description": "Agent supervisord port",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "api_key"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "datadog"
+    ],
+    "type": "object"
+}

--- a/repo/packages/D/datadog/3/marathon.json.mustache
+++ b/repo/packages/D/datadog/3/marathon.json.mustache
@@ -1,0 +1,65 @@
+{
+    "id": "{{datadog.app_id}}",
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.73925bb9ab66}}",
+            "parameters": [
+                {
+                    "key": "name", "value": "dd-agent"
+                },
+                {
+                    "key": "env", "value": "API_KEY={{datadog.api_key}}"
+                },
+                {
+                    "key": "env", "value": "MESOS_SLAVE=true"
+                },
+                {
+                    "key": "env", "value": "SD_BACKEND=docker"                
+                }
+            ],
+            "network": "BRIDGE",
+            "portMappings": [
+                { "hostPort": {{datadog.statsd_port}}, "containerPort": 8125, "protocol": "udp" },
+                { "hostPort": {{datadog.supervisor_port}}, "containerPort": 9001, "protocol": "tcp" }
+            ]
+        },
+        "volumes": [
+            {
+                "containerPath": "/var/run/docker.sock",
+                "hostPath": "/var/run/docker.sock",
+                "mode": "RO"
+            },
+            {
+                "containerPath": "/host/proc",
+                "hostPath": "/proc",
+                "mode": "RO"
+            },
+            {
+                "containerPath": "/host/sys/fs/cgroup",
+                "hostPath": "/sys/fs/cgroup",
+                "mode": "RO"
+            }
+        ]
+    },
+    "cpus": {{datadog.cpus}},
+    "mem": {{datadog.mem}},
+    "instances": {{datadog.instances}},
+    "acceptedResourceRoles": ["slave_public", "*"],
+    "constraints": [
+        ["hostname", "UNIQUE"],
+        ["hostname", "GROUP_BY"]
+    ],
+    "healthChecks": [
+        {
+            "path": "/",
+            "portIndex": 1,
+            "protocol": "HTTP",
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3,
+            "ignoreHttp1xx": false
+        }
+    ]
+}

--- a/repo/packages/D/datadog/3/package.json
+++ b/repo/packages/D/datadog/3/package.json
@@ -1,0 +1,23 @@
+{
+    "packagingVersion": "3.0",
+    "description": "Datadog is a hosted monitoring service for cloud-scale infrastructure and applications",
+    "framework": false,
+    "licenses": [
+        {
+            "name": "Simplified BSD license",
+            "url": "https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE"
+        }
+    ],
+    "maintainer": "package@datadoghq.com",
+    "name": "datadog",
+    "postInstallNotes": "Datadog on DCOS successfully installed.\nHead over to https://app.datadoghq.com to monitor your DCOS cluster.",
+    "postUninstallNotes": "Datadog on DCOS successfully uninstalled.\n.",
+    "preInstallNotes": "This DC/OS Service is currently in preview. \n Pass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api \nAlso pass the number of Mesos slaves as an option (datadog.instances).\nMarathon will make sure that the Datadog Agent runs only once per slave.",
+    "scm": "https://github.com/datadog/dd-agent.git",
+    "tags": [
+        "datadog",
+        "monitoring"
+    ],
+    "version": "5.16.0",
+    "website": "https://www.datadoghq.com/"
+}

--- a/repo/packages/D/datadog/3/package.json
+++ b/repo/packages/D/datadog/3/package.json
@@ -1,5 +1,6 @@
 {
     "packagingVersion": "3.0",
+    "minDcosReleaseVersion" : "1.8",
     "description": "Datadog is a hosted monitoring service for cloud-scale infrastructure and applications",
     "framework": false,
     "licenses": [

--- a/repo/packages/D/datadog/3/resource.json
+++ b/repo/packages/D/datadog/3/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "73925bb9ab66": "datadog/docker-dd-agent:11.0.5160"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-large.png"
+  }
+}


### PR DESCRIPTION
The latest releases brings several improvements for Mesos hosts, including:

  - added host tags `mesos-version` and `dcos-version`
  - added `marathon_app`, `chronos_job` and `chronos_job_owner` tags to metrics

For a complete list of changes, see [the dd-agent changelog](https://github.com/DataDog/dd-agent/blob/5.16.x/CHANGELOG.md) and the [docker integration changelog](https://github.com/DataDog/integrations-core/blob/5.16.x/docker_daemon/CHANGELOG.md).


Packaging changes compared to revision 2:
- reference new image tag
- raise default mem limit to recommended 256MB
- update website url