### PR TITLE
tunnel-cli: Bump to 2.1.0

### DIFF
--- a/repo/packages/T/tunnel-cli/10/package.json
+++ b/repo/packages/T/tunnel-cli/10/package.json
@@ -1,0 +1,9 @@
+{
+  "packagingVersion": "3.0",
+  "name": "tunnel-cli",
+  "version": "2.0.2",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.8",
+  "description": "Proxy and VPN access to your DC/OS cluster",
+  "tags": [ "mesosphere", "subcommand", "proxy", "vpn", "socks", "http", "cli" ]
+}

--- a/repo/packages/T/tunnel-cli/10/package.json
+++ b/repo/packages/T/tunnel-cli/10/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "tunnel-cli",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "maintainer": "support@mesosphere.io",
   "minDcosReleaseVersion": "1.8",
   "description": "Proxy and VPN access to your DC/OS cluster",

--- a/repo/packages/T/tunnel-cli/10/resource.json
+++ b/repo/packages/T/tunnel-cli/10/resource.json
@@ -1,0 +1,30 @@
+{
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "37ef0b047e224e1e026d7fde3b93083840bef9f04ee7451d4ac01a044a34f07f"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/2.0.2/dcos-tunnel.zip"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "549adb00abdef0e0251df1a993d6997a76935ab8cd1d054ab3ae593af1271514"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/2.0.2/dcos-tunnel.zip"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/T/tunnel-cli/10/resource.json
+++ b/repo/packages/T/tunnel-cli/10/resource.json
@@ -6,11 +6,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "37ef0b047e224e1e026d7fde3b93083840bef9f04ee7451d4ac01a044a34f07f"
+                            "value": "3d3bdad441c5fca4385c2cc679bbb6ce8a5c7c0074594de23e48d625991b1a26"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/2.0.2/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/2.1.0/dcos-tunnel.zip"
                 }
             },
             "linux": {
@@ -18,11 +18,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "549adb00abdef0e0251df1a993d6997a76935ab8cd1d054ab3ae593af1271514"
+                            "value": "225c83f6418a4cc9c8a4cf458847ed7db19ab5802de40aa553b39d2a3dfed7e3"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/2.0.2/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/2.1.0/dcos-tunnel.zip"
                 }
             }
         }


### PR DESCRIPTION
This adds flags to configure VPN routes.