### PR TITLE
tunnel-cli: Bump to 2.2.0

### DIFF
--- a/repo/packages/T/tunnel-cli/11/package.json
+++ b/repo/packages/T/tunnel-cli/11/package.json
@@ -1,0 +1,9 @@
+{
+  "packagingVersion": "3.0",
+  "name": "tunnel-cli",
+  "version": "2.1.0",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.8",
+  "description": "Proxy and VPN access to your DC/OS cluster",
+  "tags": [ "mesosphere", "subcommand", "proxy", "vpn", "socks", "http", "cli" ]
+}

--- a/repo/packages/T/tunnel-cli/11/package.json
+++ b/repo/packages/T/tunnel-cli/11/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "tunnel-cli",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "maintainer": "support@mesosphere.io",
   "minDcosReleaseVersion": "1.8",
   "description": "Proxy and VPN access to your DC/OS cluster",

--- a/repo/packages/T/tunnel-cli/11/resource.json
+++ b/repo/packages/T/tunnel-cli/11/resource.json
@@ -1,0 +1,30 @@
+{
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "3d3bdad441c5fca4385c2cc679bbb6ce8a5c7c0074594de23e48d625991b1a26"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/2.1.0/dcos-tunnel.zip"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "225c83f6418a4cc9c8a4cf458847ed7db19ab5802de40aa553b39d2a3dfed7e3"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/2.1.0/dcos-tunnel.zip"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/T/tunnel-cli/11/resource.json
+++ b/repo/packages/T/tunnel-cli/11/resource.json
@@ -6,11 +6,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "3d3bdad441c5fca4385c2cc679bbb6ce8a5c7c0074594de23e48d625991b1a26"
+                            "value": "5f1458ecdffbc4848543be515301ca42bd339b8b8566d0d23ad1fe42389188e1"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/2.1.0/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/darwin/x86-64/2.2.0/dcos-tunnel.zip"
                 }
             },
             "linux": {
@@ -18,11 +18,11 @@
                     "contentHash": [
                         {
                             "algo": "sha256",
-                            "value": "225c83f6418a4cc9c8a4cf458847ed7db19ab5802de40aa553b39d2a3dfed7e3"
+                            "value": "09ba714bbfef54e75048715b9747bee7243b696c00afeb113b84e27a90f61877"
                         }
                     ],
                     "kind": "zip",
-                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/2.1.0/dcos-tunnel.zip"
+                    "url": "https://downloads.dcos.io/cli/binaries/linux/x86-64/2.2.0/dcos-tunnel.zip"
                 }
             }
         }


### PR DESCRIPTION
This includes auto-configuration of VIP and overlay in the VPN.