### PR TITLE
Add Tadpole DB Hub to Universe.

### DIFF
--- a/repo/packages/T/tadpoledbhub/0/config.json
+++ b/repo/packages/T/tadpoledbhub/0/config.json
@@ -1,0 +1,69 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "description": "Configuration properties for the Tadpole DB Hub service for DC/OS.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the service to display in the DC/OS dashboard.",
+          "type": "string",
+          "default": "tadpoledbhub"
+        },
+        "cpus": {
+          "description": "CPU shares to allocate to this Tadpole DB Hub instance.",
+          "type": "number",
+          "default": 1,
+          "minimum": 0.5
+        },
+        "mem": {
+          "description": "Memory (in MB) to allocate to this Tadpole DB Hub instance.",
+          "type": "number",
+          "default": 1024.0,
+          "minimum": 512.0
+        }
+      },
+      "required": [
+        "name",
+        "cpus",
+        "mem"
+      ]
+    },
+    "networking": {
+      "description": "Networking-related configuration properties for Tadpole DB Hub on DC/OS.",
+      "type": "object",
+      "properties": {
+        "virtual-host": {
+          "description": "The virtual host address to configure for integration with Marathon-lb. This config need marathon-lb which configured with external group.",
+          "type": "string"
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "description": "Engine storage configuration properties for Tadpole DB Hub.",
+      "properties":{
+        "enable-persistent-storage": {
+          "description": "Enable or disable persistent storage. If this is not enabled, Tadpole DB Hub's data(user list, db list, query history, etc) will not be preserved. If enable, \"volume-size\" and \"pinned-hostname\" is requried.",
+          "type": "boolean",
+          "default": false
+        },
+        "volume-size": {
+          "description": "If a new volume is to be created, this controls its size in MBs.",
+          "type": "number",
+          "default": 512,
+          "minimum": 256.0
+        },
+        "pinned-hostname": {
+          "description": "Host IP or hostname where Tadpole DB Hub on.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "required": [
+    "service",
+    "networking",
+    "storage"
+  ]
+}

--- a/repo/packages/T/tadpoledbhub/0/marathon.json.mustache
+++ b/repo/packages/T/tadpoledbhub/0/marathon.json.mustache
@@ -1,0 +1,68 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "instances": 1,
+  "env": {
+    "TADPOLEDBHUB_VERSION": "1.7.4"
+  },
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.tadpoledbhub}}",
+      "network": "BRIDGE",
+      "portMappings": [
+        { "containerPort": 8080, "hostPort": 0 }
+      ]
+    },
+    "volumes": [
+{{#storage.enable-persistent-storage}}
+      {
+        "containerPath": "tadpoledata",
+        "mode": "RW",
+        "persistent": {
+          "type": "root",
+          "size": {{storage.volume-size}}
+        }
+      },
+      {
+        "containerPath": "/usr/local/tomcat/work/Catalina/localhost/ROOT/eclipse/configuration/tadpole/db",
+        "hostPath": "tadpoledata",
+        "mode": "RW"
+      }
+{{/storage.enable-persistent-storage}}
+    ]
+  },
+  "healthChecks": [
+    {
+      "path": "/",
+      "portIndex": 0,
+      "protocol": "MESOS_HTTP",
+      "gracePeriodSeconds": 180,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3
+    }
+  ],
+  "labels": {
+{{#networking.virtual-host}}
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_VHOST": "{{networking.virtual-host}}",
+    "HAPROXY_0_MODE": "http",
+{{/networking.virtual-host}}
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME" : "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX"  : "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+{{#storage.enable-persistent-storage}}
+  "residency": {
+    "taskLostBehavior": "WAIT_FOREVER"
+  },
+  "constraints": [["hostname", "CLUSTER", "{{storage.pinned-hostname}}"]],
+{{/storage.enable-persistent-storage}}
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/T/tadpoledbhub/0/package.json
+++ b/repo/packages/T/tadpoledbhub/0/package.json
@@ -1,0 +1,23 @@
+{
+  "packagingVersion": "3.0",
+  "name": "tadpoledbhub",
+  "version": "0.0.1-1.7.4r7-LGPL",
+  "minDcosReleaseVersion": "1.9",
+  "scm": "https://github.com/hangum/docker-TadpoleDBHub",
+  "maintainer": "https://dcos.io/community/",
+  "website": "https://github.com/hangum/TadpoleForDBTools",
+  "framework": false,
+  "description": "Tadpole DB Hub is Unified infrastructure tool, various environment based interface for managing Altibase, Apache Hive, Amazon RDS, MySQL, Oracle, SQLite, MSSQL, PostgreSQL and MongoDB databases.\nDocumentation is available at: https://github.com/dcos/examples/.",
+  "tags": ["mysql", "postgresql", "sqlserver", "database", "admin"],
+  "preInstallNotes": "This DC/OS Service is currently in preview.",
+  "postInstallNotes": "Tadpole DB Hub has been installed.",
+  "postUninstallNotes": "Tadpole DB Hub has been uninstalled.",
+  "licenses": [
+    {
+      "name": "LGPL",
+      "url": "https://github.com/hangum/TadpoleForDBTools/#license"
+    }
+  ],
+  "selected": false
+}
+

--- a/repo/packages/T/tadpoledbhub/0/resource.json
+++ b/repo/packages/T/tadpoledbhub/0/resource.json
@@ -1,0 +1,15 @@
+{
+  "images": {
+    "icon-small": "https://raw.githubusercontent.com/hangum/TadpoleForDBTools/master/com.hangum.tadpole.chromeapp/chrome_app/icon_16.png",
+    "icon-medium": "https://raw.githubusercontent.com/hangum/TadpoleForDBTools/master/com.hangum.tadpole.chromeapp/chrome_app/icon_48.png",
+    "icon-large": "https://raw.githubusercontent.com/hangum/TadpoleForDBTools/master/com.hangum.tadpole.chromeapp/chrome_app/icon_128.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "tadpoledbhub": "hyunjongcho/tadpoledbhub:1.7.4r7"
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Tadpole DB Hub is a DB tool like PHPMyAdmin but, it support many DBs like MySQL, MSSQL, etc. This PR is for add opensource version of Tadpole DB Hub to the Universe.