### PR TITLE
Roll back to Zeppelin 0.5.6

### DIFF
--- a/repo/packages/Z/zeppelin/5/config.json
+++ b/repo/packages/Z/zeppelin/5/config.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "service": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "default": "zeppelin"
+                },
+                "zeppelin_java_opts": {
+                    "type": "string",
+                    "description": "Sets ZEPPELIN_JAVA_OPTS.  You can use this to set arbitrary spark configuration properties (e.g. spark.mesos.uris)",
+                    "default": "-Dspark.mesos.coarse=true -Dspark.mesos.executor.home=/opt/spark/dist"
+                }
+            }
+        },
+        "spark": {
+            "type": "object",
+            "properties": {
+                "uri": {
+                    "type": "string",
+                    "description": "A URI serving the Spark distribution to use for the local Zeppelin Spark context.  By default, this will use the value specified in this package's resource.json"
+                },
+                "executor_docker_image": {
+                    "type": "string",
+                    "description": "The docker image to launch Spark executors with.  By default, this will use this value specified in this package's resource.json"
+                },
+                "cores_max": {
+                    "type": "string",
+                    "description": "Sets spark.cores.max",
+                    "default": ""
+                },
+                "executor_memory": {
+                    "type": "string",
+                    "description": "Sets spark.executor.memory"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/Z/zeppelin/5/marathon.json.mustache
+++ b/repo/packages/Z/zeppelin/5/marathon.json.mustache
@@ -1,0 +1,36 @@
+{
+    "id": "/zeppelin",
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.zeppelin}}",
+            "network": "HOST"
+        }
+    },
+    "healthChecks": [{
+        "protocol": "TCP",
+        "gracePeriodSeconds": 300,
+        "intervalSeconds": 60,
+        "portIndex": 0,
+        "timeoutSeconds": 15,
+        "maxConsecutiveFailures": 3
+    }],
+    "labels": {
+        "DCOS_SERVICE_NAME": "{{service.name}}",
+        "DCOS_SERVICE_SCHEME": "http",
+        "DCOS_SERVICE_PORT_INDEX": "0"
+    },
+    "env": {
+        "SPARK_MESOS_EXECUTOR_DOCKER_IMAGE": "{{#spark.executor_docker_image}}{{spark.executor_docker_image}}{{/spark.executor_docker_image}}{{^spark.executor_docker_image}}{{resource.assets.container.docker.spark}}{{/spark.executor_docker_image}}",
+        "SPARK_CORES_MAX": "{{spark.cores_max}}",
+        "SPARK_EXECUTOR_MEMORY": "{{spark.executor_memory}}",
+        "ZEPPELIN_JAVA_OPTS": "{{service.zeppelin_java_opts}}"
+    },
+    "cmd": "sed \"s#<value>8080</value>#<value>$PORT0</value>#\" < conf/zeppelin-site.xml.template > conf/zeppelin-site.xml && sed -i \"s#<value>-1</value>#<value>$PORT1</value>#\" conf/zeppelin-site.xml && SPARK_HOME_TGZ=$(ls ${MESOS_SANDBOX}/spark-*.tgz) SPARK_HOME=${SPARK_HOME_TGZ%.tgz} bin/zeppelin.sh start",
+    "ports": [0, 0],
+    "cpus": 1,
+    "mem": 2048.0,
+    "fetch": [
+      {"uri": "{{#spark.uri}}{{spark.uri}}{{/spark.uri}}{{^spark.uri}}{{resource.assets.uris.spark}}{{/spark.uri}}", "cache": true}
+    ]
+}

--- a/repo/packages/Z/zeppelin/5/package.json
+++ b/repo/packages/Z/zeppelin/5/package.json
@@ -1,0 +1,20 @@
+{
+    "packagingVersion": "2.0",
+    "name": "zeppelin",
+    "version": "0.5.6-2",
+    "scm": "https://github.com/apache/incubator-zeppelin",
+    "maintainer": "https://dcos.io/community/",
+    "description": "Zeppelin is a web-based notebook that enables interactive data analytics",
+    "framework": true,
+    "tags": [
+        "nflabs",
+        "framework",
+        "bigdata",
+        "spark",
+        "notebook",
+        "interactive"
+    ],
+    "website": "https://github.com/mesosphere/dcos-zeppelin",
+    "preInstallNotes": "This DC/OS Service is currently in preview.",
+    "postInstallNotes": "DC/OS Zeppelin is being installed!\n\n\tDocumentation: https://github.com/dcos/examples/tree/master/1.8/zeppelin/\n\tIssues: https://dcos.io/community/"
+}

--- a/repo/packages/Z/zeppelin/5/resource.json
+++ b/repo/packages/Z/zeppelin/5/resource.json
@@ -1,0 +1,18 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/zeppelin/assets/icon-service-zeppelin-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/zeppelin/assets/icon-service-zeppelin-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/zeppelin/assets/icon-service-zeppelin-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "zeppelin": "mesosphere/zeppelin:0.5.6-3",
+        "spark": "mesosphere/spark:1.6.0"
+      }
+    },
+    "uris": {
+      "spark": "https://downloads.mesosphere.io/spark/assets/spark-1.6.0.tgz"
+    }
+  }
+}


### PR DESCRIPTION
We're having trouble running Spark jobs with the new 0.7.0
version of this package. Roll back to known working 0.5.6.