### PR TITLE
Remove marathon as required

### DIFF
--- a/repo/meta/schema/build-definition-schema.json
+++ b/repo/meta/schema/build-definition-schema.json
@@ -317,7 +317,6 @@
       "required": [
         "packagingVersion",
         "name",
-        "marathon",
         "version",
         "maintainer",
         "description",
@@ -433,7 +432,6 @@
       "required": [
         "packagingVersion",
         "name",
-        "marathon",
         "version",
         "maintainer",
         "description",

--- a/repo/meta/schema/metadata-schema.json
+++ b/repo/meta/schema/metadata-schema.json
@@ -302,7 +302,6 @@
       "required": [
         "packagingVersion",
         "name",
-        "marathon",
         "version",
         "maintainer",
         "description",
@@ -412,7 +411,6 @@
       "required": [
         "packagingVersion",
         "name",
-        "marathon",
         "version",
         "maintainer",
         "description",


### PR DESCRIPTION
This PR makes it so that marathon is not required in metadata.json or build-definition.json 