### PR TITLE
[INFINITY-2196] Set the hello-world minDcosReleaseVersion to 1.8

### DIFF
--- a/repo/packages/H/hello-world/10/package.json
+++ b/repo/packages/H/hello-world/10/package.json
@@ -2,7 +2,7 @@
   "description": "An example implementation of a stateful service using the DC/OS SDK",
   "framework": true,
   "maintainer": "support@mesosphere.io",
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.8",
   "name": "hello-world",
   "packagingVersion": "3.0",
   "postInstallNotes": "DC/OS hello-world is being installed!\n\n\tDocumentation: https://github.com/mesosphere/dcos-commons/tree/master/frameworks/helloworld\n\tIssues: https://docs.mesosphere.com/support/",

--- a/repo/packages/H/hello-world/11/package.json
+++ b/repo/packages/H/hello-world/11/package.json
@@ -2,7 +2,7 @@
   "description": "An example implementation of a stateful service using the DC/OS SDK",
   "framework": true,
   "maintainer": "support@mesosphere.io",
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.8",
   "name": "hello-world",
   "packagingVersion": "3.0",
   "postInstallNotes": "DC/OS hello-world is being installed!\n\n\tDocumentation: https://github.com/mesosphere/dcos-commons/tree/master/frameworks/helloworld\n\tIssues: https://docs.mesosphere.com/support/",

--- a/repo/packages/H/hello-world/6/package.json
+++ b/repo/packages/H/hello-world/6/package.json
@@ -2,7 +2,7 @@
   "description": "An example implementation of a stateful service using the DC/OS SDK",
   "framework": true,
   "maintainer": "support@mesosphere.io",
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.8",
   "name": "hello-world",
   "packagingVersion": "3.0",
   "preInstallNotes": "This DC/OS Service is currently in preview.",

--- a/repo/packages/H/hello-world/7/package.json
+++ b/repo/packages/H/hello-world/7/package.json
@@ -2,7 +2,7 @@
   "description": "An example implementation of a stateful service using the DC/OS SDK",
   "framework": true,
   "maintainer": "support@mesosphere.io",
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.8",
   "name": "hello-world",
   "packagingVersion": "3.0",
   "postInstallNotes": "DC/OS hello-world is being installed!\n\n\tDocumentation: https://github.com/mesosphere/dcos-commons/tree/master/frameworks/helloworld\n\tIssues: https://docs.mesosphere.com/support/",

--- a/repo/packages/H/hello-world/8/package.json
+++ b/repo/packages/H/hello-world/8/package.json
@@ -2,7 +2,7 @@
   "description": "An example implementation of a stateful service using the DC/OS SDK",
   "framework": true,
   "maintainer": "support@mesosphere.io",
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.8",
   "name": "hello-world",
   "packagingVersion": "3.0",
   "postInstallNotes": "DC/OS hello-world is being installed!\n\n\tDocumentation: https://github.com/mesosphere/dcos-commons/tree/master/frameworks/helloworld\n\tIssues: https://docs.mesosphere.com/support/",

--- a/repo/packages/H/hello-world/9/package.json
+++ b/repo/packages/H/hello-world/9/package.json
@@ -2,7 +2,7 @@
   "description": "An example implementation of a stateful service using the DC/OS SDK",
   "framework": true,
   "maintainer": "support@mesosphere.io",
-  "minDcosReleaseVersion": "1.9",
+  "minDcosReleaseVersion": "1.8",
   "name": "hello-world",
   "packagingVersion": "3.0",
   "postInstallNotes": "DC/OS hello-world is being installed!\n\n\tDocumentation: https://github.com/mesosphere/dcos-commons/tree/master/frameworks/helloworld\n\tIssues: https://docs.mesosphere.com/support/",


### PR DESCRIPTION
The minDcosReleaseVersion for hello-world was incorrectly set to 1.9 causing problems with deploying on 1.8 clusters. This PR corrects that.