### PR TITLE
Drop Minimum DC/OS Version to 1.9 in Marathon LB Latest

### DIFF
--- a/repo/packages/M/marathon-lb/23/package.json
+++ b/repo/packages/M/marathon-lb/23/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "4.0",
   "name": "marathon-lb",
   "version": "1.10.0",
-  "minDcosReleaseVersion": "1.10",
+  "minDcosReleaseVersion": "1.9",
   "scm": "https://github.com/mesosphere/marathon-lb",
   "description": "HAProxy configured using Marathon state",
   "maintainer": "support@mesosphere.io",


### PR DESCRIPTION
This minimum version was added as a temporary measure until we could do further testing on this MLB version with DC/OS 1.9 as well as 1.9 -> 1.10 upgrades.

These test scenarios have been verified so we can now drop the `minDcosReleaseVersion` from marathon-lb.