### PR TITLE
upgrade nifi to 1.3

### DIFF
--- a/repo/packages/N/nifi/2/config.json
+++ b/repo/packages/N/nifi/2/config.json
@@ -1,0 +1,90 @@
+{
+    "type": "object",
+    "properties": {
+        "service": {
+            "description": "Configuration properties for the NIFI service for DC/OS.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "The name of the service to display in the DC/OS dashboard.",
+                    "type": "string",
+                    "default": "nifi"
+                },
+                "cpus": {
+                    "description": "CPU shares to allocate to each Nifi master.",
+                    "type": "number",
+                    "default": 1.0,
+                    "minimum": 0.1
+                },
+                "mem": {
+                    "description": "Memory (in MB) to allocate to each Nifi instance.",
+                    "type": "number",
+                    "default": 2048.0,
+                    "minimum": 1024.0
+                },
+                "instances": {
+                    "description": "Amount of nifi instances",
+                    "type": "number",
+                    "default": 1,
+                    "minimum": 1
+                }
+            }
+        },
+        "nifi": {
+            "description": "NIFI settings which will be added to nifi.properties file.",
+            "type": "object",
+            "properties": {
+                "banner": {
+                    "description": "This is banner text that may be configured to display at the top of the User Interface. It is blank by default",
+                    "type": "string",
+                    "default": ""
+                },
+                "zookeeper": {
+                    "description": "The Connect String that is needed to connect to Apache ZooKeeper. This is a comma-separted list of hostname:port pairs.",
+                    "type": "string",
+                    "default": "leader.mesos:2181"
+                },
+                "zookeeper-root": {
+                    "description": "The root ZNode that should be used in ZooKeeper. ZooKeeper provides a directory-like structure for storing data. Each directory in this structure is referred to as a ZNode. This denotes the root ZNode, or directory, that should be used for storing data. The default value is /nifi. This is important to set correctly, as which cluster the NiFi instance attempts to join is determined by which ZooKeeper instance it connects to and the ZooKeeper Root Node that is specified.",
+                    "type": "string",
+                    "default": "/nifi"
+                },                
+                "cluster": {
+                    "description": "Set this to true if the instance is a node in a cluster. The default value is false.",
+                    "type": "boolean",
+                    "default": false
+                }
+            }
+        },
+        "networking": {
+            "description": "Networking-related configuration properties for NIFI on DC/OS.",
+            "type": "object",
+            "properties": {
+                "service-port": {
+                    "description": "Port to be used when exposing the service in Marathon-LB.",
+                    "type": "string",
+                    "default": "10102"
+                },
+                "virtual-host": {
+                    "description": "The virtual host address to configure for integration with Marathon-lb.",
+                    "type": "string"
+                }
+            }
+        },
+        "advanced": {
+            "description": "Advanced configuration properties for the Nifi service. Under normal circumstances, you shouldn't need to modify these values.",
+            "type": "object",
+            "properties": {
+                "docker-image": {
+                    "description": "The Docker image to use for the Nifi service.",
+                    "type": "string",
+                    "default": "mderela/apache-nifi:1.3.0"
+                },
+                "docker-credentials-uri": {
+                    "description": "An optional URI to be fetched and extracted that contains docker credentials (e.g. file:///etc/docker/docker.tar.gz).",
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/N/nifi/2/marathon.json.mustache
+++ b/repo/packages/N/nifi/2/marathon.json.mustache
@@ -1,0 +1,55 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "instances": {{service.instances}},
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{advanced.docker-image}}",
+      "network": "HOST"    
+    }
+  },
+  "portDefinitions": [
+    {
+      "servicePort": {{networking.service-port}},
+      "port": 0,
+      "protocol": "tcp", 
+      "name": "{{service.name}}"
+    },
+    {
+      "port": 0,
+      "protocol": "tcp", 
+      "name": "remote"
+    },
+    {
+      "port": 0,
+      "protocol": "tcp", 
+      "name": "cluster"
+    }
+  ],
+  "healthChecks": [
+    {
+      "path": "/nifi",
+      "portIndex": 0,
+      "gracePeriodSeconds": 120,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3
+    }
+  ],
+  "env": {
+    "NIFI_WEB_HTTP_PORT": "$PORT0",
+    "NIFI_ZOOKEEPER_CONNECT_STRING": "{{nifi.zookeeper}}",
+    "NIFI_ZOOKEEPER_ROOT_NODE": "{{nifi.zookeeper-root}}",
+    "NIFI_UI_BANNER_TEXT": "{{nifi.banner}}",
+    "NIFI_CLUSTER_IS_NODE": "{{nifi.cluster}}"
+  },
+  "labels": {
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "DCOS_PACKAGE_VERSION": "1.3.0-0.1",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "HAPROXY_GROUP":"external",
+    "HAPROXY_0_VHOST":"{{networking.virtual-host}}"
+  }
+}

--- a/repo/packages/N/nifi/2/package.json
+++ b/repo/packages/N/nifi/2/package.json
@@ -1,0 +1,22 @@
+{
+  "packagingVersion": "3.0",
+  "name": "nifi",
+  "version": "1.1.1-0.1",
+  "minDcosReleaseVersion" : "1.8",
+  "scm": "https://git-wip-us.apache.org/repos/asf?p=nifi.git",
+  "maintainer": "mariusz.derela@gmail.com",
+  "website": "https://nifi.apache.org",
+  "framework": false,
+  "description": "Apache NiFi is an integrated data logistics platform for automating the movement of data between disparate systems. It provides real-time control that makes it easy to manage the movement of data between any source and any destination. It is data source agnostic, supporting disparate and distributed sources of differing formats, schemas, protocols, speeds and sizes such as machines, geo location devices, click streams, files, social feeds, log files and videos and more. It is configurable plumbing for moving data around, similar to how Fedex, UPS or other courier delivery services move parcels around. And just like those services, Apache NiFi allows you to trace your data in real time, just like you could trace a delivery. Installation instruction: https://github.com/dcos/examples/tree/master/1.8/nifi",
+  "tags": ["nifi","dataflow","apache","flow","data"],
+  "preInstallNotes":"This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Experimental packages should never be used in production!",
+  "postInstallNotes": "Nifi has been successfully installed and is accessible through Marathon-LB.\nDocumentation can be found at https://nifi.apache.org/docs.html\nPlease keep in mind that first start of nifi can take a more than 60 seconds, so please be patient. If you selected single node installation please add /nifi at the end of URL, ex.: http://NIFI_ENDOPOINT:PORT/nifi ",
+  "postUninstallNotes": "Nifi has been uninstalled.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/apache/nifi/blob/master/LICENSE"
+    }
+  ],
+  "selected": false
+}

--- a/repo/packages/N/nifi/2/resource.json
+++ b/repo/packages/N/nifi/2/resource.json
@@ -1,0 +1,18 @@
+{
+  "images": {
+    "icon-small": "https://raw.githubusercontent.com/us3r/apache-nifi/master/media/images/nifi_small.png",
+    "icon-medium": "https://raw.githubusercontent.com/us3r/apache-nifi/master/media/images/nifi_medium.png",
+    "icon-large": "https://raw.githubusercontent.com/us3r/apache-nifi/master/media/images/nifi_large.png",
+    "screenshots": [
+     "https://raw.githubusercontent.com/us3r/apache-nifi/master/media/screenshots/screen1.png",
+     "https://raw.githubusercontent.com/us3r/apache-nifi/master/media/screenshots/screen2.png"
+    ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "dcos-nifi": "mderela/apache-nifi:1.3.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Nifi has been upgraded to version 1.3. Moreover "cluster mode" left the experiment stage.
There is no need to update the documentation.  It is up-to-date.