### PR TITLE
Bumped GeoServer packaging to 1.2.1 and service to 2.11.2

### DIFF
--- a/repo/packages/G/geoserver/2/config.json
+++ b/repo/packages/G/geoserver/2/config.json
@@ -1,0 +1,104 @@
+{
+	"type": "object",
+	"description": "GeoServer DCOS Service properties",
+	"properties": {
+		"geoserver": {
+			"description": "GeoServer shared configuration properties.",
+			"properties": {
+				"framework-name": {
+					"type": "string",
+					"description": "Mesos Framework Name",
+					"default": "geoserver"
+				},
+				"instances": {
+					"type": "integer",
+					"description": "Number of GeoServer instances to launch. These are the tasks that actually provide OGC service handlers.",
+					"default": 2,
+					"minimum": 1
+				},
+				"cpus": {
+					"type": "integer",
+					"description": "Number of cores allocated per GeoServer instance",
+					"default": 2,
+					"minimum": 1
+				},
+				"memory": {
+					"type": "integer",
+					"description": "Amount of memory in MiBs to allocate per GeoServer instance.",
+					"default": 1024,
+					"minimum": 512
+				},
+				"virtual-host": {
+					"type": "string",
+					"description": "External address for access to the GeoServer cluster. This should be added to your DNS as an A record targeting your marathon-lb public slave.",
+					"default": "geoserver.marathon.mesos"
+				},
+				"data-dir": {
+					"description": "Absolute path present on all Mesos nodes for GeoServer configuration storage. This location must be shared across all Mesos nodes to ensure consistent GeoServer configuration.",
+					"type": "string",
+					"default": "/shared/geoserver",
+					"pattern": "^['\"]?(?:\/[^\/]+)*['\"]?$"
+				},
+				"data-dir-owner": {
+					"description": "User ID and group ID ownership of GeoServer configuration storage. Used within containers to match host ownership by way of gosu.",
+					"type": "string",
+					"default": "root:root",
+					"pattern": "^([a-zA-Z0-9]+)((:[a-zA-Z0-9]+)){0,1}$"
+				},
+				"supplemental-data-dirs": {
+					"description": "Absolute path present on Mesos nodes of data for serving via GeoServer. Multiple values can be given delimited by commas.",
+					"type": "string",
+					"default": "",
+					"pattern": "^['\"]?(?:\/[^\/]+)*['\"]?$"
+				},
+				"auth-uri": {
+					"description": "URI to file for private Docker registry authentication",
+					"type": "string"
+				},
+				"enable-cors": {
+					"description": "CORS headers added to response (true/false)",
+					"default": false,
+					"type": "boolean"
+				},
+				"extension-tarball-uri": {
+					"description": "URI of tarballed JARs to inject into GeoServer instances",
+					"type": "string"
+				},
+				"web-xml-uri": {
+					"description": "URI of web.xml to inject into GeoServer instances",
+					"type": "string"
+				}
+			},
+			"required": [
+				"data-dir",
+				"data-dir-owner"
+			],
+			"type": "object"
+		},
+		"sync": {
+			"description": "Settings used to tune the synchronization of GeoServer slaves on configuration updates.",
+			"properties": {
+				"polling-interval": {
+					"description": "Interval between GeoServer configuration directory file system polls.",
+					"type": "integer",
+					"default": 5
+				},
+				"file-blacklist": {
+					"description": "Comma delimited string of file name snippets that should be ignored. Snippets are compared to file names using contains.",
+					"default": ".log",
+					"pattern": "^[a-zA-Z0-9\\.\\-\\_ ]+$",
+					"type": "string"
+				}
+			},
+			"required": [
+				"polling-interval",
+				"file-blacklist"
+			],
+			"type": "object"
+		}
+	},
+	"required": [
+		"geoserver",
+		"sync"
+	]
+}

--- a/repo/packages/G/geoserver/2/marathon.json.mustache
+++ b/repo/packages/G/geoserver/2/marathon.json.mustache
@@ -1,0 +1,59 @@
+{
+	"id": "{{geoserver.framework-name}}",
+	"cpus": 0.1,
+	"mem": 8,
+	"instances": 1,
+	"container": {
+		"type": "DOCKER",
+		"docker": {
+			"image": "{{resource.assets.container.docker.geoserver-sync}}",
+			"network": "BRIDGE",
+			"portMappings": [{
+				"containerPort": 8000,
+				"hostPort": 0,
+				"servicePort": 0,
+				"protocol": "tcp"
+			}],
+			"forcePullImage": true
+		},
+		"volumes": [{
+			"containerPath": "/etc/geoserver",
+			"hostPath": "{{geoserver.data-dir}}",
+			"mode": "RW"
+		}]
+	},
+	"healthChecks": [{
+		"path": "/sync-health/",
+		"portIndex": 0,
+		"protocol": "HTTP",
+		"gracePeriodSeconds": 360,
+		"intervalSeconds": 30,
+		"maxConsecutiveFailures": 3,
+		"timeoutSeconds": 10
+	}],
+	"env": {
+		{{#geoserver.auth-uri}}
+		"AUTH_URI": "{{geoserver.auth-uri}}",
+		{{/geoserver.auth-uri}}
+		"ENABLE_CORS": "{{geoserver.enable-cors}}",
+		"FILE_BLACKLIST": "{{sync.file-blacklist}}",
+		"FRAMEWORK_NAME": "{{geoserver.framework-name}}",
+		"GEOSERVER_CPUS": "{{geoserver.cpus}}",
+		"GEOSERVER_IMAGE": "{{resource.assets.container.docker.geoserver-app}}",
+		"GEOSERVER_INSTANCES": "{{geoserver.instances}}",
+		"GEOSERVER_MEMORY": "{{geoserver.memory}}",
+		"GEOSERVER_EXTENSION_TARBALL_URI": "{{geoserver.extension-tarball-uri}}",
+		"GEOSERVER_WEB_XML_URI": "{{geoserver.web-xml-uri}}",
+		"GOSU_USER": "{{geoserver.data-dir-owner}}",
+		"HAPROXY_VHOST": "{{geoserver.virtual-host}}",
+		"HOST_GEOSERVER_DATA_DIR": "{{geoserver.data-dir}}",
+		"HOST_SUPPLEMENTAL_DATA_DIRS": "{{geoserver.supplemental-data-dirs}}",
+		"POLLING_INTERVAL": "{{sync.polling-interval}}"
+	},
+	{{#geoserver.auth-uri}}
+	"fetch": [{ "uri": "{{geoserver.auth-uri}}" }],
+	{{/geoserver.auth-uri}}
+	"labels": {
+		"DCOS_PACKAGE_FRAMEWORK_NAME": "{{geoserver.framework-name}}"
+	}
+}

--- a/repo/packages/G/geoserver/2/package.json
+++ b/repo/packages/G/geoserver/2/package.json
@@ -1,0 +1,18 @@
+{
+  "packagingVersion" : "3.0",
+  "minDcosReleaseVersion": "1.8",
+  "name" : "geoserver",
+  "version" : "2.11.2-1.2.1",
+  "scm" : "https://github.com/appliedis/dcos-geoserver",
+  "maintainer" : "dcos-support@appliedis.com",
+  "description" : "GeoServer is an open source server for sharing geospatial data. GeoServer 2.11.2 implements Open Geospatial Consortium (OGC) Web Map Service (WMS), Web Feature Service (WFS), Web Coverage Service (WCS) and Catalog Serivce for the Web (CSW). The GeoServer project can be found at http://geoserver.org/.",
+  "framework" : true,
+  "licenses" : [ {
+    "name" : "Apache License Version 2.0",
+    "url" : "https://github.com/appliedis/dcos-geoserver/blob/master/LICENSE"
+  } ],
+  "tags" : [ "long-running", "mapping", "geospatial", "geoserver", "gis", "ogc", "wms", "wfs", "csw" ],
+  "preInstallNotes" : "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nThis package and its child packages depend on a shared file system.  It doesn't matter what form this takes (NFS, GlusterFS, etc.), but it must be consistent across all DCOS slave nodes. The default location on the nodes is */shared/geoserver* and may be overridden in the *geoserver.data-dir* configuration field.\n\nTutorial documentation for GeoServer configuration can be found here: https://github.com/dcos/examples/tree/master/geoserver",
+  "postUninstallNotes" : "The GeoServer Service has been uninstalled and will no longer run.\nThis does not remove the geoserver-app marathon app which should also be removed to eliminate any traces of GeoServer from your DCOS cluster.",
+  "selected" : false
+}

--- a/repo/packages/G/geoserver/2/resource.json
+++ b/repo/packages/G/geoserver/2/resource.json
@@ -1,0 +1,15 @@
+{
+  "images" : {
+    "icon-small" : "https://raw.githubusercontent.com/AppliedIS/universe-assets/master/geoserver/icon-small-geoserver.png",
+    "icon-medium" : "https://raw.githubusercontent.com/AppliedIS/universe-assets/master/geoserver/icon-medium-geoserver.png",
+    "icon-large" : "https://raw.githubusercontent.com/AppliedIS/universe-assets/master/geoserver/icon-large-geoserver.png"
+  },
+  "assets" : {
+    "container" : {
+      "docker" : {
+        "geoserver-sync" : "appliedis/dcos-geoserver:1.2.1",
+        "geoserver-app" : "appliedis/geoserver:2.11.2"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Bump of GeoServer version to fix DCOS 1.10 support. I did not add a new version to the Universe directory structure as this is just a patch release. Let me know if that is not the correct way to bump for patches. Thanks!