### PR TITLE
update Datadog package to 5.18.1

### DIFF
--- a/repo/packages/D/datadog/4/config.json
+++ b/repo/packages/D/datadog/4/config.json
@@ -1,0 +1,49 @@
+{
+    "properties": {
+        "datadog": {
+            "description": "Datadog specific configuration properties",
+            "properties": {
+                "api_key": {
+                    "description": "Your Datadog API key.",
+                    "type": "string"
+                },
+                "app_id": {
+                    "default": "datadog-agent",
+                    "description": "Marathon Application ID",
+                    "type": "string"
+                },
+                "cpus": {
+                    "default": 0.05,
+                    "description": "CPU shares to allocate to each Marathon instance.",
+                    "minimum": 0.0,
+                    "type": "number"
+                },
+                "instances": {
+                    "default": 1,
+                    "description": "Number of Marathon instances to run.",
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "mem": {
+                    "default": 256.0,
+                    "description": "Memory (MB) to allocate to each Marathon task.",
+                    "minimum": 256.0,
+                    "type": "number"
+                },
+                "statsd_port": {
+                    "default": 8125,
+                    "description": "statsD port",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "api_key"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "datadog"
+    ],
+    "type": "object"
+}

--- a/repo/packages/D/datadog/4/marathon.json.mustache
+++ b/repo/packages/D/datadog/4/marathon.json.mustache
@@ -1,0 +1,62 @@
+{
+    "id": "{{datadog.app_id}}",
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.a11d1631f99d}}",
+            "parameters": [
+                {
+                    "key": "name", "value": "dd-agent"
+                },
+                {
+                    "key": "env", "value": "API_KEY={{datadog.api_key}}"
+                },
+                {
+                    "key": "env", "value": "MESOS_SLAVE=true"
+                },
+                {
+                    "key": "env", "value": "SD_BACKEND=docker"
+                }
+            ],
+            "network": "BRIDGE",
+            "portMappings": [
+                { "hostPort": {{datadog.statsd_port}}, "containerPort": 8125, "protocol": "udp" }
+            ]
+        },
+        "volumes": [
+            {
+                "containerPath": "/var/run/docker.sock",
+                "hostPath": "/var/run/docker.sock",
+                "mode": "RO"
+            },
+            {
+                "containerPath": "/host/proc",
+                "hostPath": "/proc",
+                "mode": "RO"
+            },
+            {
+                "containerPath": "/host/sys/fs/cgroup",
+                "hostPath": "/sys/fs/cgroup",
+                "mode": "RO"
+            }
+        ]
+    },
+    "cpus": {{datadog.cpus}},
+    "mem": {{datadog.mem}},
+    "instances": {{datadog.instances}},
+    "acceptedResourceRoles": ["slave_public", "*"],
+    "constraints": [
+        ["hostname", "UNIQUE"],
+        ["hostname", "GROUP_BY"]
+    ],
+    "healthChecks": [
+        {
+            "protocol": "COMMAND",
+            "command": { "value": "/probe.sh" },
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ]
+}

--- a/repo/packages/D/datadog/4/marathon.json.mustache
+++ b/repo/packages/D/datadog/4/marathon.json.mustache
@@ -3,7 +3,7 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "{{resource.assets.container.docker.a11d1631f99d}}",
+            "image": "{{resource.assets.container.docker.a5669b334fa2}}",
             "parameters": [
                 {
                     "key": "name", "value": "dd-agent"

--- a/repo/packages/D/datadog/4/package.json
+++ b/repo/packages/D/datadog/4/package.json
@@ -19,6 +19,6 @@
         "datadog",
         "monitoring"
     ],
-    "version": "5.17.2",
+    "version": "5.18.1",
     "website": "https://www.datadoghq.com/"
 }

--- a/repo/packages/D/datadog/4/package.json
+++ b/repo/packages/D/datadog/4/package.json
@@ -13,7 +13,7 @@
     "name": "datadog",
     "postInstallNotes": "Datadog on DCOS successfully installed.\nHead over to https://app.datadoghq.com to monitor your DCOS cluster.",
     "postUninstallNotes": "Datadog on DCOS successfully uninstalled.\n.",
-    "preInstallNotes": "This DC/OS Service is currently in preview. \n Pass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api \nAlso pass the number of Mesos slaves as an option (datadog.instances).\nMarathon will make sure that the Datadog Agent runs only once per slave.",
+    "preInstallNotes": "This DC/OS Service is currently in preview. \n Pass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api \nAlso pass the number of Mesos slaves as an option (datadog.instances).\nMarathon will make sure that the Datadog Agent runs only once per slave.\nDatadog package doesn't work on 1.10 clusters. This is a known issue and will be fixed by the Datadog team in the next revision.",
     "scm": "https://github.com/datadog/dd-agent.git",
     "tags": [
         "datadog",

--- a/repo/packages/D/datadog/4/package.json
+++ b/repo/packages/D/datadog/4/package.json
@@ -1,0 +1,24 @@
+{
+    "packagingVersion": "3.0",
+    "minDcosReleaseVersion" : "1.8",
+    "description": "Datadog is a hosted monitoring service for cloud-scale infrastructure and applications",
+    "framework": false,
+    "licenses": [
+        {
+            "name": "Simplified BSD license",
+            "url": "https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE"
+        }
+    ],
+    "maintainer": "package@datadoghq.com",
+    "name": "datadog",
+    "postInstallNotes": "Datadog on DCOS successfully installed.\nHead over to https://app.datadoghq.com to monitor your DCOS cluster.",
+    "postUninstallNotes": "Datadog on DCOS successfully uninstalled.\n.",
+    "preInstallNotes": "This DC/OS Service is currently in preview. \n Pass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api \nAlso pass the number of Mesos slaves as an option (datadog.instances).\nMarathon will make sure that the Datadog Agent runs only once per slave.",
+    "scm": "https://github.com/datadog/dd-agent.git",
+    "tags": [
+        "datadog",
+        "monitoring"
+    ],
+    "version": "5.17.2",
+    "website": "https://www.datadoghq.com/"
+}

--- a/repo/packages/D/datadog/4/resource.json
+++ b/repo/packages/D/datadog/4/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "a11d1631f99d": "datadog/docker-dd-agent:12.2.5172"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-large.png"
+  }
+}

--- a/repo/packages/D/datadog/4/resource.json
+++ b/repo/packages/D/datadog/4/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "a11d1631f99d": "datadog/docker-dd-agent:12.2.5172"
+        "7bc2cd5d30b2": "datadog/docker-dd-agent:12.3.5172"
       }
     }
   },

--- a/repo/packages/D/datadog/4/resource.json
+++ b/repo/packages/D/datadog/4/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "7bc2cd5d30b2": "datadog/docker-dd-agent:12.3.5172"
+        "a5669b334fa2": "datadog/docker-dd-agent:12.4.5181"
       }
     }
   },


### PR DESCRIPTION
This PR updates the Datadog package to the latest 5.18.1:

- update image hash to use 12.4.5181
- remove supervisord port mapping
- update healthcheck to use /probe.sh command

Full diff from previous package version 3

```
diff -u 3/config.json 4/config.json
--- 3/config.json	2017-09-19 10:18:04.000000000 +0200
+++ 4/config.json	2017-09-19 11:25:31.000000000 +0200
@@ -34,11 +34,6 @@
                     "default": 8125,
                     "description": "statsD port",
                     "type": "integer"
-                },
-                "supervisor_port": {
-                    "default": 9001,
-                    "description": "Agent supervisord port",
-                    "type": "integer"
                 }
             },
             "required": [
diff -u 3/marathon.json.mustache 4/marathon.json.mustache
--- 3/marathon.json.mustache	2017-10-19 10:40:48.000000000 +0200
+++ 4/marathon.json.mustache	2017-10-19 10:42:43.000000000 +0200
@@ -3,7 +3,7 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "{{resource.assets.container.docker.73925bb9ab66}}",
+            "image": "{{resource.assets.container.docker.a5669b334fa2}}",
             "parameters": [
                 {
                     "key": "name", "value": "dd-agent"
@@ -15,13 +15,12 @@
                     "key": "env", "value": "MESOS_SLAVE=true"
                 },
                 {
-                    "key": "env", "value": "SD_BACKEND=docker"                
+                    "key": "env", "value": "SD_BACKEND=docker"
                 }
             ],
             "network": "BRIDGE",
             "portMappings": [
-                { "hostPort": {{datadog.statsd_port}}, "containerPort": 8125, "protocol": "udp" },
-                { "hostPort": {{datadog.supervisor_port}}, "containerPort": 9001, "protocol": "tcp" }
+                { "hostPort": {{datadog.statsd_port}}, "containerPort": 8125, "protocol": "udp" }
             ]
         },
         "volumes": [
@@ -52,14 +51,12 @@
     ],
     "healthChecks": [
         {
-            "path": "/",
-            "portIndex": 1,
-            "protocol": "HTTP",
+            "protocol": "COMMAND",
+            "command": { "value": "/probe.sh" },
             "gracePeriodSeconds": 300,
             "intervalSeconds": 60,
             "timeoutSeconds": 20,
-            "maxConsecutiveFailures": 3,
-            "ignoreHttp1xx": false
+            "maxConsecutiveFailures": 3
         }
     ]
 }
diff -u 3/package.json 4/package.json
--- 3/package.json	2017-09-19 10:18:04.000000000 +0200
+++ 4/package.json	2017-10-18 11:36:05.000000000 +0200
@@ -19,6 +19,6 @@
         "datadog",
         "monitoring"
     ],
-    "version": "5.16.0",
+    "version": "5.18.1",
     "website": "https://www.datadoghq.com/"
 }
diff -u 3/resource.json 4/resource.json
--- 3/resource.json	2017-10-19 10:40:48.000000000 +0200
+++ 4/resource.json	2017-10-18 11:36:02.000000000 +0200
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "73925bb9ab66": "datadog/docker-dd-agent:11.0.5160"
+        "a5669b334fa2": "datadog/docker-dd-agent:12.4.5181"
       }
     }
   },
```