### PR TITLE
Updated urls from http to https

### DIFF
--- a/repo/packages/G/grafana/0/resource.json
+++ b/repo/packages/G/grafana/0/resource.json
@@ -4,7 +4,7 @@
     "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-grafana-medium.png",
     "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-grafana-large.png",
    "screenshots": [
-     "http://grafana.org/assets/img/blog/v3.0/wP-Screenshot-dash-web.png",
+     "https://grafana.org/assets/img/blog/v3.0/wP-Screenshot-dash-web.png",
      "https://prometheus.io/assets/grafana_prometheus-cbb943f0bb3.png"
    ]
   },

--- a/repo/packages/G/grafana/1/resource.json
+++ b/repo/packages/G/grafana/1/resource.json
@@ -4,7 +4,7 @@
     "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-grafana-medium.png",
     "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-grafana-large.png",
    "screenshots": [
-     "http://grafana.org/assets/img/blog/v3.0/wP-Screenshot-dash-web.png",
+     "https://grafana.org/assets/img/blog/v3.0/wP-Screenshot-dash-web.png",
      "https://prometheus.io/assets/grafana_prometheus-cbb943f0bb3.png"
    ]
   },

--- a/repo/packages/P/postgresql-admin/0/resource.json
+++ b/repo/packages/P/postgresql-admin/0/resource.json
@@ -1,6 +1,6 @@
 {
   "images": {
-    "icon-small": "http://www.coretechnologies.com/images/postgresql-logo-48x48.png",
+    "icon-small": "https://www.coretechnologies.com/images/postgresql-logo-48x48.png",
     "icon-medium": "https://www.freebsdnews.com/wp-content/uploads/postgresql-96x96.png",
     "icon-large": "https://www.iconattitude.com/icons/open_icon_library/apps/png/256/postgresql.png"
   },

--- a/repo/packages/P/postgresql/0/resource.json
+++ b/repo/packages/P/postgresql/0/resource.json
@@ -1,6 +1,6 @@
 {
   "images": {
-    "icon-small": "http://www.coretechnologies.com/images/postgresql-logo-48x48.png",
+    "icon-small": "https://www.coretechnologies.com/images/postgresql-logo-48x48.png",
     "icon-medium": "https://www.freebsdnews.com/wp-content/uploads/postgresql-96x96.png",
     "icon-large": "https://www.iconattitude.com/icons/open_icon_library/apps/png/256/postgresql.png"
   },

--- a/repo/packages/Q/quobyte/0/resource.json
+++ b/repo/packages/Q/quobyte/0/resource.json
@@ -4,9 +4,9 @@
     "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-quobyte-medium.png",
     "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-quobyte-large.png",
     "screenshots": [
-      "http://www.quobyte.com/mesos/screen-1.png",
-      "http://www.quobyte.com/mesos/screen-2.png",
-      "http://www.quobyte.com/mesos/screen-3.png"
+      "https://www.quobyte.com/mesos/screen-1.png",
+      "https://www.quobyte.com/mesos/screen-2.png",
+      "https://www.quobyte.com/mesos/screen-3.png"
     ]
   },
   "assets": {

--- a/repo/packages/Q/quobyte/1/resource.json
+++ b/repo/packages/Q/quobyte/1/resource.json
@@ -1,12 +1,12 @@
 {
   "images": {
-    "icon-small": "http://www.quobyte.com/mesos/icon-quobyte-small.png",
-    "icon-medium": "http://www.quobyte.com/mesos/icon-quobyte-medium.png",
-    "icon-large": "http://www.quobyte.com/mesos/icon-quobyte-large.png",
+    "icon-small": "https://www.quobyte.com/mesos/icon-quobyte-small.png",
+    "icon-medium": "https://www.quobyte.com/mesos/icon-quobyte-medium.png",
+    "icon-large": "https://www.quobyte.com/mesos/icon-quobyte-large.png",
     "screenshots": [
-      "http://www.quobyte.com/mesos/screen-1.png",
-      "http://www.quobyte.com/mesos/screen-2.png",
-      "http://www.quobyte.com/mesos/screen-3.png"
+      "https://www.quobyte.com/mesos/screen-1.png",
+      "https://www.quobyte.com/mesos/screen-2.png",
+      "https://www.quobyte.com/mesos/screen-3.png"
     ]
   },
   "assets": {

--- a/repo/packages/R/redis/0/resource.json
+++ b/repo/packages/R/redis/0/resource.json
@@ -4,7 +4,7 @@
    "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-redis-medium.png",
    "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-redis-large.png",
    "screenshots": [
-     "http://redis.io/images/redis-white.png"
+     "https://redis.io/images/redis-white.png"
    ]
  },
  "assets": {

--- a/repo/packages/R/redis/1/resource.json
+++ b/repo/packages/R/redis/1/resource.json
@@ -4,7 +4,7 @@
    "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-redis-medium.png",
    "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-redis-large.png",
    "screenshots": [
-     "http://redis.io/images/redis-white.png"
+     "https://redis.io/images/redis-white.png"
    ]
  },
  "assets": {


### PR DESCRIPTION
This PR changes urls in multiple packages to use https scheme instead of http. The http urls already redirect to https and in order to generate `.dcos` files this redirection is not supported at the moment. We change these urls to https and thus would be able to generate `.dcos` files.

Addresses https://jira.mesosphere.com/browse/DCOS-18698'
Spreadhseet list : https://docs.google.com/spreadsheets/d/1BMTL5dFvU0fkuo0zqoSfxUzLaJqFRBOe5zd9VXhKMac/edit#gid=1276889969