### PR TITLE
Kong log redirect envs. and Cassandra contact-point config update

### DIFF
--- a/repo/packages/K/kong/4/config.json
+++ b/repo/packages/K/kong/4/config.json
@@ -1,0 +1,211 @@
+{
+  "$schema":"http://json-schema.org/schema#",
+  "type":"object",
+  "properties":{
+    "service":{
+      "type":"object",
+      "description":"DC/OS service configuration properties",
+      "properties":{
+        "name":{
+          "description":"The name of this Kong instance.",
+          "type":"string",
+          "default":"kong"
+        },
+        "instances":{
+          "default":1,
+          "description":"Number of instances to run.",
+          "minimum":1,
+          "type":"integer"
+        },
+        "cpus":{
+          "default":1,
+          "description":"CPU shares to allocate to each instance.",
+          "minimum":1,
+          "type":"number"
+        },
+        "mem":{
+          "default":512,
+          "description":"Memory (MB) to allocate to each task.",
+          "minimum":512,
+          "type":"number"
+        },
+        "role":{
+          "default":"*",
+          "description":"Deploy Kong only on nodes with this role.",
+          "type":"string"
+        }
+      },
+      "required":[
+        "name",
+        "instances",
+        "cpus",
+        "mem",
+        "role"
+      ]
+    },
+    "configurations":{
+      "type":"object",
+      "description":"Kong configuration properties.",
+      "properties":{
+        "database": {
+          "description":"Database properties.",
+          "type":"object",
+          "properties": {
+            "migrations": {
+              "title": "Run Kong migrations",
+              "description": "Enable or disable Kong migrations. Recommended if Kong being run with clean backing datastore.",
+              "type": "boolean",
+              "default": true
+            },
+            "use-cassandra":{
+              "title":"Use Cassandra as Kong backing datastore?",
+              "description":"If true, Cassandra is used as Kong backing datastore.",
+              "type":"boolean",
+              "default":false
+            }
+          }
+        },
+        "postgres":{
+          "description":"Postgres connection properties.",
+          "type":"object",
+          "properties":{
+            "host":{
+              "description":"Postgres host address.",
+              "type":"string",
+              "default":"postgresql.marathon.l4lb.thisdcos.directory"
+            },
+            "port":{
+              "description":"Postgres port.",
+              "type":"integer",
+              "default":5432
+            },
+            "database":{
+              "description":"Postgres database name.",
+              "type":"string",
+              "default":"kong"
+            },
+            "user":{
+              "description":"Postgres user.",
+              "type":"string",
+              "default":"kong"
+            },
+            "password":{
+              "description":"Postgres password.",
+              "type":"string",
+              "default":"kong"
+            }
+          }
+        },
+        "cassandra":{
+          "description":"Cassandra connection properties.",
+          "type":"object",
+          "properties":{
+            "contact-points":{
+              "description":"A comma-separated list of contact points.",
+              "type":"string",
+              "default":"node.cassandra.l4lb.thisdcos.directory"
+            },
+            "port":{
+              "description":"The port on which cassandra nodes are listening on.",
+              "type":"integer",
+              "default":9042
+            },
+            "keyspace":{
+              "description":"Cassandra keyspace.",
+              "type":"string",
+              "default":"kong"
+            }
+          }
+        },
+        "log-level":{
+          "description":"Log level of the Kong server.",
+          "type":"string",
+          "default":"notice"
+        },
+        "custom-envs":{
+          "description":"A space-separated list Kong configurations. Please avoid updating properties which already being set through other properties above.",
+          "type":"string",
+          "pattern":"^(KONG_\\w+=\\S+)*(\\sKONG_\\w+=\\S+)*$"
+        }
+      }
+    },
+    "networking":{
+      "type":"object",
+      "description":"Marathon-LB service configuration properties.",
+      "properties": {
+        "proxy": {
+          "type": "object",
+          "description": "Kong's Proxy port configuration.",
+          "properties": {
+            "external-access": {
+              "title": "Allow external access",
+              "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+              "type": "boolean",
+              "default": true
+            },
+            "vip-port":{
+              "description":"Port number to be used for communication internally to the cluster. Default is 8000.",
+              "type":"number",
+              "default":8000
+            },
+            "vip-port-ssl":{
+              "description":"Port number to be used for secure communication internally to the cluster. Default is 8443.",
+              "type":"number",
+              "default":8443
+            },
+            "virtual-host": {
+              "description": "The virtual host address to integrate Kong proxy port with Marathon-lb.",
+              "type": "string"
+            },
+            "https-redirect": {
+              "description": "Whether Marathon-lb should redirect HTTP traffic to HTTPS. This requires 'virtual-host' to be set.",
+              "type": "boolean",
+              "default": false
+            },
+            "service-port": {
+              "description": "Port number to be used for external traffic to cluster through Marathon-LB load balancer.",
+              "type": "integer",
+              "default": 10201
+            }
+          }
+        },
+        "admin": {
+          "type": "object",
+          "description": "Kong's Admin port configuration.",
+          "properties": {
+            "external-access": {
+              "title": "Allow external access",
+              "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+              "type": "boolean",
+              "default": false
+            },
+            "vip-port":{
+              "description":"Port number to be used for communication internally to the cluster. Default is 8001.",
+              "type":"number",
+              "default":8001
+            },
+            "vip-port-ssl":{
+              "description":"Port number to be used for secure communication internally to the cluster. Default is 8444.",
+              "type":"number",
+              "default":8444
+            },
+            "virtual-host": {
+              "description": "The virtual host address to integrate Kong proxy port with Marathon-lb.",
+              "type": "string"
+            },
+            "https-redirect": {
+              "description": "Whether Marathon-lb should redirect HTTP traffic to HTTPS. This requires 'virtual-host' to be set.",
+              "type": "boolean",
+              "default": false
+            },
+            "service-port": {
+              "description": "Port number to be used for external traffic to cluster through Marathon-LB load balancer.",
+              "type": "integer",
+              "default": 10202
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/K/kong/4/marathon.json.mustache
+++ b/repo/packages/K/kong/4/marathon.json.mustache
@@ -1,0 +1,110 @@
+{
+  "id": "{{service.name}}",
+  "instances": {{service.instances}},
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  {{^configurations.database.migrations}}
+  "cmd": "export KONG_NGINX_DAEMON=\"off\" {{configurations.custom-envs}} && kong prepare -p /usr/local/kong/ && /usr/local/openresty/nginx/sbin/nginx -c /usr/local/kong/nginx.conf -p /usr/local/kong/ ",
+  {{/configurations.database.migrations}}
+  {{#configurations.database.migrations}}
+  "cmd": "export KONG_NGINX_DAEMON=\"off\" {{configurations.custom-envs}} && kong migrations up && kong prepare -p /usr/local/kong/ && /usr/local/openresty/nginx/sbin/nginx -c /usr/local/kong/nginx.conf -p /usr/local/kong/ ",
+  {{/configurations.database.migrations}}
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.kong-image}}",
+      "network": "BRIDGE",
+      "forcePullImage": true,
+      "portMappings": [
+        {
+          "containerPort": 8443,
+          "hostPort": 0,
+          "protocol": "tcp",
+          "name": "{{service.name}}-proxy-ssl",
+          "labels": {
+            "VIP_0": "/{{service.name}}:{{networking.proxy.vip-port-ssl}}"
+          }
+        },
+        {
+          "containerPort": 8444,
+          "hostPort": 0,
+          "protocol": "tcp",
+          "name": "{{service.name}}-admin-ssl",
+          "labels": {
+            "VIP_1": "/{{service.name}}:{{networking.admin.vip-port-ssl}}"
+          }
+        },
+        {
+          "containerPort": 8000,
+          "hostPort": 0,
+          "protocol": "tcp",
+          {{#networking.proxy.external-access}}
+          "servicePort": {{networking.proxy.service-port}},
+          {{/networking.proxy.external-access}}
+          "name": "{{service.name}}",
+          "labels": {
+            "VIP_2": "/{{service.name}}:{{networking.proxy.vip-port}}"
+          }
+        },
+        {
+          "containerPort": 8001,
+          "hostPort": 0,
+          "protocol": "tcp",
+          {{#networking.admin.external-access}}
+          "servicePort": {{networking.admin.service-port}},
+          {{/networking.admin.external-access}}
+          "name": "{{service.name}}-admin",
+          "labels": {
+            "VIP_3": "/{{service.name}}:{{networking.admin.vip-port}}"
+          }
+        }
+      ]
+    }
+  },
+  "healthChecks": [
+    {
+      "protocol": "TCP",
+      "portIndex": 1,
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "acceptedResourceRoles": [
+    "{{service.role}}"
+  ],
+  "env": {
+    {{^configurations.database.use-cassandra}}
+    "KONG_PG_PASSWORD": "{{configurations.postgres.password}}",
+    "KONG_PG_HOST": "{{configurations.postgres.host}}",
+    "KONG_PG_USER": "{{configurations.postgres.user}}",
+    "KONG_PG_PORT": "{{configurations.postgres.port}}",
+    {{/configurations.database.use-cassandra}}
+    {{#configurations.database.use-cassandra}}
+    "KONG_DATABASE": "cassandra",
+    "KONG_CASSANDRA_CONTACT_POINTS": "{{configurations.cassandra.contact-points}}",
+    "KONG_CASSANDRA_PORT": "{{configurations.cassandra.port}}",
+    "KONG_CASSANDRA_KEYSPACE": "{{configurations.cassandra.keyspace}}",
+    {{/configurations.database.use-cassandra}}
+    "KONG_LOG_LEVEL": "{{configurations.log-level}}",
+    "KONG_PROXY_ACCESS_LOG": "/dev/stdout",
+    "KONG_ADMIN_ACCESS_LOG": "/dev/stdout",
+    "KONG_PROXY_ERROR_LOG": "/dev/stderr",
+    "KONG_ADMIN_ERROR_LOG": "/dev/stderr"
+  },
+  "labels": {
+    {{#networking.proxy.external-access}}
+    "HAPROXY_2_GROUP": "external",
+    "HAPROXY_2_VHOST": "{{networking.proxy.virtual-host}}",
+    "HAPROXY_2_REDIRECT_TO_HTTPS": "{{networking.proxy.https-redirect}}",
+    {{/networking.proxy.external-access}}
+    {{#networking.admin.external-access}}
+    "HAPROXY_3_GROUP": "external",
+    "HAPROXY_3_VHOST": "{{networking.admin.virtual-host}}",
+    "HAPROXY_3_REDIRECT_TO_HTTPS": "{{networking.admin.https-redirect}}",
+    {{/networking.admin.external-access}}
+    "DCOS_SERVICE_NAME": "{{service.name}}"
+  }
+}

--- a/repo/packages/K/kong/4/package.json
+++ b/repo/packages/K/kong/4/package.json
@@ -1,0 +1,25 @@
+{
+  "packagingVersion": "3.0",
+  "name": "kong",
+  "version": "0.11.0",
+  "scm": "https://github.com/Mashape/kong",
+  "maintainer": "https://getkong.org/community/",
+  "website": "https://getkong.org/",
+  "description": "Kong is open-source API Gateway and Microservices Management Layer, delivering high performance and reliability.",
+  "framework": false,
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production! You need to have Kong supported DB and Marathon-LB instances running. Please check https://github.com/dcos/examples/tree/master/kong for more information.",
+  "postInstallNotes": "Kong has been installed.",
+  "postUninstallNotes": "Kong has been uninstalled.",
+  "tags": [
+    "microservices",
+    "proxy",
+    "api-layer",
+    "api-management"
+  ],
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/Mashape/kong/blob/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/K/kong/4/resource.json
+++ b/repo/packages/K/kong/4/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-small.png",
+    "icon-medium": "https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-medium.png",
+    "icon-large": "https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "kong-image": "kong:0.11.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Kong environment vars for redirecting logs to stdout and stderr
- Cassandra default endpoint updated to match
  https://docs.mesosphere.com/service-docs/cassandra/v2.0.0-3.0.14/connecting-clients/