### PR TITLE
Update release version for minio package

### DIFF
--- a/repo/packages/M/minio/9/config.json
+++ b/repo/packages/M/minio/9/config.json
@@ -1,0 +1,101 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service": {
+            "type": "object",
+            "description": "Service properties for Minio on DC/OS",
+            "properties": {
+                "name": {
+                    "description": "Name of this service instance",
+                    "type": "string",
+                    "default": "minio"
+                },
+                "tls": {
+                    "description": "Enable secure connections by https://docs.minio.io/docs/how-to-secure-access-to-minio-server-with-tls. Then set this field to true",
+                    "type": "boolean",
+                    "default": false
+                }
+            },
+            "required": [
+                "name",
+                "tls"
+            ]
+        },
+        "resource": {
+            "type": "object",
+            "description": "Resource properties for Minio on DC/OS",
+            "properties": {
+                "cpus": {
+                    "description": "CPU shares to allocate to service instance",
+                    "type": "number",
+                    "default": 1,
+                    "minimum": 0.5
+                },
+                "mem": {
+                    "description": "Memory to allocate to service instance",
+                    "type": "number",
+                    "default": 1024,
+                    "minimum": 1024
+                }
+            },
+            "required": [
+                "cpus",
+                "mem"
+            ]
+        },
+        "storage": {
+            "type": "object",
+            "description": "Storage properties for Minio on DC/OS",
+            "properties": {
+                "volume-size": {
+                    "type": "number",
+                    "description": "Size of volume in MiB",
+                    "default": 1024
+                }
+            },
+            "required": [
+                "volume-size"
+            ]
+
+        },
+        "credentials": {
+            "type": "object",
+            "description": "Credentials to authenticate with Minio server",
+            "properties": {
+                "access-key": {
+                    "type": "string",
+                    "description": "Access Key",
+                    "default": "minio"
+                },
+                "secret-key": {
+                    "type": "string",
+                    "description": "Secret Key",
+                    "default": "minio123"
+                }
+            },
+            "required": [
+                "access-key",
+                "secret-key"
+            ]
+        },
+        "networking": {
+            "description": "Networking properties for Minio on DC/OS",
+            "type": "object",
+            "properties": {
+                "port": {
+                    "description": "Port on which Minio service is available",
+                    "type": "number",
+                    "default": 9000
+                },
+                "public-access": {
+                    "description": "Enables public access to Minio server if true",
+                    "type": "boolean",
+                    "default": true
+                }
+            },
+            "required": [
+                "port"
+            ]
+        }
+    }
+}

--- a/repo/packages/M/minio/9/marathon.json.mustache
+++ b/repo/packages/M/minio/9/marathon.json.mustache
@@ -1,0 +1,86 @@
+{
+   "id":"{{service.name}}",
+   "cpus":{{resource.cpus}},
+   "mem":{{resource.mem}},
+   "instances":1,
+   "maxLaunchDelaySeconds":36000,
+   "args":[
+      "server",
+      "-C",
+      "/config",
+      "/export"
+   ],
+   "container":{
+      "type":"DOCKER",
+      "volumes": [
+        {
+            "containerPath": "miniodata",
+            "mode": "RW",
+            "persistent": {
+            "type": "root",
+            "size" : {{storage.volume-size}}
+            }
+        },
+        {
+            "containerPath": "minioconfig",
+            "mode": "RW",
+            "persistent": {
+            "type": "root",
+            "size": 10
+            }
+        },
+        {
+            "containerPath": "/export",
+            "hostPath": "miniodata",
+            "mode": "RW"
+        },
+        {
+            "containerPath": "/config",
+            "hostPath": "minioconfig",
+            "mode": "RW"
+        }
+      ],
+      "docker":{
+         "image": "{{resource.assets.container.docker.minio-docker-RELEASE}}",
+         "network":"BRIDGE",
+         "portMappings":[
+            {
+               "containerPort":9000,
+               "hostPort":0,
+               "servicePort":{{networking.port}}
+            }
+         ],
+         "privileged":true,
+         "forcePullImage":true
+      }
+   },
+   "healthChecks": [
+        {
+            {{#service.tls}}
+            "protocol": "HTTPS",
+            {{/service.tls}}
+            "path": "/minio/index.html",
+            "portIndex": 0,
+
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+   ],
+   "env": {
+          "MINIO_ACCESS_KEY": "{{credentials.access-key}}",
+          "MINIO_SECRET_KEY": "{{credentials.secret-key}}"
+   },
+   "labels":{
+    {{#networking.public-access}}
+    "HAPROXY_GROUP":"external",
+    {{/networking.public-access}}
+    "MARATHON_SINGLE_INSTANCE_APP": "true"
+   },
+   "upgradeStrategy":{
+      "minimumHealthCapacity": 0,
+      "maximumOverCapacity": 0
+    }
+}
+

--- a/repo/packages/M/minio/9/package.json
+++ b/repo/packages/M/minio/9/package.json
@@ -1,0 +1,26 @@
+{
+  "packagingVersion": "3.0",
+  "name": "minio",
+  "version": "0.0.10-RELEASE.2017-09-29T19-16-56Z",
+  "minDcosReleaseVersion": "1.8",
+  "scm": "https://github.com/minio/minio.git",
+  "maintainer": "dev@minio.io",
+  "website": "https://www.minio.io",
+  "framework": false,
+  "description": "Minio is an object storage server for cloud native applications. To deploy at scale, use DC/OS to orchestrate Minio containers one per tenant.",
+  "tags": [
+    "data",
+    "storage",
+    "filesystem"
+  ],
+  "preInstallNotes": "This DC/OS service is currently in preview. There may be bugs, incomplete features, incorrect documentation or other discrepancies in packaging. Preview packages should never be used in production! There is no limit to number of Minio services you can launch. To learn how to install Minio on DC/OS refer to https://github.com/dcos/examples/blob/master/minio/1.9/README.md",
+  "postInstallNotes": "Minio is compatible with AWS S3 APIs. Learn more about Minio on docs.minio.io . Minio has an active community on Slack slack.minio.io.",
+  "postUninstallNotes": "Minio DC/OS service has been successfully uninstalled and will no longer run.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/minio/minio/blob/master/LICENSE"
+    }
+  ],
+  "selected": false
+}

--- a/repo/packages/M/minio/9/resource.json
+++ b/repo/packages/M/minio/9/resource.json
@@ -1,0 +1,22 @@
+{
+  "images": {
+    "icon-small": "https://minio.io/img/icons/minio/minio_dark_sm_ic.png",
+    "icon-medium": "https://minio.io/img/icons/minio/minio_dark_md_ic.png",
+    "icon-large": "https://minio.io/img/icons/minio/minio_dark_lg_ic.png",
+    "screenshots": [
+      "https://minio.io/img/browser/1.png",
+      "https://minio.io/img/browser/2.png",
+      "https://minio.io/img/browser/3.png",
+      "https://minio.io/img/browser/4.png",
+      "https://minio.io/img/browser/5.png",
+      "https://minio.io/img/browser/6.png"
+    ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "minio-docker-RELEASE": "minio/minio:RELEASE.2017-09-29T19-16-56Z"
+      }
+    }
+  }
+}


### PR DESCRIPTION
To use the latest minio server release - [RELEASE.2017-09-29T19-16-56Z](https://github.com/minio/minio/releases/tag/RELEASE.2017-09-29T19-16-56Z)