### PR TITLE
Humio agent

### DIFF
--- a/repo/packages/H/humio-agent/0/config.json
+++ b/repo/packages/H/humio-agent/0/config.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "humio": {
+      "properties": {
+        "host": {
+          "description": "Humio url. i.e. go.humio.com",
+          "type": "string"
+        },
+        "dataspace": {
+          "description": "Name of Humio dataspace",
+          "type": "string"
+        },
+        "ingestToken": {
+          "description": "Humio ingest token",
+          "type": "string"
+        }
+      },
+      "required": [
+        "host",
+        "dataspace",
+        "ingestToken"
+      ],
+      "type": "object"
+    },
+    "service": {
+      "properties": {
+        "name": {
+          "default": "humio-agent",
+          "description": "Name for this Humio application",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "node": {
+      "properties": {
+        "cpus": {
+          "default": 0.5,
+          "description": "CPU shares to allocate to each Filebeat instance.",
+          "minimum": 0.1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 512.0,
+          "description": "Memory (MB) to allocate to each Filebeat task.",
+          "minimum": 256.0,
+          "type": "number"
+        },
+        "datadir": {
+          "default": "/var/humio/data",
+          "description": "Path of directory",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "datadir"
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/H/humio-agent/0/marathon.json.mustache
+++ b/repo/packages/H/humio-agent/0/marathon.json.mustache
@@ -1,0 +1,61 @@
+{
+  "id": "/{{service.name}}",
+  "instances": 1,
+  "cpus": 0.5,
+  "mem": 512,
+  "cmd": "SERVER_PORT=$PORT0 jre*/bin/java -Xms256m -Xmx512m -jar scheduler-*.jar",
+  "constraints": [
+    [
+      "hostname", "UNIQUE"
+    ]
+  ],
+  "networks": [
+    {
+      "mode": "host"
+    }
+  ],
+    "portDefinitions": [
+      {
+        "name": "api",
+        "protocol": "tcp",
+        "port": 0,
+        "labels": { "VIP_0": "/api.{{service.name}}:80" }
+      }
+  ],
+  "env": {
+    "SPRING_APPLICATION_NAME": "{{service.name}}",
+    "HUMIO_EXECUTOR_URL": "{{resource.assets.uris.executor-jar}}",
+    "HUMIO_HOST": "{{humio.host}}",
+    "HUMIO_DATASPACE": "{{humio.dataspace}}",
+    "HUMIO_INGESTTOKEN": "{{humio.ingestToken}}",
+    "HUMIO_EXECUTOR_DATADIR": "{{node.datadir}}",
+    "MESOS_RESOURCES_CPUS": "{{node.cpus}}",
+    "MESOS_RESOURCES_mem": "{{node.mem}}"
+  },
+  "labels": {
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-jar}}"
+  ],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/application/status",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 10,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ]
+}

--- a/repo/packages/H/humio-agent/0/package.json
+++ b/repo/packages/H/humio-agent/0/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "humio-agent",
+  "framework": false,
+  "description": "Log management for developers. Like tail and grep with aggregations and graphs built-in.\n\nMake sure you have created an account with a dataspace at https://humio.com",
+  "version": "0.5-beta-1",
+  "scm": "http://github.com/humio/dcos2humio",
+  "maintainer": "martin@mwl.dk",
+  "tags": ["log", "humio", "monitoring"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Experimental packages should never be used in production!",
+  "postInstallNotes": "Humio agent has been installed successfully.",
+  "postUninstallNotes": "Humio agent was uninstalled successfully.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/apache/spark/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/H/humio-agent/0/resource.json
+++ b/repo/packages/H/humio-agent/0/resource.json
@@ -1,0 +1,15 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz",
+      "scheduler-jar": "https://github.com/humio/dcos2humio/releases/download/0.5-beta-1/scheduler-0.5-beta-1.jar",
+      "executor-jar": "https://github.com/humio/dcos2humio/releases/download/0.5-beta-1/executor-0.5-beta-1.jar",
+      "filebeat-tar-gz": "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-5.5.2-linux-x86_64.tar.gz"
+    }
+  },
+  "images": {
+    "icon-small": "https://raw.githubusercontent.com/humio/graphics/master/48.png",
+    "icon-medium": "https://raw.githubusercontent.com/humio/graphics/master/96.png",
+    "icon-large": "https://raw.githubusercontent.com/humio/graphics/master/256_icon.png"
+  }
+}


### PR DESCRIPTION
Mesos framework for forwarding task logs to Humio.

By default it will deploy a Filebeat on all (including public) nodes in the cluster.