### PR TITLE
Arangodb update mesos framework 

### DIFF
--- a/repo/packages/A/arangodb3/8/config.json
+++ b/repo/packages/A/arangodb3/8/config.json
@@ -1,0 +1,293 @@
+{
+  "type": "object",
+  "properties": {
+
+    "mesos": {
+      "description": "Mesos specific configuration properties",
+      "type": "object",
+      "properties": {
+        "master": {
+          "description": "The URL of the Mesos master. The format is a comma-delimited list of hosts like zk://host1:port,host2:port/mesos. If using ZooKeeper, pay particular attention to the leading zk:// and trailing /mesos! If not using ZooKeeper, standard URLs like http://localhost are also acceptable.",
+          "type": "string",
+          "default": "zk://master.mesos:2181/mesos"
+        }
+      },
+      "required": [
+        "master"
+      ]
+    },
+
+    "arangodb": {
+      "description": "ArangoDB specific configuration properties",
+      "type": "object",
+      "properties": {
+
+        "framework-name": {
+          "description": "Identifier for the cluster.",
+          "type": "string",
+          "default": "arangodb3"
+        },
+
+        "useDocker": {
+          "description": "Whether to run on docker or mesos containers.",
+          "type": "boolean",
+          "default": true
+        },
+
+        "zk": {
+          "description": "ZooKeeper URL for storing state. Format: zk://host1:port1,host2:port2,.../path. Please note that the id is appended to the path.",
+          "type": "string",
+          "default": "zk://master.mesos:2181/arangodb3"
+        },
+
+        "webui-host": {
+          "description": "For debugging: use this host for WEBUI request.",
+          "type": "string",
+          "default": ""
+        },
+
+        "proxy-port": {
+          "description": "Proxy port, use '0' to let Mesos select a port for you.",
+          "type": "integer",
+          "default": 0
+        },
+
+        "framework-port": {
+          "description": "Framework port, use '0' to let Mesos select a port for you.",
+          "type": "integer",
+          "default": 0
+        },
+
+        "framework-cpus": {
+          "description": "cpus resources needed for each framework instance.",
+          "type": "number",
+          "default": 0.25
+        },
+
+        "framework-mem": {
+          "description": "mem resources needed for each framework instance.",
+          "type": "number",
+          "default": 512.0
+        },
+
+        "framework-instances": {
+          "description": "number of instances of the framework to run.",
+          "type": "integer",
+          "default": 1
+        },
+
+        "framework-user": {
+          "description": "user under which to run the framework tasks",
+          "type": "string",
+          "default": ""
+        },
+
+        "principal": {
+          "description": "Principal for persistent volumes",
+          "type": "string",
+          "default": "arangodb3"
+        },
+
+        "mode": {
+          "description": "Mode for framework, possible values: \"standalone\", \"cluster\"",
+          "type": "string",
+          "default": "cluster"
+        },
+
+        "async-replication": {
+          "description": "Whether we do asynchronous replication, possible values: \"true\", \"false\"",
+          "type": "boolean",
+          "default": false
+        },
+
+        "role": {
+          "description": "Role for framework",
+          "type": "string",
+          "default": "arangodb3"
+        },
+
+        "minimal-resources-agent": {
+          "description": "Minimal mesos resources for an agent",
+          "type": "string",
+          "default": "mem(*):2048;cpus(*):0.25;disk(*):2048"
+        },
+
+        "minimal-resources-coordinator": {
+          "description": "Minimal mesos resources for a coordinator",
+          "type": "string",
+          "default": "mem(*):4096;cpus(*):1;disk(*):1024"
+        },
+
+        "minimal-resources-dbserver": {
+          "description": "Minimal mesos resources for a DBserver",
+          "type": "string",
+          "default": "mem(*):4096;cpus(*):1;disk(*):4096"
+        },
+
+        "minimal-resources-secondary": {
+          "description": "Minimal mesos resources for a secondary DBserver",
+          "type": "string",
+          "default": "mem(*):4096;cpus(*):1;disk(*):4096"
+        },
+
+        "nr-agents": {
+          "description": "Number of Agents",
+          "type": "integer",
+          "default": 3
+        },
+
+        "nr-dbservers": {
+          "description": "Initial number of DBservers",
+          "type": "integer",
+          "default": 2
+        },
+
+        "nr-coordinators": {
+          "description": "Initial number of coordinators",
+          "type": "integer",
+          "default": 2
+        },
+
+        "failover-timeout": {
+          "description": "Timeout after which an automatic failover is done.",
+          "type": "number",
+          "default": 604800
+        },
+
+        "mesos-authenticate": {
+          "description": "If true use authentication with Mesos master.",
+          "type": "boolean",
+          "default": false
+        },
+
+        "secret": {
+          "description": "Secret for authentication with Mesos.",
+          "type": "string",
+          "default": ""
+        },
+
+        "secondaries-with-dbservers": {
+          "description": "Flag, if each secondary must run on a node with a DBServer",
+          "type": "boolean",
+          "default": false
+        },
+
+        "coordinators-with-dbservers": {
+          "description": "Flag, if each coordinator must run on a node with a DBServer",
+          "type": "boolean",
+          "default": false
+        },
+
+        "offer-limit": {
+          "description": "Maximum number of outstanding offers to look at",
+          "type": "integer",
+          "default": 10
+        },
+
+        "refuse-seconds": {
+          "description": "Number of seconds that declined offers will be put back to mesos",
+          "type": "integer",
+          "default": 20
+        },
+
+        "arangodb-docker-image": {
+          "description": "Docker image to run arangodb.",
+          "type": "string",
+          "default": "arangodb/arangodb-mesos:3.2"
+        },
+
+        "arangodb-privileged-image": {
+          "description": "Run arangodb image in privileged mode.",
+          "type": "boolean",
+          "default": false
+        },
+
+        "arangodb-force-pull-image": {
+          "description": "Forcefully pull arangodb image.",
+          "type": "boolean",
+          "default": true
+        },
+
+        "arangodb-ssl-keyfile": {
+          "description": "Enable SSL using this base64 encoded SSL keyfile (see ArangoDB docs for keyfile specification)",
+          "type": "string",
+          "default": ""
+        },
+        "arangodb-enterprise-key": {
+          "description": "Use enterprise edition using the following key",
+          "type": "string",
+          "default": ""
+        },
+        "arangodb-storage-engine": {
+          "description": "Storage engine to use: rocksdb, mmfiles",
+          "type": "string",
+          "default": "auto"
+        },
+        "arangodb-encryption-keyfile": {
+          "description": "Enable data encryption (implies rocksdb storage engine). Provide a base64 encoded 32 byte long key. ENTERPRISE ONLY",
+          "type": "string",
+          "default": ""
+        },
+        "arangodb-storage-engine": {
+          "description": "Storage engine to use: rocksdb, mmfiles",
+          "type": "string",
+          "default": "auto"
+        },
+        "arangodb-encryption-keyfile": {
+          "description": "Enable data encryption (implies rocksdb storage engine). Provide a base64 encoded 32 byte long key. ENTERPRISE ONLY",
+          "type": "string",
+          "default": ""
+        },
+        "arangodb-additional-agent-args": {
+          "description": "Additional arangod arguments to use when starting an agent (see arangod --help)",
+          "type": "string",
+          "default": ""
+        },
+        "arangodb-additional-dbserver-args": {
+          "description": "Additional arangod arguments to use when starting a dbserver (see arangod --help)",
+          "type": "string",
+          "default": ""
+        },
+        "arangodb-additional-secondary-args": {
+          "description": "Additional arangod arguments to use when starting a secondary dbserver (see arangod --help)",
+          "type": "string",
+          "default": ""
+        },
+        "arangodb-additional-coordinator-args": {
+          "description": "Additional arangod arguments to use when starting a coordinator (see arangod --help)",
+          "type": "string",
+          "default": ""
+        }
+      },
+
+      "required": [
+        "arangodb-docker-image",
+        "arangodb-privileged-image",
+        "async-replication",
+        "failover-timeout",
+        "framework-cpus",
+        "framework-instances",
+        "framework-mem",
+        "framework-name",
+        "framework-port",
+        "mesos-authenticate",
+        "minimal-resources-agent",
+        "minimal-resources-coordinator",
+        "minimal-resources-dbserver",
+        "minimal-resources-secondary",
+        "mode",
+        "nr-agents",
+        "nr-coordinators",
+        "nr-dbservers",
+        "role",
+        "secondaries-with-dbservers",
+        "zk"
+      ]
+    }
+  },
+
+  "required": [
+      "mesos",
+      "arangodb"
+  ]
+}

--- a/repo/packages/A/arangodb3/8/config.json
+++ b/repo/packages/A/arangodb3/8/config.json
@@ -193,7 +193,7 @@
         "arangodb-docker-image": {
           "description": "Docker image to run arangodb.",
           "type": "string",
-          "default": "arangodb/arangodb-mesos:3.2"
+          "default": "arangodb/arangodb-mesos:3.2_port"
         },
 
         "arangodb-privileged-image": {

--- a/repo/packages/A/arangodb3/8/marathon.json.mustache
+++ b/repo/packages/A/arangodb3/8/marathon.json.mustache
@@ -75,7 +75,7 @@
     "docker": {
       "image": "{{resource.assets.container.docker.framework}}",
       "forcePullImage": true,
-      "network": "HOST"=
+      "network": "HOST"
     }
     {{/arangodb.useDocker}}
 

--- a/repo/packages/A/arangodb3/8/marathon.json.mustache
+++ b/repo/packages/A/arangodb3/8/marathon.json.mustache
@@ -1,0 +1,108 @@
+{
+  "id": "{{arangodb.framework-name}}",
+  "cpus": {{arangodb.framework-cpus}},
+  "mem": {{arangodb.framework-mem}},
+  "portDefinitions": [
+    {
+      "port": {{arangodb.proxy-port}},
+      "protocol": "tcp",
+      "name": "proxy",
+      "labels": {}
+    },
+    {
+      "port": {{arangodb.framework-port}},
+      "protocol": "tcp",
+      "name": "framework",
+      "labels": {}
+    },
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "mesos",
+      "labels": {}
+    }
+  ],
+  "instances": {{arangodb.framework-instances}},
+  "args": [
+    "framework",
+    "--framework_name={{arangodb.framework-name}}",
+    {{#arangodb.useDocker}}
+    "--containerizer=DOCKER",
+    {{/arangodb.useDocker}}
+    {{^arangodb.useDocker}}    
+    "--containerizer=MESOS",
+    {{/arangodb.useDocker}}
+    "--master={{mesos.master}}",
+    "--zk={{arangodb.zk}}",
+    "--user={{arangodb.framework-user}}",
+    "--principal={{arangodb.principal}}",
+    "--role={{arangodb.role}}",
+    "--mode={{arangodb.mode}}",
+    "--async_replication={{arangodb.async-replication}}",
+    "--minimal_resources_agent={{arangodb.minimal-resources-agent}}",
+    "--minimal_resources_dbserver={{arangodb.minimal-resources-dbserver}}",
+    "--minimal_resources_secondary={{arangodb.minimal-resources-secondary}}",
+    "--minimal_resources_coordinator={{arangodb.minimal-resources-coordinator}}",
+    "--nr_agents={{arangodb.nr-agents}}",
+    "--nr_dbservers={{arangodb.nr-dbservers}}",
+    "--nr_coordinators={{arangodb.nr-coordinators}}",
+    "--failover_timeout={{arangodb.failover-timeout}}",
+    "--secondaries_with_dbservers={{arangodb.secondaries-with-dbservers}}",
+    "--coordinators_with_dbservers={{arangodb.coordinators-with-dbservers}}",
+    "--offer_limit={{arangodb.offer-limit}}",
+    "--refuse_seconds={{arangodb.refuse-seconds}}",
+    "--arangodb_enterprise_key={{arangodb.arangodb-enterprise-key}}",
+    "--arangodb_storage_engine={{arangodb.arangodb-storage-engine}}",
+    "--arangodb_ssl_keyfile={{arangodb.arangodb-ssl-keyfile}}",
+    "--arangodb_encryption_keyfile={{arangodb.arangodb-encryption-keyfile}}",
+    "--arangodb_image={{arangodb.arangodb-docker-image}}",
+    "--arangodb_privileged_image={{arangodb.arangodb-privileged-image}}",
+    "--arangodb_additional_agent_args={{arangodb.arangodb-additional-agent-args}}",
+    "--arangodb_additional_dbserver_args={{arangodb.arangodb-additional-dbserver-args}}",
+    "--arangodb_additional_secondary_args={{arangodb.arangodb-additional-secondary-args}}",
+    "--arangodb_additional_coordinator_args={{arangodb.arangodb-additional-coordinator-args}}",
+    "--arangodb_force_pull_image={{arangodb.arangodb-force-pull-image}}"
+  ],
+  "env": {
+    "ARANGODB_WEBUI_HOST": "{{arangodb.webui-host}}",
+    "ARANGODB_WEBUI_PORT": "{{arangodb.framework-port}}",
+    "MESOS_AUTHENTICATE": "{{arangodb.mesos-authenticate}}",
+    "ARANGODB_SECRET": "{{arangodb.secret}}"
+  },
+  "container": {
+    {{#arangodb.useDocker}}
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.framework}}",
+      "forcePullImage": true,
+      "network": "HOST"=
+    }
+    {{/arangodb.useDocker}}
+
+    {{^arangodb.useDocker}}    
+    "type": "MESOS",
+    "docker":{
+      "image":"{{resource.assets.container.docker.framework}}",
+      "force_pull_image": true
+    }
+    {{/arangodb.useDocker}}
+
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/framework/v1/health.json",
+      "gracePeriodSeconds": 3,
+      "intervalSeconds": 10,
+      "portIndex": 0,
+      "timeoutSeconds": 10,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "labels": {
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{arangodb.framework-name}}",
+    "DCOS_SERVICE_NAME": "{{arangodb.framework-name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/A/arangodb3/8/package.json
+++ b/repo/packages/A/arangodb3/8/package.json
@@ -1,0 +1,21 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.8",
+  "name": "arangodb3",
+  "version": "3.2-1.1.3",
+  "scm": "https://github.com/arangodb/arangodb3-dcos.git",
+  "maintainer": "info@arangodb.com",
+  "description": "A distributed free and open-source database with a flexible data model for documents, graphs, and key-values. Build high performance applications using a convenient SQL-like query language or JavaScript extensions. Guidance on how to install can be found here: https://github.com/dcos/examples/tree/master/arangodb",
+  "framework": true,
+  "tags": [ "arangodb", "NoSQL", "database" ],
+  "preInstallNotes": "The default configuration requires at least 3 nodes having 4.75 CPU, 22GB of memory and 20GB of persistent disk storage in total.",
+  "postInstallNotes": "The ArangoDB DCOS Service has been successfully installed!\n\n\tDocumentation: https://github.com/arangodb/arangodb3-dcos\n\tIssues: https://github.com/arangodb/arangodb3-dcos/issues",
+  "postUninstallNotes": "The ArangoDB DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at https://github.com/arangodb/arangodb3-dcos to clean up any persisted state.",
+    "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/arangodb/arangodb-dcos/master/LICENSE"
+    }
+  ],
+  "selected": false
+}

--- a/repo/packages/A/arangodb3/8/resource.json
+++ b/repo/packages/A/arangodb3/8/resource.json
@@ -1,0 +1,48 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "framework": "arangodb/arangodb-mesos-framework:3.2-1.1.3"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://raw.githubusercontent.com/arangodb/arangodb3-dcos/master/icons/arangodb_small.png",
+    "icon-medium": "https://raw.githubusercontent.com/arangodb/arangodb3-dcos/master/icons/arangodb_medium.png",
+    "icon-large": "https://raw.githubusercontent.com/arangodb/arangodb3-dcos/master/icons/arangodb_large.png"
+  },
+  "cli": {
+    "binaries": {
+      "linux": {
+        "x86-64": {
+          "kind": "executable",
+          "url": "https://github.com/arangodb/arangodb3-dcos/releases/download/1.0.0/dcos-arangodb3-1.0.0-linux-x64",
+          "contentHash": [{
+            "algo": "sha256",
+            "value": "6936cd713783a483087f0f9391b831f4fd8c490207bd5b13725429060c67da9d"
+          }]
+        }
+      },
+      "darwin": {
+        "x86-64": {
+          "kind": "executable",
+          "url": "https://github.com/arangodb/arangodb3-dcos/releases/download/1.0.0/dcos-arangodb3-1.0.0-darwin-x64",
+          "contentHash": [{
+            "algo": "sha256",
+            "value": "feec66ad4f92cdf6cf50c8cc1bce5048aeb20def0a69578d3dacced15bdb1b54"
+          }]
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "kind": "executable",
+          "url": "https://github.com/arangodb/arangodb3-dcos/releases/download/1.0.0/dcos-arangodb3-1.0.0-windows-x64.exe",
+          "contentHash": [{
+            "algo": "sha256",
+            "value": "2395504f2f3fa4786face0343bf2d7f31a6ace67109e277382b4159859c430bd"
+          }]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add new revision of the arangodb framework
    
- we now use the mesos 1.1 framework to build the client
- we may now choose the storage engine of arangodb
- we may now choose the container engine to run in;
  ContainerInfo::DOCKER (as previously) and ContainerInfo::MESOS
  are supported now.
