### PR TITLE
Upgrade to Grafana 4.6.0

### DIFF
--- a/repo/packages/G/grafana/3/config.json
+++ b/repo/packages/G/grafana/3/config.json
@@ -1,0 +1,76 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "service":{
+            "type":"object",
+            "description": "DC/OS service configuration properties",
+            "properties":{
+                "name" : {
+                    "description":"Name of this service instance.",
+                    "type":"string",
+                    "default":"grafana"
+                }
+            }
+        },
+        "grafana":{
+            "type": "object",
+            "description": "grafana service configuration properties",
+            "properties": {
+                "cpus": {
+                    "description": "CPU shares to allocate to each service instance.",
+                    "type": "number",
+                    "default": 0.3,
+                    "minimum": 0.3
+                },
+                "mem": {
+                    "description":  "Memory to allocate to each service instance.",
+                    "type": "number",
+                    "default": 512.0,
+                    "minimum": 512.0
+                },
+                "admin_password": {
+                    "description": "Admin password.",
+                    "type": "string",
+                    "default": "admin"
+                },
+                "plugins": {
+                    "description": "Comma separated Grafana plugins which will be installed via `grafana-cli plugins install grafana-example-app,grafana-clock-panel`. See https://grafana.com/plugins",
+                    "type": "string",
+                    "default": ""
+                }
+
+            },
+            "required": [
+                "cpus",
+                "mem"
+            ]
+        },
+        "networking":{
+            "type": "object",
+            "description": "Grafana networking configuration properties",
+            "properties": {
+                "external_access": {
+                    "type": "object",
+                    "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+                    "properties": {
+                        "enable": {
+                            "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "external_access_port": {
+                            "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+                            "type": "number",
+                            "default": 13000
+                        },
+                        "virtual_host": {
+                            "description": "For external access, Virtual Host URL to be used in the external load balancer.",
+                            "type": "string",
+                            "default": "grafana.example.org"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/G/grafana/3/marathon.json.mustache
+++ b/repo/packages/G/grafana/3/marathon.json.mustache
@@ -1,0 +1,48 @@
+{
+    "id": "{{service.name}}",
+    "cpus": {{grafana.cpus}},
+    "mem": {{grafana.mem}},
+    "instances": 1,
+    "env": {
+        "GF_SECURITY_ADMIN_PASSWORD": "{{grafana.admin_password}}",
+        "GF_INSTALL_PLUGINS": "{{grafana.plugins}}"
+    },
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.grafana-docker}}",
+            "forcePullImage": false,
+            "network": "BRIDGE",
+            "portMappings": [
+            {
+                "containerPort": 3000,
+                "hostPort": 0,
+                {{#networking.external_access.enable}}
+                "servicePort": {{networking.external_access.external_access_port}},
+                {{/networking.external_access.enable}}
+                "protocol": "tcp"
+            }
+            ]
+        }
+    },
+    "healthChecks": [
+        {
+            "protocol": "HTTP",
+            "path": "/api/health",
+            "portIndex": 0,
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ],
+    "labels": {
+        "DCOS_PACKAGE_VERSION": "5.0.0-4.6.0",
+        "DCOS_SERVICE_NAME": "{{service.name}}",
+        {{#networking.external_access.enable}}
+        "HAPROXY_GROUP": "external",
+        "HAPROXY_0_VHOST": "{{networking.external_access.virtual_host}}",
+        {{/networking.external_access.enable}}
+        "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+    }
+}

--- a/repo/packages/G/grafana/3/marathon.json.mustache
+++ b/repo/packages/G/grafana/3/marathon.json.mustache
@@ -37,7 +37,7 @@
         }
     ],
     "labels": {
-        "DCOS_PACKAGE_VERSION": "5.0.0-4.6.0",
+        "DCOS_PACKAGE_VERSION": "5.0.0-4.6.2",
         "DCOS_SERVICE_NAME": "{{service.name}}",
         {{#networking.external_access.enable}}
         "HAPROXY_GROUP": "external",

--- a/repo/packages/G/grafana/3/package.json
+++ b/repo/packages/G/grafana/3/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "grafana",
-  "version": "5.0.0-4.6.0",
+  "version": "5.0.0-4.6.2",
   "scm": "https://github.com/grafana/grafana",
   "maintainer": "https://dcos.io/community",
   "website": "https://grafana.com",

--- a/repo/packages/G/grafana/3/package.json
+++ b/repo/packages/G/grafana/3/package.json
@@ -1,0 +1,22 @@
+{
+  "packagingVersion": "3.0",
+  "name": "grafana",
+  "version": "5.0.0-4.6.0",
+  "scm": "https://github.com/grafana/grafana",
+  "maintainer": "https://dcos.io/community",
+  "website": "https://grafana.com",
+  "description": "Grafana is a leading open source application for visualizing large-scale measurement data. It provides a powerful and elegant way to create, share, and explore data and dashboards from your disparate metric databases, either with your team or the world. Grafana is most commonly used for Internet infrastructure and application analytics, but many use it in other domains including industrial sensors, home automation, weather, and process control. Grafana features pluggable panels and data sources allowing easy extensibility. There is currently rich support for Graphite, InfluxDB and OpenTSDB. There is also experimental support for KairosDB, and SQL is on the roadmap. Grafana has a variety of panels, including a fully featured graph panel with rich visualization options. In order to install Grafana plugins use ENV variable with plugin names separated by comma, e.g.: `GF_INSTALL_PLUGINS=grafana-piechart-panel`.\n\nThis package can be used alongside the DC/OS 'cadvisor' and 'influxdb' packages for a cluster-wide monitoring solution.\n\nInstallation Documentation: https://github.com/dcos/examples/tree/master/cadvisor-influxdb-grafana\n\n",
+  "tags": [
+    "grafana",
+    "monitoring",
+    "visualization"
+    ],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\n```Advanced Installation options notes```\n\nnetworking / *external_access*: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / *external_access_port*: port to be used in Marathon-LB for accessing the service.",
+  "postInstallNotes": "Service installed.\n\nIt is recommended to access this service through the endpoint created in Marathon-LB.\n\nDefault login: `admin`/`admin`.",
+  "licenses": [
+    {
+      "name": "Apache License",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ]
+}

--- a/repo/packages/G/grafana/3/resource.json
+++ b/repo/packages/G/grafana/3/resource.json
@@ -12,7 +12,7 @@
   "assets": {
     "container": {
       "docker": {
-        "grafana-docker": "grafana/grafana:4.6.0"
+        "grafana-docker": "grafana/grafana:4.6.2"
       }
     }
   }

--- a/repo/packages/G/grafana/3/resource.json
+++ b/repo/packages/G/grafana/3/resource.json
@@ -1,0 +1,19 @@
+{
+  "images": {
+    "icon-small": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-grafana-small.png",
+    "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-grafana-medium.png",
+    "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-grafana-large.png",
+   "screenshots": [
+     "http://grafana.org/assets/img/blog/v3.0/wP-Screenshot-dash-web.png",
+     "https://prometheus.io/assets/grafana_prometheus-cbb943f0bb3.png",
+     "https://grafana.com/blog/img/docs/v45/query_inspector.png"
+   ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "grafana-docker": "grafana/grafana:4.6.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Grafana upgraded to 4.6.0, [release notes](https://grafana.com/blog/2017/10/26/grafana-4.6-released/)
* Bumped framework version, so that is follows common versioning scheme `{dcos package version}-{project version}`. In order to make this change compatible with semantic versioning I've used `5.0.0`, or we could use `4.6.0-4.6.0` if you prefer that.
 
changes:
```
 $ git diff --no-index repo/packages/G/grafana/2 repo/packages/G/grafana/3
diff --git a/repo/packages/G/grafana/2/marathon.json.mustache b/repo/packages/G/grafana/3/marathon.json.mustache
index 225917c..f1b5096 100644
--- a/repo/packages/G/grafana/2/marathon.json.mustache
+++ b/repo/packages/G/grafana/3/marathon.json.mustache
@@ -37,7 +37,7 @@
         }
     ],
     "labels": {
-        "DCOS_PACKAGE_VERSION": "4.5.1-0.3",
+        "DCOS_PACKAGE_VERSION": "5.0.0-4.6.0",
         "DCOS_SERVICE_NAME": "{{service.name}}",
         {{#networking.external_access.enable}}
         "HAPROXY_GROUP": "external",
diff --git a/repo/packages/G/grafana/2/package.json b/repo/packages/G/grafana/3/package.json
index 3da302a..c13135c 100644
--- a/repo/packages/G/grafana/2/package.json
+++ b/repo/packages/G/grafana/3/package.json
@@ -1,11 +1,11 @@
 {
   "packagingVersion": "3.0",
   "name": "grafana",
-  "version": "4.5.2-0.3",
+  "version": "5.0.0-4.6.0",
   "scm": "https://github.com/grafana/grafana",
   "maintainer": "https://dcos.io/community",
-  "website": "https://grafana.net/",
-  "description": "Grafana is a leading open source application for visualizing large-scale measurement data. It provides a powerful and elegant way to create, share, and explore data and dashboards from your disparate metric databases, either with your team or the world. Grafana is most commonly used for Internet infrastructure and application analytics, but many use it in other domains including industrial sensors, home automation, weather, and process control. Grafana features pluggable panels and data sources allowing easy extensibility. There is currently rich support for Graphite, InfluxDB and OpenTSDB. There is also experimental support for KairosDB, and SQL is on the roadmap. Grafana has a variety of panels, including a fully featured graph panel with rich visualization options.\n\nThis package can be used alongside the DC/OS 'cadvisor' and 'influxdb' packages for a cluster-wide monitoring solution.\n\nInstallation Documentation: https://github.com/dcos/examples/tree/master/cadvisor-influxdb-grafana\n\n",
+  "website": "https://grafana.com",
+  "description": "Grafana is a leading open source application for visualizing large-scale measurement data. It provides a powerful and elegant way to create, share, and explore data and dashboards from your disparate metric databases, either with your team or the world. Grafana is most commonly used for Internet infrastructure and application analytics, but many use it in other domains including industrial sensors, home automation, weather, and process control. Grafana features pluggable panels and data sources allowing easy extensibility. There is currently rich support for Graphite, InfluxDB and OpenTSDB. There is also experimental support for KairosDB, and SQL is on the roadmap. Grafana has a variety of panels, including a fully featured graph panel with rich visualization options. In order to install Grafana plugins use ENV variable with plugin names separated by comma, e.g.: `GF_INSTALL_PLUGINS=grafana-piechart-panel`.\n\nThis package can be used alongside the DC/OS 'cadvisor' and 'influxdb' packages for a cluster-wide monitoring solution.\n\nInstallation Documentation: https://github.com/dcos/examples/tree/master/cadvisor-influxdb-grafana\n\n",
   "tags": [
     "grafana",
     "monitoring",
diff --git a/repo/packages/G/grafana/2/resource.json b/repo/packages/G/grafana/3/resource.json
index 1740de9..c2a16f5 100644
--- a/repo/packages/G/grafana/2/resource.json
+++ b/repo/packages/G/grafana/3/resource.json
@@ -12,7 +12,7 @@
   "assets": {
     "container": {
       "docker": {
-        "grafana-docker": "grafana/grafana:4.5.2"
+        "grafana-docker": "grafana/grafana:4.6.0"
       }
     }
   }

```