### PR TITLE
Relax url schema in build def to accept file paths as well

### DIFF
--- a/repo/meta/schema/build-definition-schema.json
+++ b/repo/meta/schema/build-definition-schema.json
@@ -16,10 +16,7 @@
 
     "url": {
       "type": "string",
-      "allOf": [
-        { "format": "uri" },
-        { "pattern": "^https?://" }
-      ]
+      "pattern": "."
     },
 
     "base64String": {


### PR DESCRIPTION
We need this as we would use docker references and file paths. The universe packages are protected with the regular schema so we can relax this here.