### PR TITLE
Release portworx-elastic 1.1-5.5.1-bf399c5 (automated commit)

### DIFF
--- a/repo/packages/P/portworx-elastic/1/config.json
+++ b/repo/packages/P/portworx-elastic/1/config.json
@@ -1,0 +1,354 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "The name of the Elasticsearch service instance",
+          "type": "string",
+          "default": "portworx-elastic"
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "user": {
+          "description": "The user that runs the Elasticsearch services and owns the Mesos sandbox.",
+          "type": "string",
+          "default": "nobody"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "deploy_strategy": {
+          "description": "Elasticsearch deploy strategy. [parallel, serial]",
+          "type": "string",
+          "default": "parallel",
+          "enum": [
+            "parallel",
+            "serial"
+          ]
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "default": "V0"
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        }
+      },
+      "required": [
+        "name",
+        "user",
+        "deploy_strategy"
+      ]
+    },
+    "elasticsearch": {
+      "description": "Elasticsearch service configuration properties",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "xpack_enabled": {
+          "description": "Whether or not to enable the commercial X-Pack plugin from Elastic",
+          "type": "boolean",
+          "default": false
+        },
+        "plugins": {
+          "description": "Comma-separated list of plugins to install",
+          "type": "string",
+          "default": ""
+        },
+        "health_user": {
+          "description": "Elastic username to use for X-Pack authentication, if enabled",
+          "type": "string",
+          "default": "elastic"
+        },
+        "health_user_password": {
+          "description": "Password to use with health_user for X-Pack authentication, if enabled. Note that you are not setting the password here. You are telling the framework the credentials to use when sending in health check requests.",
+          "type": "string",
+          "default": "changeme"
+        }
+      }
+    },
+    "master_nodes": {
+      "description": "Configuration properties for the three (3) Elasticsearch master nodes",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "Node cpu requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "mem": {
+          "description": "Node mem requirements",
+          "type": "integer",
+          "default": 2048
+        },
+        "heap": {
+          "description": "The Elasticsearch process JVM heap configuration object",
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "integer",
+              "description": "The amount of JVM heap, in MB, allocated to the Elasticsearch node process.",
+              "default": 1024
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "size"
+          ]
+        },
+        "disk": {
+          "description": "Node disk requirements (only respected with persistent volumes)",
+          "type": "integer",
+          "default": 2000
+        },
+        "portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "MasterNodeVolume"
+        },
+        "portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "transport_port": {
+          "description": "Transport port for master nodes to listen on.",
+          "type": "integer",
+          "default": 9300
+        },
+        "placement": {
+          "description": "Marathon-style placement constraints",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "transport_port"
+      ]
+    },
+    "data_nodes": {
+      "description": "Elasticsearch data node configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "description": "Number of data nodes to run",
+          "type": "integer",
+          "default": 2,
+          "minimum": 1
+        },
+        "cpus": {
+          "description": "Node cpu requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "mem": {
+          "description": "Node mem requirements",
+          "type": "integer",
+          "default": 4096
+        },
+        "heap": {
+          "description": "The Elasticsearch process JVM heap configuration object",
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "integer",
+              "description": "The amount of JVM heap, in MB, allocated to the Elasticsearch node process.",
+              "default": 2048
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "size"
+          ]
+        },
+        "disk": {
+          "description": "Node disk requirements (only respected with persistent volumes)",
+          "type": "integer",
+          "default": 10000
+        },
+        "portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "DataNodeVolume"
+        },
+        "portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "placement": {
+          "description": "Marathon-style placement constraints",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "count"
+      ]
+    },
+    "ingest_nodes": {
+      "description": "Elasticsearch ingest node configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "description": "Number of ingest nodes to run",
+          "type": "integer",
+          "default": 0,
+          "minimum": 0
+        },
+        "cpus": {
+          "description": "Node cpu requirements",
+          "type": "number",
+          "default": 0.5
+        },
+        "mem": {
+          "description": "Node mem requirements",
+          "type": "integer",
+          "default": 2048
+        },
+        "heap": {
+          "description": "The Elasticsearch process JVM heap configuration object",
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "integer",
+              "description": "The amount of JVM heap, in MB, allocated to the Elasticsearch node process.",
+              "default": 512
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "size"
+          ]
+        },
+        "disk": {
+          "description": "Node disk requirements (only respected with persistent volumes)",
+          "type": "integer",
+          "default": 2000
+        },
+        "portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "IngestNodeVolume"
+        },
+        "portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "placement": {
+          "description": "Marathon-style placement constraints",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "count"
+      ]
+    },
+    "coordinator_nodes": {
+      "description": "Elasticsearch coordinator node configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "description": "Number of coordinator nodes to run",
+          "type": "integer",
+          "default": 1,
+          "minimum": 0
+        },
+        "cpus": {
+          "description": "Node cpu requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "mem": {
+          "description": "Node mem requirements",
+          "type": "integer",
+          "default": 2048
+        },
+        "heap": {
+          "description": "The Elasticsearch process JVM heap configuration object",
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "integer",
+              "description": "The amount of JVM heap, in MB, allocated to the Elasticsearch node process.",
+              "default": 1024
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "size"
+          ]
+        },
+        "disk": {
+          "description": "Node disk requirements (only respected with persistent volumes)",
+          "type": "integer",
+          "default": 1000
+        },
+        "portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "CoordinatorNodeVolume"
+        },
+        "portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "placement": {
+          "description": "Marathon-style placement constraints",
+          "type": "string"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "count"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/portworx-elastic/1/marathon.json.mustache
+++ b/repo/packages/P/portworx-elastic/1/marathon.json.mustache
@@ -1,0 +1,129 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 0.5,
+  "mem": 2048,
+  "instances": 1,
+  "user":"{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx1024M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./elastic-scheduler/bin/elastic ./elastic-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "ELASTIC_VERSION": "5.5.1",
+    "STATSD_URI": "{{resource.assets.uris.statsd-plugin-zip}}",
+    "ELASTICSEARCH_URI" : "{{resource.assets.uris.elasticsearch-tar-gz}}",
+    "ELASTICSEARCH_JAVA_URI" : "{{resource.assets.uris.elasticsearch-jre-tar-gz}}",
+    "XPACK_URI" : "{{resource.assets.uris.xpack-zip}}",
+    "DIAGNOSTICS_URI" : "{{resource.assets.uris.diagnostics-zip}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "SCHEDULER_URI": "{{resource.assets.uris.scheduler-zip}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.service_account_secret}}
+
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+
+    "DEPLOY_STRATEGY": "{{service.deploy_strategy}}",
+    "TASKCFG_ALL_XPACK_ENABLED": "{{elasticsearch.xpack_enabled}}",
+    "ELASTICSEARCH_HEALTH_USER": "{{elasticsearch.health_user}}",
+    "ELASTICSEARCH_HEALTH_USER_PASSWORD": "{{elasticsearch.health_user_password}}",
+    "TASKCFG_ALL_ELASTICSEARCH_PLUGINS": "{{elasticsearch.plugins}}",
+    "MASTER_NODE_CPUS": "{{master_nodes.cpus}}",
+    "MASTER_NODE_MEM": "{{master_nodes.mem}}",
+    "MASTER_NODE_PLACEMENT": "{{master_nodes.placement}}",
+    "MASTER_NODE_HEAP_MB": "{{master_nodes.heap.size}}",
+    "MASTER_NODE_DISK": "{{master_nodes.disk}}",
+    "MASTER_NODE_DOCKER_VOLUME_NAME": "{{{master_nodes.portworx_volume_name}}}",
+    "MASTER_NODE_DOCKER_DRIVER_OPTIONS": "{{{master_nodes.portworx_volume_options}}}",
+    "MASTER_NODE_TRANSPORT_PORT": "{{master_nodes.transport_port}}",
+    "DATA_NODE_COUNT": "{{data_nodes.count}}",
+    "DATA_NODE_CPUS": "{{data_nodes.cpus}}",
+    "DATA_NODE_MEM": "{{data_nodes.mem}}",
+    "DATA_NODE_PLACEMENT": "{{data_nodes.placement}}",
+    "DATA_NODE_HEAP_MB": "{{data_nodes.heap.size}}",
+    "DATA_NODE_DISK": "{{data_nodes.disk}}",
+    "DATA_NODE_DOCKER_VOLUME_NAME": "{{{data_nodes.portworx_volume_name}}}",
+    "DATA_NODE_DOCKER_DRIVER_OPTIONS": "{{{data_nodes.portworx_volume_options}}}",
+    "INGEST_NODE_COUNT": "{{ingest_nodes.count}}",
+    "INGEST_NODE_CPUS": "{{ingest_nodes.cpus}}",
+    "INGEST_NODE_MEM": "{{ingest_nodes.mem}}",
+    "INGEST_NODE_PLACEMENT": "{{ingest_nodes.placement}}",
+    "INGEST_NODE_HEAP_MB": "{{ingest_nodes.heap.size}}",
+    "INGEST_NODE_DISK": "{{ingest_nodes.disk}}",
+    "INGEST_NODE_DOCKER_VOLUME_NAME": "{{{ingest_nodes.portworx_volume_name}}}",
+    "INGEST_NODE_DOCKER_DRIVER_OPTIONS": "{{{ingest_nodes.portworx_volume_options}}}",
+    "COORDINATOR_NODE_COUNT": "{{coordinator_nodes.count}}",
+    "COORDINATOR_NODE_CPUS": "{{coordinator_nodes.cpus}}",
+    "COORDINATOR_NODE_MEM": "{{coordinator_nodes.mem}}",
+    "COORDINATOR_NODE_PLACEMENT": "{{coordinator_nodes.placement}}",
+    "COORDINATOR_NODE_HEAP_MB": "{{coordinator_nodes.heap.size}}",
+    "COORDINATOR_NODE_DISK": "{{coordinator_nodes.disk}}",
+    "COORDINATOR_NODE_DOCKER_VOLUME_NAME": "{{{coordinator_nodes.portworx_volume_name}}}",
+    "COORDINATOR_NODE_DOCKER_DRIVER_OPTIONS": "{{{coordinator_nodes.portworx_volume_options}}}",
+    "CONFIG_TEMPLATE_PATH": "elastic-scheduler"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx-elastic/1/package.json
+++ b/repo/packages/P/portworx-elastic/1/package.json
@@ -1,0 +1,20 @@
+{
+  "description": "Elasticsearch 5, and optionally X-Pack",
+  "framework": true,
+  "maintainer": "support@portworx.com",
+  "minDcosReleaseVersion": "1.9",
+  "name": "portworx-elastic",
+  "packagingVersion": "4.0",
+  "postInstallNotes": "DC/OS elastic service is being installed!\n\n\tDocumentation: https://docs.portworx.com/scheduler/mesosphere-dcos/elasticsearch.html",
+  "postUninstallNotes": "DC/OS elastic service is being uninstalled\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required.",
+  "preInstallNotes": "Default configuration requires 3 agent nodes each with: CPU: 4.5 | Memory: 11264MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM\n\nIngest node: 1 instance | 0.5 CPU | 2048 MB MEM\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM\n\nPortworx should be installed on the Private Agents to be able to provision volumes.\n\nCommunity packages are unverified and unreviewed content from the community.",
+  "selected": false,
+  "tags": [
+    "elastic",
+    "elasticsearch",
+    "kibana",
+    "x-pack",
+    "portworx"
+  ],
+  "version": "1.1-5.5.1-bf399c5"
+}

--- a/repo/packages/P/portworx-elastic/1/resource.json
+++ b/repo/packages/P/portworx-elastic/1/resource.json
@@ -1,0 +1,61 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.1-5.5.1-bf399c5/executor.zip",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.1-5.5.1-bf399c5/bootstrap.zip",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.1-5.5.1-bf399c5/elastic-scheduler.zip",
+      "statsd-plugin-zip": "https://github.com/mesosphere/elasticsearch-statsd-plugin/releases/download/5.5.1.0/elasticsearch-statsd-5.5.1.0.zip",
+      "elasticsearch-jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
+      "elasticsearch-tar-gz": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.1.tar.gz",
+      "xpack-zip": "https://artifacts.elastic.co/downloads/packs/x-pack/x-pack-5.5.1.zip",
+      "diagnostics-zip": "https://github.com/elastic/elasticsearch-support-diagnostics/releases/download/5.12/support-diagnostics-5.12-dist.zip"
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/elasticsearch-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/elasticsearch-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/elasticsearch-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "f25ef4ac7166363d0173239df7d388352e49faea1ee191befb1965e55285f4c2"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.1-5.5.1-bf399c5/dcos-portworx-elastic-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "11c78228fa2c16ee3fd5826a0665d21bd82df13416d36fad33fbcc4971c3799e"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.1-5.5.1-bf399c5/dcos-portworx-elastic-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "79c28a1619be8ce41afee9daabaa978d246028eae690860305f14f1da792c7e0"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.1-5.5.1-bf399c5/dcos-portworx-elastic.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Changes since revision 0:
0 files added: []
0 files removed: []
4 files changed:

```
--- 0/config.json
+++ 1/config.json
@@ -8,9 +8,9 @@
         "name": {
           "description": "The name of the Elasticsearch service instance",
           "type": "string",
-          "default": "elastic"
-        },
-        "secret_name": {
+          "default": "portworx-elastic"
+        },
+        "service_account_secret": {
           "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
           "type": "string",
           "default": ""
@@ -18,17 +18,27 @@
         "user": {
           "description": "The user that runs the Elasticsearch services and owns the Mesos sandbox.",
           "type": "string",
-          "default": "root"
-        },
-        "principal": {
-          "description": "The principal for the Elasticsearch service instance.",
-          "type": "string",
-          "default": ""
-        },
-        "virtual_networks": {
-          "description": "Enable DC/OS Virtual Networking",
+          "default": "nobody"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
           "type": "boolean",
           "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
         },
         "deploy_strategy": {
           "description": "Elasticsearch deploy strategy. [parallel, serial]",
@@ -145,11 +155,6 @@
         "placement": {
           "description": "Marathon-style placement constraints",
           "type": "string"
-        },
-        "virtual_network": {
-          "description": "Name of virtual network to join",
-          "type": "string",
-          "default": "dcos"
         }
       },
       "required": [
@@ -212,11 +217,6 @@
         "placement": {
           "description": "Marathon-style placement constraints",
           "type": "string"
-        },
-        "virtual_network": {
-          "description": "Name of virtual network to join",
-          "type": "string",
-          "default": "dcos"
         }
       },
       "required": [
@@ -233,8 +233,8 @@
         "count": {
           "description": "Number of ingest nodes to run",
           "type": "integer",
-          "default": 1,
-          "minimum": 1
+          "default": 0,
+          "minimum": 0
         },
         "cpus": {
           "description": "Node cpu requirements",
@@ -279,11 +279,6 @@
         "placement": {
           "description": "Marathon-style placement constraints",
           "type": "string"
-        },
-        "virtual_network": {
-          "description": "Name of virtual network to join",
-          "type": "string",
-          "default": "dcos"
         }
       },
       "required": [
@@ -346,11 +341,6 @@
         "placement": {
           "description": "Marathon-style placement constraints",
           "type": "string"
-        },
-        "virtual_network": {
-          "description": "Name of virtual network to join",
-          "type": "string",
-          "default": "dcos"
         }
       },
       "required": [
--- 0/marathon.json.mustache
+++ 1/marathon.json.mustache
@@ -14,13 +14,13 @@
     "DCOS_SERVICE_PORT_INDEX": "0",
     "DCOS_SERVICE_SCHEME": "http"
   },
-  {{#service.secret_name}}
+  {{#service.service_account_secret}}
   "secrets": {
     "serviceCredential": {
-      "source": "{{service.secret_name}}"
+      "source": "{{service.service_account_secret}}"
     }
   },
-  {{/service.secret_name}}
+  {{/service.service_account_secret}}
   "env": {
     "ELASTIC_VERSION": "5.5.1",
     "STATSD_URI": "{{resource.assets.uris.statsd-plugin-zip}}",
@@ -35,26 +35,20 @@
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_USER": "{{service.user}}",
-    "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",

-    {{#service.secret_name}}
+    {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
     "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
-    {{/service.secret_name}}
+    {{/service.service_account_secret}}

-    {{#service.virtual_networks}}
+    {{#service.virtual_network_enabled}}
     "ENABLE_VIRTUAL_NETWORK": "yes",
-    "VIRTUAL_NETWORK_NAME_MASTER": "{{master_nodes.virtual_network}}",
-    "CNI_PLUGIN_LABELS_MASTER": "{{master_nodes.cni_plugin_labels}}",
-    "VIRTUAL_NETWORK_NAME_DATA": "{{data_nodes.virtual_network}}",
-    "CNI_PLUGIN_LABELS_DATA": "{{data_nodes.cni_plugin_labels}}",
-    "VIRTUAL_NETWORK_NAME_INGEST": "{{ingest_nodes.virtual_network}}",
-    "CNI_PLUGIN_LABELS_INGEST": "{{ingest_nodes.cni_plugin_labels}}",
-    "VIRTUAL_NETWORK_NAME_COORDINATOR": "{{coordinator_nodes.virtual_network}}",
-    "CNI_PLUGIN_LABELS_COORDINATOR": "{{coordinator_nodes.cni_plugin_labels}}",
-    {{/service.virtual_networks}}
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}

     "DEPLOY_STRATEGY": "{{service.deploy_strategy}}",
     "TASKCFG_ALL_XPACK_ENABLED": "{{elasticsearch.xpack_enabled}}",
@@ -67,7 +61,7 @@
     "MASTER_NODE_HEAP_MB": "{{master_nodes.heap.size}}",
     "MASTER_NODE_DISK": "{{master_nodes.disk}}",
     "MASTER_NODE_DOCKER_VOLUME_NAME": "{{{master_nodes.portworx_volume_name}}}",
-    "MASTER_NODE_DOCKER_DRIVER_OPTIONS": "{{{master_nodes.portworx_driver_options}}}",
+    "MASTER_NODE_DOCKER_DRIVER_OPTIONS": "{{{master_nodes.portworx_volume_options}}}",
     "MASTER_NODE_TRANSPORT_PORT": "{{master_nodes.transport_port}}",
     "DATA_NODE_COUNT": "{{data_nodes.count}}",
     "DATA_NODE_CPUS": "{{data_nodes.cpus}}",
@@ -76,7 +70,7 @@
     "DATA_NODE_HEAP_MB": "{{data_nodes.heap.size}}",
     "DATA_NODE_DISK": "{{data_nodes.disk}}",
     "DATA_NODE_DOCKER_VOLUME_NAME": "{{{data_nodes.portworx_volume_name}}}",
-    "DATA_NODE_DOCKER_DRIVER_OPTIONS": "{{{data_nodes.portworx_driver_options}}}",
+    "DATA_NODE_DOCKER_DRIVER_OPTIONS": "{{{data_nodes.portworx_volume_options}}}",
     "INGEST_NODE_COUNT": "{{ingest_nodes.count}}",
     "INGEST_NODE_CPUS": "{{ingest_nodes.cpus}}",
     "INGEST_NODE_MEM": "{{ingest_nodes.mem}}",
@@ -84,7 +78,7 @@
     "INGEST_NODE_HEAP_MB": "{{ingest_nodes.heap.size}}",
     "INGEST_NODE_DISK": "{{ingest_nodes.disk}}",
     "INGEST_NODE_DOCKER_VOLUME_NAME": "{{{ingest_nodes.portworx_volume_name}}}",
-    "INGEST_NODE_DOCKER_DRIVER_OPTIONS": "{{{ingest_nodes.portworx_driver_options}}}",
+    "INGEST_NODE_DOCKER_DRIVER_OPTIONS": "{{{ingest_nodes.portworx_volume_options}}}",
     "COORDINATOR_NODE_COUNT": "{{coordinator_nodes.count}}",
     "COORDINATOR_NODE_CPUS": "{{coordinator_nodes.cpus}}",
     "COORDINATOR_NODE_MEM": "{{coordinator_nodes.mem}}",
@@ -92,7 +86,7 @@
     "COORDINATOR_NODE_HEAP_MB": "{{coordinator_nodes.heap.size}}",
     "COORDINATOR_NODE_DISK": "{{coordinator_nodes.disk}}",
     "COORDINATOR_NODE_DOCKER_VOLUME_NAME": "{{{coordinator_nodes.portworx_volume_name}}}",
-    "COORDINATOR_NODE_DOCKER_DRIVER_OPTIONS": "{{{coordinator_nodes.portworx_driver_options}}}",
+    "COORDINATOR_NODE_DOCKER_DRIVER_OPTIONS": "{{{coordinator_nodes.portworx_volume_options}}}",
     "CONFIG_TEMPLATE_PATH": "elastic-scheduler"
   },
   "uris": [
--- 0/package.json
+++ 1/package.json
@@ -4,7 +4,7 @@
   "maintainer": "support@portworx.com",
   "minDcosReleaseVersion": "1.9",
   "name": "portworx-elastic",
-  "packagingVersion": "3.0",
+  "packagingVersion": "4.0",
   "postInstallNotes": "DC/OS elastic service is being installed!\n\n\tDocumentation: https://docs.portworx.com/scheduler/mesosphere-dcos/elasticsearch.html",
   "postUninstallNotes": "DC/OS elastic service is being uninstalled\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required.",
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: CPU: 4.5 | Memory: 11264MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM\n\nIngest node: 1 instance | 0.5 CPU | 2048 MB MEM\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM\n\nPortworx should be installed on the Private Agents to be able to provision volumes.\n\nCommunity packages are unverified and unreviewed content from the community.",
@@ -16,5 +16,5 @@
     "x-pack",
     "portworx"
   ],
-  "version": "1.0-5.5.1-c2ddff7"
+  "version": "1.1-5.5.1-bf399c5"
 }
--- 0/resource.json
+++ 1/resource.json
@@ -3,9 +3,9 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
-      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.0-5.5.1-c2ddff7/executor.zip",
-      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.0-5.5.1-c2ddff7/bootstrap.zip",
-      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.0-5.5.1-c2ddff7/elastic-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.1-5.5.1-bf399c5/executor.zip",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.1-5.5.1-bf399c5/bootstrap.zip",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.1-5.5.1-bf399c5/elastic-scheduler.zip",
       "statsd-plugin-zip": "https://github.com/mesosphere/elasticsearch-statsd-plugin/releases/download/5.5.1.0/elasticsearch-statsd-5.5.1.0.zip",
       "elasticsearch-jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
       "elasticsearch-tar-gz": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.1.tar.gz",
@@ -25,11 +25,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "5d970be53a25f53704af924882aa3b717f49e9d4d919bda81674de27c2040487"
+              "value": "f25ef4ac7166363d0173239df7d388352e49faea1ee191befb1965e55285f4c2"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.0-5.5.1-c2ddff7/dcos-elastic-darwin"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.1-5.5.1-bf399c5/dcos-portworx-elastic-darwin"
         }
       },
       "linux": {
@@ -37,11 +37,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "3460e89efae66f32da157c48683b11fc0db8c449640d38df47b421e84b6e429a"
+              "value": "11c78228fa2c16ee3fd5826a0665d21bd82df13416d36fad33fbcc4971c3799e"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.0-5.5.1-c2ddff7/dcos-elastic-linux"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.1-5.5.1-bf399c5/dcos-portworx-elastic-linux"
         }
       },
       "windows": {
@@ -49,11 +49,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "45d8c536ee9deef04c4c26f03084c1c9a8fa9411fc0d351a225cf12d8ae52ac8"
+              "value": "79c28a1619be8ce41afee9daabaa978d246028eae690860305f14f1da792c7e0"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.0-5.5.1-c2ddff7/dcos-elastic.exe"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-elastic/assets/1.1-5.5.1-bf399c5/dcos-portworx-elastic.exe"
         }
       }
     }
```