### PR TITLE
Update cadvisor to 0.27.2

### DIFF
--- a/repo/packages/C/cadvisor/1/config.json
+++ b/repo/packages/C/cadvisor/1/config.json
@@ -1,0 +1,66 @@
+{
+	"$schema": "http://json-schema.org/schema#",
+	"properties": {
+		"service": {
+			"type": "object",
+			"description": "DC/OS service configuration properties",
+			"properties": {
+				"name": {
+					"description": "Name of this service instance",
+					"type": "string",
+					"default": "cadvisor"
+				},
+				"instances": {
+					"description": "Number of service instances to run in the cluster. A single instance will be run per node in the cluster. Normally, this number should be equal or higher than the number of nodes in the cluster.",
+					"type": "number",
+					"default": 256,
+					"minimum": 1
+				},
+				"cpus": {
+					"description": "CPU shares to allocate to each service instance.",
+					"type": "number",
+					"default": 0.1,
+					"minimum": 0.1
+				},
+				"mem": {
+					"description":  "Memory to allocate to each service instance.",
+					"type": "number",
+					"default": 128.0,
+					"minimum": 128.0
+				}
+			}
+		},
+		"networking": {
+			"type": "object",
+			"description": "cadvisor networking configuration properties",
+			"properties": {
+    			"influxdb_host": {
+					"description":  "Hostname or IP address of the host running InfluxDB for metrics storage.",
+					"type": "string",
+					"default": "influxdb.marathon.l4lb.thisdcos.directory"
+				},
+    			"influxdb_port": {
+					"description":  "TCP port where the influxdb_host is listening.",
+					"type": "number",
+					"default": 8086
+				},
+				"external_access": {
+					"type": "object",
+					"description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+						"properties": {
+							"enable": {
+								"description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+								"type": "boolean",
+								"default": false
+							},
+							"external_access_port": {
+								"description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+								"type": "number",
+								"default": 18080
+							}
+						}
+				}
+			}
+		}
+	}
+}

--- a/repo/packages/C/cadvisor/1/marathon.json.mustache
+++ b/repo/packages/C/cadvisor/1/marathon.json.mustache
@@ -1,0 +1,89 @@
+{
+  "id": "{{service.name}}",
+  "cmd": "/usr/bin/cadvisor -storage_driver=influxdb -storage_driver_db=cadvisor -storage_driver_host={{networking.influxdb_host}}:{{networking.influxdb_port}}",
+  "args": null,
+  "user": null,
+  "env": null,
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "instances": {{service.instances}},
+  "constraints": [
+    [
+      "hostname",
+      "UNIQUE"
+    ]
+  ],
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.cadvisor-docker}}",
+      "forcePullImage": false,
+      "privileged": false,
+      "portMappings": [
+        {
+          "containerPort": 8080,
+          "name": "cadvisor",
+          {{#networking.external_access.enable}}
+          "servicePort": {{networking.external_access.external_access_port}},
+          {{/networking.external_access.enable}}
+          "protocol": "tcp"
+        }
+      ],
+      "network": "BRIDGE"
+    },
+    "volumes": [
+      {
+        "containerPath": "/rootfs",
+        "hostPath": "/",
+        "mode": "RO"
+      },
+      {
+        "containerPath": "/var/run",
+        "hostPath": "/var/run",
+        "mode": "RW"
+      },
+      {
+        "containerPath": "/sys",
+        "hostPath": "/sys",
+        "mode": "RO"
+      },
+      {
+        "containerPath": "/var/lib/docker",
+        "hostPath": "/var/lib/docker",
+        "mode": "RO"
+      }
+    ]
+  },
+  "portDefinitions": [
+    {
+      "port": 18080,
+      "protocol": "tcp",
+      "labels": {}
+    }
+  ],
+  "requirePorts": false,
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/",
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "acceptedResourceRoles": [
+    "*",
+    "slave_public"
+  ],
+  "labels": {
+    "DCOS_PACKAGE_VERSION": "0.3.0-0.27.2",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    {{#networking.external_access.enable}}
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_STICKY": "true",
+    {{/networking.external_access.enable}}
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  }
+}

--- a/repo/packages/C/cadvisor/1/marathon.json.mustache
+++ b/repo/packages/C/cadvisor/1/marathon.json.mustache
@@ -1,6 +1,6 @@
 {
   "id": "{{service.name}}",
-  "cmd": "/usr/bin/cadvisor -storage_driver=influxdb -storage_driver_db=cadvisor -storage_driver_host={{networking.influxdb_host}}:{{networking.influxdb_port}}",
+  "cmd": "/usr/bin/cadvisor --logtostderr=true -storage_driver=influxdb -storage_driver_db=cadvisor -storage_driver_host={{networking.influxdb_host}}:{{networking.influxdb_port}}",
   "args": null,
   "user": null,
   "env": null,

--- a/repo/packages/C/cadvisor/1/package.json
+++ b/repo/packages/C/cadvisor/1/package.json
@@ -1,0 +1,20 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.9",
+  "name": "cadvisor",
+  "version": "0.3.0-0.27.2",
+  "scm": "https://github.com/google/cadvisor",
+  "maintainer": "https://dcos.io/community",
+  "website": "https://github.com/google/cadvisor",
+  "description": "cAdvisor (Container Advisor) provides container users an understanding of the resource usage and performance characteristics of their running containers. It is a running daemon that collects, aggregates, processes, and exports information about running containers. Specifically, for each container it keeps resource isolation parameters, historical resource usage, histograms of complete historical resource usage and network statistics. This data is exported by container and machine-wide.\n\nNOTE: This package will install by default a single instance of cAdvisor in each host of your cluster.\n\nThis package is intended to be used alongside the DC/OS 'influxdb' and 'grafana' packages for a cluster-wide monitoring solution.\n\nInstallation Documentation: https://github.com/dcos/examples/tree/master/cadvisor-influxdb-grafana\n\n",
+  "tags": ["docker", "cadvisor", "monitoring", "metrics"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nAdvanced Installation options notes\n\nnetworking / external_access: create an entry in Marathon-LB for accessing the service from outside of the cluster. Please note that each access to this endpoint will connect you to a SINGLE instance of cAdvisor running in one of the nodes of your cluster.\n\nnetworking / external_access_port: port to be used in Marathon-LB for accessing the service.",
+ "postInstallNotes": "Service installed.",
+ "postUninstallNotes": "Service uninstalled.",
+  "licenses": [
+    {
+      "name": "Apache License",
+      "url": "https://raw.githubusercontent.com/google/cadvisor/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/cadvisor/1/resource.json
+++ b/repo/packages/C/cadvisor/1/resource.json
@@ -1,0 +1,17 @@
+{
+  "images": {
+    "icon-small": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-cadvisor-small.png",
+    "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-cadvisor-medium.png",
+    "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-cadvisor-large.png",
+  "screenshots": [
+     "https://3.bp.blogspot.com/-o9DqyR-EegY/VMbnOAJcETI/AAAAAAAAAy0/WxfIMxxrxk0/s1600/cAdvisorScreenshot.png"
+   ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "cadvisor-docker": "google/cadvisor:v0.27.2"
+      }
+    }
+  }
+}


### PR DESCRIPTION
* update `cadvisor` to latest stable release
* use `MESOS_HTTP` health checks by default
* switch to versioning `{dcos package version}-{cadvisor version}`
* minimal supported DC/OS version is 1.9 (I'm not sure about Mesos based health checks in earlier versions)

changes:
```
diff --git a/repo/packages/C/cadvisor/0/config.json b/repo/packages/C/cadvisor/1/config.json
index b63d350..641d88d 100644
--- a/repo/packages/C/cadvisor/0/config.json
+++ b/repo/packages/C/cadvisor/1/config.json
@@ -43,15 +43,15 @@
                                        "description":  "TCP port where the influxdb_host is listening.",
                                        "type": "number",
                                        "default": 8086
-                               },                              
+                               },
                                "external_access": {
                                        "type": "object",
                                        "description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
-                                               "properties": {    
+                                               "properties": {
                                                        "enable": {
                                                                "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB
.",
                                                                "type": "boolean",
-                                                               "default": false                    
+                                                               "default": false
                                                        },
                                                        "external_access_port": {
                                                                "description": "For external access, port number to be used for clear communication in the external Marathon-L
B load balancer",
@@ -59,9 +59,8 @@
                                                                "default": 18080
                                                        }
                                                }
-                                       
                                }
-                       }      
+                       }
                }
        }
 }
diff --git a/repo/packages/C/cadvisor/0/marathon.json.mustache b/repo/packages/C/cadvisor/1/marathon.json.mustache
index 1678a9e..ed8ac8e 100644
--- a/repo/packages/C/cadvisor/0/marathon.json.mustache
+++ b/repo/packages/C/cadvisor/1/marathon.json.mustache
@@ -18,12 +18,12 @@
     "docker": {
       "image": "{{resource.assets.container.docker.cadvisor-docker}}",
       "forcePullImage": false,
-      "privileged": false,      
+      "privileged": false,
       "portMappings": [
         {
           "containerPort": 8080,
           "name": "cadvisor",
-          {{#networking.external_access.enable}}          
+          {{#networking.external_access.enable}}
           "servicePort": {{networking.external_access.external_access_port}},
           {{/networking.external_access.enable}}
           "protocol": "tcp"
@@ -61,10 +61,10 @@
       "labels": {}
     }
   ],
-  "requirePorts": false,  
+  "requirePorts": false,
   "healthChecks": [
     {
-      "protocol": "HTTP",
+      "protocol": "MESOS_HTTP",
       "path": "/",
       "gracePeriodSeconds": 300,
       "intervalSeconds": 60,
@@ -78,7 +78,7 @@
     "slave_public"
   ],
   "labels": {
-    "DCOS_PACKAGE_VERSION": "0.24.1-0.1",
+    "DCOS_PACKAGE_VERSION": "0.3.0-0.27.2",
     "DCOS_SERVICE_NAME": "{{service.name}}",
     {{#networking.external_access.enable}}
     "HAPROXY_GROUP": "external",
diff --git a/repo/packages/C/cadvisor/0/package.json b/repo/packages/C/cadvisor/1/package.json
index e03abe4..f52f3c6 100644
--- a/repo/packages/C/cadvisor/0/package.json
+++ b/repo/packages/C/cadvisor/1/package.json
@@ -1,8 +1,8 @@
 {
   "packagingVersion": "3.0",
-  "minDcosReleaseVersion": "1.7",
+  "minDcosReleaseVersion": "1.9",
   "name": "cadvisor",
-  "version": "0.24.1-0.1",
+  "version": "0.3.0-0.27.2",
   "scm": "https://github.com/google/cadvisor",
   "maintainer": "https://dcos.io/community",
   "website": "https://github.com/google/cadvisor",
diff --git a/repo/packages/C/cadvisor/0/resource.json b/repo/packages/C/cadvisor/1/resource.json
index 30604c4..c187900 100644
--- a/repo/packages/C/cadvisor/0/resource.json
+++ b/repo/packages/C/cadvisor/1/resource.json
@@ -10,7 +10,7 @@
   "assets": {
     "container": {
       "docker": {
-        "cadvisor-docker": "google/cadvisor:v0.24.1"
+        "cadvisor-docker": "google/cadvisor:v0.27.2"
       }
     }
   }

```