### PR TITLE
Upgrade CP to 3.3.1

### DIFF
--- a/repo/packages/C/confluent-connect/9/config.json
+++ b/repo/packages/C/confluent-connect/9/config.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "connect": {
+      "properties": {
+        "name": {
+          "default": "connect",
+          "description": "Service name for the connect worker application(s)",
+          "type": "string"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 2,
+          "description": "CPU shares to allocate to each connect worker instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 1024,
+          "description": "Memory (MB) to allocate to each connect worker instance.",
+          "minimum": 512,
+          "type": "number"
+        },
+        "heap": {
+          "default": 768,
+          "description": "JVM heap allocation (in MB) for connect worker task; should be ~256MB less than total memory for the instance.",
+          "minimum": 256,
+          "type": "number"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy connect worker only on nodes with this role.",
+          "type": "string"
+        },
+        "kafka-service": {
+          "default": "confluent-kafka",
+          "description": "Target Apache Kafka by Confluent service to which these tasks will connect. ",
+          "type": "string"
+        },
+        "zookeeper-connect": {
+          "default": "master.mesos:2181/dcos-service-confluent-kafka",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        },
+        "schema-registry-service": {
+          "default": "schema-registry",
+          "description": "Schema Registry service to be used by connect workers. The named VIP associated with this service will be used to specify the converter-schema-registry-url's",
+
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-connect/9/marathon.json.mustache
+++ b/repo/packages/C/confluent-connect/9/marathon.json.mustache
@@ -1,0 +1,69 @@
+{
+  "id": "/{{connect.name}}",
+  "instances": {{connect.instances}},
+  "cpus": {{connect.cpus}},
+  "mem": {{connect.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.image}}",
+	  "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [ {
+          "containerPort": 8083,
+          "hostPort": 0,
+          "protocol": "tcp",
+          "labels": {
+            "VIP_0": "{{connect.name}}:8083"
+          }
+      } ]
+    }
+  },
+  "portDefinitions": [ {
+    "name": "{{connect.name}}",
+    "port": 8083,
+    "protocol": "tcp",
+    "labels": {
+      "VIP_0": "{{connect.name}}:8083"
+    }
+  } ],
+  "env": {
+    "CONNECT_BOOTSTRAP_SERVERS": "broker.{{connect.kafka-service}}.l4lb.thisdcos.directory:9092",
+    "CONNECT_REST_PORT": "8083",
+    "CONNECT_GROUP_ID": "dcos-{{connect.name}}-group",
+    "CONNECT_CONFIG_STORAGE_TOPIC": "dcos-{{connect.name}}-configs",
+    "CONNECT_OFFSET_STORAGE_TOPIC": "dcos-{{connect.name}}-offsets",
+    "CONNECT_STATUS_STORAGE_TOPIC": "dcos-{{connect.name}}-status",
+	"CONNECT_KEY_CONVERTER" : "io.confluent.connect.avro.AvroConverter",
+    "CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL": "http://{{connect.schema-registry-service}}.marathon.l4lb.thisdcos.directory:8081",
+	"CONNECT_VALUE_CONVERTER" : "io.confluent.connect.avro.AvroConverter",
+    "CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL": "http://{{connect.schema-registry-service}}.marathon.l4lb.thisdcos.directory:8081",
+	"CONNECT_INTERNAL_KEY_CONVERTER" : "org.apache.kafka.connect.json.JsonConverter",
+	"CONNECT_INTERNAL_VALUE_CONVERTER" : "org.apache.kafka.connect.json.JsonConverter",
+    "CONNECT_PRODUCER_INTERCEPTOR_CLASSES" : "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor",
+    "CONNECT_CONSUMER_INTERCEPTOR_CLASSES" : "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor",
+    "CONNECT_ZOOKEEPER_CONNECT": "{{connect.zookeeper-connect}}",
+    "KAFKA_HEAP_OPTS": "-Xmx{{connect.heap}}M"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{connect.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{connect.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-connect/9/package.json
+++ b/repo/packages/C/confluent-connect/9/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "confluent-connect",
+  "version": "1.0.0-3.3.1",
+  "scm": "https://github.com/confluentinc/kafka",
+  "description": "Confluent Connect worker\n\n\tDocumentation: http://docs.confluent.io/3.3.1/connect/managing.html",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "connect"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. Preparing to install confluent-connect",
+  "postInstallNotes": "confluent-connect has been installed.",
+  "postUninstallNotes": "confluent-connect was uninstalled successfully.",
+  "minDcosReleaseVersion" : "1.8",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-connect/9/resource.json
+++ b/repo/packages/C/confluent-connect/9/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "image": "confluentinc/cp-kafka-connect:3.3.1"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}

--- a/repo/packages/C/confluent-control-center/10/config.json
+++ b/repo/packages/C/confluent-control-center/10/config.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "control-center": {
+      "properties": {
+        "name": {
+          "default": "control-center",
+          "description": "Name for this control-center application",
+          "type": "string"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 2,
+          "description": "CPU shares to allocate to each control-center instance.",
+          "minimum": 2,
+          "type": "number"
+        },
+        "mem": {
+          "default": 4096,
+          "description": "Memory (MB) to allocate to each control-center task.",
+          "minimum": 4096,
+          "type": "number"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy control-center only on nodes with this role.",
+          "type": "string"
+        },
+        "kafka-service": {
+          "default": "confluent-kafka",
+          "description": "Target Apache Kafka by Confluent service to which these tasks will connect. ",
+          "type": "string"
+        },
+        "connect-service": {
+          "default": "connect",
+          "description": "Service name of Kafka Connect Workers to which this instance will deploy connectors.",
+          "type": "string"
+        },
+        "confluent-controlcenter-internal-topics-partitions": {
+          "default": 3,
+          "description": "Parition count for internal control-center kafka topics",
+          "type": "number"
+        },
+        "confluent-controlcenter-internal-topics-replication": {
+          "default": 2,
+          "description": "Replication factor for internal control-center kafka topics",
+          "type": "number"
+        },
+        "confluent-monitoring-interceptor-topic-partitions": {
+          "default": 3,
+          "description": "Parition count for kafka topics used to store data from the interceptor classes",
+          "type": "number"
+        },
+        "confluent-monitoring-interceptor-topic-replication": {
+          "default": 2,
+          "description": "Replication factor for kafka topics used to store data from the interceptor classes",
+          "type": "number"
+        },
+        "confluent-license": {
+          "default": "",
+          "description": "License key for Confluent Enterprise (default is 30-day trial)",
+          "type": "string"
+        },
+        "zookeeper-connect": {
+          "default": "master.mesos:2181/dcos-service-confluent-kafka",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-control-center/10/marathon.json.mustache
+++ b/repo/packages/C/confluent-control-center/10/marathon.json.mustache
@@ -1,0 +1,49 @@
+{
+  "id": "/{{control-center.name}}",
+  "instances": {{control-center.instances}},
+  "cpus": {{control-center.cpus}},
+  "mem": {{control-center.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.image}}",
+	  "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [ {
+          "containerPort": 9021,
+          "hostPort": 0,
+          "protocol": "tcp"
+      } ]
+    }
+  },
+  "env": {
+    "CONTROL_CENTER_BOOTSTRAP_SERVERS": "broker.{{control-center.kafka-service}}.l4lb.thisdcos.directory:9092",
+    "CONTROL_CENTER_CONNECT_CLUSTER": "{{control-center.connect-service}}.marathon.l4lb.thisdcos.directory:8083",
+    "CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS": "{{control-center.confluent-controlcenter-internal-topics-partitions}}",
+    "CONTROL-CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS": "{{control-center.confluent-monitoring-interceptor-topic-partitions}}",
+    "CONTROL_CENTER_REPLICATION_FACTOR": "{{control-center.confluent-controlcenter-internal-topics-replication}}",
+    "CONTROL_CENTER_LICENSE": "{{control-center.confluent-license}}",
+    "CONTROL_CENTER_ZOOKEEPER_CONNECT": "{{control-center.zookeeper-connect}}"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 3600,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 10,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{control-center.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{control-center.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-control-center/10/package.json
+++ b/repo/packages/C/confluent-control-center/10/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "confluent-control-center",
+  "version": "1.0.0-3.3.1",
+  "scm": "https://github.com/confluentinc/control-center",
+  "description": "Confluent Control Center service\n\n\tDocumentation: http://docs.confluent.io/3.3.1/control-center/docs/userguide.html\n\tDC/OS Specifics: https://www.confluent.io/whitepaper/deploying-confluent-platform-with-mesosphere",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "control", "center"],
+  "preInstallNotes": "Preparing to install confluent-control-center",
+  "postInstallNotes": "confluent-control-center has been installed.",
+  "postUninstallNotes": "confluent-control-center was uninstalled successfully.",
+  "minDcosReleaseVersion" : "1.8",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/control-center/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-control-center/10/resource.json
+++ b/repo/packages/C/confluent-control-center/10/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "image": "confluentinc/cp-enterprise-control-center:3.3.1"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}

--- a/repo/packages/C/confluent-replicator/6/config.json
+++ b/repo/packages/C/confluent-replicator/6/config.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "connect": {
+      "properties": {
+        "name": {
+          "default": "replicator",
+          "description": "Service name for the Confluent Enterprise Replicator",
+          "type": "string"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 2,
+          "description": "CPU shares to allocate to each connect worker instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 1024,
+          "description": "Memory (MB) to allocate to each connect worker instance.",
+          "minimum": 512,
+          "type": "number"
+        },
+        "heap": {
+          "default": 768,
+          "description": "JVM heap allocation (in MB) for connect worker task; should be ~256MB less than total memory for the instance.",
+          "minimum": 256,
+          "type": "number"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy connect worker only on nodes with this role.",
+          "type": "string"
+        },
+        "kafka-service": {
+          "default": "confluent-kafka",
+          "description": "Target Apache Kafka by Confluent service to which these tasks will connect. ",
+          "type": "string"
+        },
+        "zookeeper-connect": {
+          "default": "master.mesos:2181/dcos-service-confluent-kafka",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        },
+        "schema-registry-service": {
+          "default": "schema-registry",
+          "description": "Schema Registry service to be used by connect workers. The named VIP associated with this service will be used to specify the converter-schema-registry-url's",
+
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-replicator/6/marathon.json.mustache
+++ b/repo/packages/C/confluent-replicator/6/marathon.json.mustache
@@ -1,0 +1,67 @@
+{
+  "id": "/{{connect.name}}",
+  "instances": {{connect.instances}},
+  "cpus": {{connect.cpus}},
+  "mem": {{connect.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.image}}",
+	  "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [ {
+          "containerPort": 8083,
+          "hostPort": 0,
+          "protocol": "tcp",
+          "labels": {
+            "VIP_0": "{{connect.name}}:8083"
+          }
+      } ]
+    }
+  },
+  "portDefinitions": [ {
+    "name": "{{connect.name}}",
+    "port": 8083,
+    "protocol": "tcp",
+    "labels": {
+      "VIP_0": "{{connect.name}}:8083"
+    }
+  } ],
+  "env": {
+    "CONNECT_BOOTSTRAP_SERVERS": "broker.{{connect.kafka-service}}.l4lb.thisdcos.directory:9092",
+    "CONNECT_REST_PORT": "8083",
+    "CONNECT_GROUP_ID": "dcos-{{connect.name}}-group",
+    "CONNECT_CONFIG_STORAGE_TOPIC": "dcos-{{connect.name}}-configs",
+    "CONNECT_OFFSET_STORAGE_TOPIC": "dcos-{{connect.name}}-offsets",
+    "CONNECT_STATUS_STORAGE_TOPIC": "dcos-{{connect.name}}-status",
+	"CONNECT_KEY_CONVERTER" : "io.confluent.connect.replicator.util.ByteArrayConverter",
+	"CONNECT_VALUE_CONVERTER" : "io.confluent.connect.replicator.util.ByteArrayConverter",
+	"CONNECT_INTERNAL_KEY_CONVERTER" : "org.apache.kafka.connect.json.JsonConverter",
+	"CONNECT_INTERNAL_VALUE_CONVERTER" : "org.apache.kafka.connect.json.JsonConverter",
+    "CONNECT_PRODUCER_INTERCEPTOR_CLASSES" : "io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor",
+    "CONNECT_CONSUMER_INTERCEPTOR_CLASSES" : "io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor",
+    "CONNECT_ZOOKEEPER_CONNECT": "{{connect.zookeeper-connect}}",
+    "KAFKA_HEAP_OPTS": "-Xmx{{connect.heap}}M"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{connect.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{connect.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-replicator/6/package.json
+++ b/repo/packages/C/confluent-replicator/6/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "confluent-replicator",
+  "version": "1.0.0-3.3.1",
+  "scm": "https://github.com/confluentinc/kafka",
+  "description": "Confluent Enterprise Replicator for multi-data center synchronization of topic data\n\n\tDocumentation: http://docs.confluent.io/3.3.1/connect/connect-replicator/docs/index.html",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "connect", "replicator"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. Preparing to install Replicator service",
+  "postInstallNotes": "Replicator service has been installed.",
+  "postUninstallNotes": "Replicator service was uninstalled successfully.",
+  "minDcosReleaseVersion" : "1.8",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-replicator/6/resource.json
+++ b/repo/packages/C/confluent-replicator/6/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "image": "confluentinc/cp-enterprise-replicator:3.3.1"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}

--- a/repo/packages/C/confluent-rest-proxy/9/config.json
+++ b/repo/packages/C/confluent-rest-proxy/9/config.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "proxy": {
+      "properties": {
+        "name": {
+          "default": "rest-proxy",
+          "description": "Service name for the rest-proxy instance(s)",
+          "type": "string"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 2,
+          "description": "CPU shares to allocate to each rest-proxy instance.",
+          "minimum": 2,
+          "type": "number"
+        },
+        "mem": {
+          "default": 1024,
+          "description": "Memory (MB) to allocate to each rest-proxy instance.",
+          "minimum": 512,
+          "type": "number"
+        },
+        "heap": {
+          "default": 768,
+          "description": "JVM heap allocation (in MB) for rest-proxy task; should be ~256MB less than total memory for the instance.",
+          "minimum": 256,
+          "type": "number"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy rest-proxy only on nodes with this role.",
+          "type": "string"
+        },
+        "kafka-service": {
+          "default": "confluent-kafka",
+          "description": "Target Apache Kafka by Confluent service to which these tasks will connect. ",
+          "type": "string"
+        },
+        "zookeeper-connect": {
+          "default": "master.mesos:2181/dcos-service-confluent-kafka",
+          "description": "Zookeeper Connect string for service cluster. Format is comma-separated list of <zk-host>:<zkport>/<kservice>",
+          "type": "string"
+        },
+        "schema-registry-service": {
+          "default": "schema-registry",
+          "description": "Schema Registry service to be used by REST Proxy workers. The named VIP associated with this service will be used to specify the converter-schema-registry-url's",
+
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-rest-proxy/9/config.json
+++ b/repo/packages/C/confluent-rest-proxy/9/config.json
@@ -50,7 +50,16 @@
         "schema-registry-service": {
           "default": "schema-registry",
           "description": "Schema Registry service to be used by REST Proxy workers. The named VIP associated with this service will be used to specify the converter-schema-registry-url's",
-
+          "type": "string"
+        },
+        "access-control-allow-methods": {
+          "default": "",
+          "description": "Set value to Jetty Access-Control-Allow-Origin header for specified methods",
+          "type": "string"
+        },
+        "access-control-allow-origin": {
+          "default": "",
+          "description": "Set value for Jetty Access-Control-Allow-Origin header",
           "type": "string"
         }
       },

--- a/repo/packages/C/confluent-rest-proxy/9/marathon.json.mustache
+++ b/repo/packages/C/confluent-rest-proxy/9/marathon.json.mustache
@@ -1,0 +1,57 @@
+{
+  "id": "/{{proxy.name}}",
+  "instances": {{proxy.instances}},
+  "cpus": {{proxy.cpus}},
+  "mem": {{proxy.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.image}}",
+	  "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [ {
+          "containerPort": 8082,
+          "hostPort": 0,
+          "protocol": "tcp",
+          "labels": {
+            "VIP_0": "{{proxy.name}}:8082"
+          }
+      } ]
+    }
+  },
+  "portDefinitions": [ {
+      "name": "{{proxy.name}}",
+      "port": 8082,
+      "protocol": "tcp",
+      "labels": {
+        "VIP_0": "{{proxy.name}}:8082"
+      }
+  } ],
+  "env": {
+    "KAFKAREST_HEAP_OPTS": "-Xmx{{proxy.heap}}M",
+    "KAFKA_REST_BOOTSTRAP_SERVERS": "broker.{{proxy.kafka-service}}.l4lb.thisdcos.directory:9092",
+    "KAFKA_REST_ZOOKEEPER_CONNECT": "{{proxy.zookeeper-connect}}",
+    "KAFKA_REST_SCHEMA_REGISTRY_URL": "http://{{proxy.schema-registry-service}}.marathon.l4lb.thisdcos.directory:8081"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+	  "ignoreHttp1xx": false
+	}
+  ],
+  "acceptedResourceRoles": [
+    "{{proxy.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{proxy.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-rest-proxy/9/marathon.json.mustache
+++ b/repo/packages/C/confluent-rest-proxy/9/marathon.json.mustache
@@ -32,7 +32,9 @@
     "KAFKAREST_HEAP_OPTS": "-Xmx{{proxy.heap}}M",
     "KAFKA_REST_BOOTSTRAP_SERVERS": "broker.{{proxy.kafka-service}}.l4lb.thisdcos.directory:9092",
     "KAFKA_REST_ZOOKEEPER_CONNECT": "{{proxy.zookeeper-connect}}",
-    "KAFKA_REST_SCHEMA_REGISTRY_URL": "http://{{proxy.schema-registry-service}}.marathon.l4lb.thisdcos.directory:8081"
+    "KAFKA_REST_SCHEMA_REGISTRY_URL": "http://{{proxy.schema-registry-service}}.marathon.l4lb.thisdcos.directory:8081",
+    "KAFKA_REST_ACCESS_CONTROL_ALLOW_METHODS": "{{proxy.access-control-allow-methods}}",
+    "KAFKA_REST_ACCESS_CONTROL_ALLOW_ORIGIN": "{{proxy.access-control-allow-origin}}"
   },
   "healthChecks": [
     {

--- a/repo/packages/C/confluent-rest-proxy/9/package.json
+++ b/repo/packages/C/confluent-rest-proxy/9/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "confluent-rest-proxy",
+  "version": "1.0.0-3.3.1",
+  "scm": "https://github.com/confluentinc/kafka-rest",
+  "description": "Confluent REST Proxy service\n\n\tDocumentation: http://docs.confluent.io/3.3.1/kafka-rest/docs/api.html",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "proxy", "rest"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. Preparing to install confluent-rest-proxy",
+  "postInstallNotes": "confluent-rest-proxy has been installed.",
+  "postUninstallNotes": "confluent-rest-proxy was uninstalled successfully.",
+  "minDcosReleaseVersion" : "1.8",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/kafka-rest/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-rest-proxy/9/resource.json
+++ b/repo/packages/C/confluent-rest-proxy/9/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "image": "confluentinc/cp-kafka-rest:3.3.1"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}

--- a/repo/packages/C/confluent-schema-registry/10/config.json
+++ b/repo/packages/C/confluent-schema-registry/10/config.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "registry": {
+      "properties": {
+        "name": {
+          "default": "schema-registry",
+          "description": "Service name for the schema-registry instance(s)",
+          "type": "string"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run (currently limited to 1).",
+          "minimum": 1,
+          "maximum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each schema-registry instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 512,
+          "description": "Memory (MB) to allocate to each schema-registry instance.",
+          "minimum": 320,
+          "type": "number"
+        },
+        "heap": {
+          "default": 256,
+          "description": "JVM heap allocation (in MB) for connect worker task; should be no greater than ~64MB less than total memory for the instance.",
+          "minimum": 256,
+          "type": "number"
+        },
+        "role": {
+          "default": "*",
+          "description": "Deploy schema-registry only on nodes with this role.",
+          "type": "string"
+        },
+        "zookeeper-master": {
+          "default": "master.mesos:2181",
+          "description": "Zookeeper Connect string for service cluster. Format limited to single target: <zk-host>:<zkport>",
+          "type": "string"
+        },
+        "kafkastore": {
+          "default": "dcos-service-confluent-kafka",
+          "description": "Name of the Kafka service hosting the storage for this Schema Registry edition.",
+          "type": "string"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/C/confluent-schema-registry/10/config.json
+++ b/repo/packages/C/confluent-schema-registry/10/config.json
@@ -47,6 +47,16 @@
           "default": "dcos-service-confluent-kafka",
           "description": "Name of the Kafka service hosting the storage for this Schema Registry edition.",
           "type": "string"
+        },
+        "access-control-allow-methods": {
+          "default": "",
+          "description": "Set value to Jetty Access-Control-Allow-Origin header for specified methods",
+          "type": "string"
+        },
+        "access-control-allow-origin": {
+          "default": "",
+          "description": "Set value for Jetty Access-Control-Allow-Origin header",
+          "type": "string"
         }
       },
       "required": ["cpus", "mem", "instances", "name"],

--- a/repo/packages/C/confluent-schema-registry/10/marathon.json.mustache
+++ b/repo/packages/C/confluent-schema-registry/10/marathon.json.mustache
@@ -1,0 +1,56 @@
+{
+  "id": "/{{registry.name}}",
+  "instances": {{registry.instances}},
+  "cpus": {{registry.cpus}},
+  "mem": {{registry.mem}},
+  "maintainer": "partner-support@confluent.io", 
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.image}}",
+      "forcePullImage": true,
+      "network": "BRIDGE",    
+      "portMappings": [ {
+          "containerPort": 8081,
+          "hostPort": 0,
+          "protocol": "tcp",
+          "labels": {
+            "VIP_0": "{{registry.name}}:8081"
+          }
+      } ]
+    }
+  },
+  "portDefinitions": [ {
+    "name": "{{registry.name}}",
+    "port": 8081,
+    "protocol": "tcp",
+    "labels": {
+      "VIP_0": "{{registry.name}}:8081"
+    }
+  } ],
+  "env": {
+    "SCHEMA_REGISTRY_HEAP_OPTS": "-Xmx{{registry.heap}}M",
+    "SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL": "{{registry.zookeeper-master}}/{{registry.kafkastore}}",
+    "SCHEMA_REGISTRY_SCHEMA_REGISTRY_ZK_NAMESPACE": "{{registry.kafkastore}}/{{registry.name}}"
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "acceptedResourceRoles": [
+    "{{registry.role}}"
+  ],
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{registry.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/C/confluent-schema-registry/10/marathon.json.mustache
+++ b/repo/packages/C/confluent-schema-registry/10/marathon.json.mustache
@@ -31,7 +31,9 @@
   "env": {
     "SCHEMA_REGISTRY_HEAP_OPTS": "-Xmx{{registry.heap}}M",
     "SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL": "{{registry.zookeeper-master}}/{{registry.kafkastore}}",
-    "SCHEMA_REGISTRY_SCHEMA_REGISTRY_ZK_NAMESPACE": "{{registry.kafkastore}}/{{registry.name}}"
+    "SCHEMA_REGISTRY_SCHEMA_REGISTRY_ZK_NAMESPACE": "{{registry.kafkastore}}/{{registry.name}}",
+    "SCHEMA_REGISTRY_ACCESS_CONTROL_ALLOW_METHODS": "{{registry.access-control-allow-methods}}",
+    "SCHEMA_REGISTRY_ACCESS_CONTROL_ALLOW_ORIGIN": "{{registry.access-control-allow-origin}}"
   },
   "healthChecks": [
     {

--- a/repo/packages/C/confluent-schema-registry/10/package.json
+++ b/repo/packages/C/confluent-schema-registry/10/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "3.0",
+  "name": "confluent-schema-registry",
+  "version": "1.0.0-3.3.1",
+  "scm": "https://github.com/confluentinc/schema-registry",
+  "description": "Confluent Schema Registry service\n\n\tDocumentation: http://docs.confluent.io/3.3.1/schema-registry/docs/intro.html",
+  "maintainer": "partner-support@confluent.io",
+  "tags": ["kafka", "confluent", "schema", "registry"],
+  "preInstallNotes": "Preparing to install confluent-schema-registry",
+  "postInstallNotes": "confluent-schema-registry has been installed.",
+  "postUninstallNotes": "confluent-schema-registry was uninstalled successfully.",
+  "minDcosReleaseVersion" : "1.8",
+  "licenses": [
+    {
+      "name": "Apache License v2",
+      "url": "https://raw.githubusercontent.com/confluentinc/schema-registry/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/C/confluent-schema-registry/10/resource.json
+++ b/repo/packages/C/confluent-schema-registry/10/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "image": "confluentinc/cp-schema-registry:3.3.1"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_small.png",
+    "icon-medium": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_medium.png",
+    "icon-large": "https://s3-us-west-2.amazonaws.com/confluent-mesos-devel/ConfIcon_large.png"
+  }
+}


### PR DESCRIPTION
```
confluent-connect
--------------------------------------------------------------------------------
Only in repo/packages/C/confluent-connect/9: .package.json.swp
diff repo/packages/C/confluent-connect/8/package.json repo/packages/C/confluent-connect/9/package.json
4c4
<   "version": "1.0.0-3.3.0",
---
>   "version": "1.0.0-3.3.1",
6c6
<   "description": "Confluent Connect worker\n\n\tDocumentation: http://docs.confluent.io/3.3.0/connect/managing.html",
---
>   "description": "Confluent Connect worker\n\n\tDocumentation: http://docs.confluent.io/3.3.1/connect/managing.html",
diff repo/packages/C/confluent-connect/8/resource.json repo/packages/C/confluent-connect/9/resource.json
5c5
<         "image": "confluentinc/cp-kafka-connect:3.3.0"
---
>         "image": "confluentinc/cp-kafka-connect:3.3.1"

confluent-control-center
--------------------------------------------------------------------------------
diff repo/packages/C/confluent-control-center/9/package.json repo/packages/C/confluent-control-center/10/package.json
4c4
<   "version": "1.0.0-3.3.0",
---
>   "version": "1.0.0-3.3.1",
6c6
<   "description": "Confluent Control Center service\n\n\tDocumentation: http://docs.confluent.io/3.3.0/control-center/docs/userguide.html\n\tDC/OS Specifics: https://www.confluent.io/whitepaper/deploying-confluent-platform-with-mesosphere",
---
>   "description": "Confluent Control Center service\n\n\tDocumentation: http://docs.confluent.io/3.3.1/control-center/docs/userguide.html\n\tDC/OS Specifics: https://www.confluent.io/whitepaper/deploying-confluent-platform-with-mesosphere",
diff repo/packages/C/confluent-control-center/9/resource.json repo/packages/C/confluent-control-center/10/resource.json
5c5
<         "image": "confluentinc/cp-enterprise-control-center:3.3.0"
---
>         "image": "confluentinc/cp-enterprise-control-center:3.3.1"

confluent-replicator
--------------------------------------------------------------------------------
diff repo/packages/C/confluent-replicator/5/package.json repo/packages/C/confluent-replicator/6/package.json
4c4
<   "version": "1.0.0-3.3.0",
---
>   "version": "1.0.0-3.3.1",
6c6
<   "description": "Confluent Enterprise Replicator for multi-data center synchronization of topic data\n\n\tDocumentation: http://docs.confluent.io/3.3.0/connect/connect-replicator/docs/index.html",
---
>   "description": "Confluent Enterprise Replicator for multi-data center synchronization of topic data\n\n\tDocumentation: http://docs.confluent.io/3.3.1/connect/connect-replicator/docs/index.html",
diff repo/packages/C/confluent-replicator/5/resource.json repo/packages/C/confluent-replicator/6/resource.json
5c5
<         "image": "confluentinc/cp-enterprise-replicator:3.3.0"
---
>         "image": "confluentinc/cp-enterprise-replicator:3.3.1"

confluent-rest-proxy
--------------------------------------------------------------------------------
diff repo/packages/C/confluent-rest-proxy/8/config.json repo/packages/C/confluent-rest-proxy/9/config.json
53c53,62
< 
---
>           "type": "string"
>         },
>         "access-control-allow-methods": {
>           "default": "",
>           "description": "Set value to Jetty Access-Control-Allow-Origin header for specified methods",
>           "type": "string"
>         },
>         "access-control-allow-origin": {
>           "default": "",
>           "description": "Set value for Jetty Access-Control-Allow-Origin header",
diff repo/packages/C/confluent-rest-proxy/8/marathon.json.mustache repo/packages/C/confluent-rest-proxy/9/marathon.json.mustache
35c35,37
<     "KAFKA_REST_SCHEMA_REGISTRY_URL": "http://{{proxy.schema-registry-service}}.marathon.l4lb.thisdcos.directory:8081"
---
>     "KAFKA_REST_SCHEMA_REGISTRY_URL": "http://{{proxy.schema-registry-service}}.marathon.l4lb.thisdcos.directory:8081",
>     "KAFKA_REST_ACCESS_CONTROL_ALLOW_METHODS": "{{proxy.access-control-allow-methods}}",
>     "KAFKA_REST_ACCESS_CONTROL_ALLOW_ORIGIN": "{{proxy.access-control-allow-origin}}"
diff repo/packages/C/confluent-rest-proxy/8/package.json repo/packages/C/confluent-rest-proxy/9/package.json
4c4
<   "version": "1.0.0-3.3.0",
---
>   "version": "1.0.0-3.3.1",
6c6
<   "description": "Confluent REST Proxy service\n\n\tDocumentation: http://docs.confluent.io/3.3.0/kafka-rest/docs/api.html",
---
>   "description": "Confluent REST Proxy service\n\n\tDocumentation: http://docs.confluent.io/3.3.1/kafka-rest/docs/api.html",
diff repo/packages/C/confluent-rest-proxy/8/resource.json repo/packages/C/confluent-rest-proxy/9/resource.json
5c5
<         "image": "confluentinc/cp-kafka-rest:3.3.0"
---
>         "image": "confluentinc/cp-kafka-rest:3.3.1"

confluent-schema-registry
--------------------------------------------------------------------------------
diff repo/packages/C/confluent-schema-registry/9/config.json repo/packages/C/confluent-schema-registry/10/config.json
49a50,59
>         },
>         "access-control-allow-methods": {
>           "default": "",
>           "description": "Set value to Jetty Access-Control-Allow-Origin header for specified methods",
>           "type": "string"
>         },
>         "access-control-allow-origin": {
>           "default": "",
>           "description": "Set value for Jetty Access-Control-Allow-Origin header",
>           "type": "string"
diff repo/packages/C/confluent-schema-registry/9/marathon.json.mustache repo/packages/C/confluent-schema-registry/10/marathon.json.mustache
34c34,36
<     "SCHEMA_REGISTRY_SCHEMA_REGISTRY_ZK_NAMESPACE": "{{registry.kafkastore}}/{{registry.name}}"
---
>     "SCHEMA_REGISTRY_SCHEMA_REGISTRY_ZK_NAMESPACE": "{{registry.kafkastore}}/{{registry.name}}",
>     "SCHEMA_REGISTRY_ACCESS_CONTROL_ALLOW_METHODS": "{{registry.access-control-allow-methods}}",
>     "SCHEMA_REGISTRY_ACCESS_CONTROL_ALLOW_ORIGIN": "{{registry.access-control-allow-origin}}"
diff repo/packages/C/confluent-schema-registry/9/package.json repo/packages/C/confluent-schema-registry/10/package.json
4c4
<   "version": "1.0.0-3.3.0",
---
>   "version": "1.0.0-3.3.1",
6c6
<   "description": "Confluent Schema Registry service\n\n\tDocumentation: http://docs.confluent.io/3.3.0/schema-registry/docs/intro.html",
---
>   "description": "Confluent Schema Registry service\n\n\tDocumentation: http://docs.confluent.io/3.3.1/schema-registry/docs/intro.html",
diff repo/packages/C/confluent-schema-registry/9/resource.json repo/packages/C/confluent-schema-registry/10/resource.json
5c5
<         "image": "confluentinc/cp-schema-registry:3.3.0"
---
>         "image": "confluentinc/cp-schema-registry:3.3.1"

```