### PR TITLE
Bump to 1.4

### DIFF
--- a/repo/packages/I/influxdb/1/config.json
+++ b/repo/packages/I/influxdb/1/config.json
@@ -1,0 +1,112 @@
+{
+	"$schema": "http://json-schema.org/schema#",
+	"properties": {
+		"service": {
+			"type": "object",
+			"description": "DC/OS service configuration properties",
+			"properties": {
+				"name": {
+					"description": "Name of this service instance",
+					"type": "string",
+					"default": "influxdb"
+				},
+				"cpus": {
+					"description": "CPU shares to allocate to each service instance.",
+					"type": "number",
+					"default": 1,
+					"minimum": 1
+				},
+				"mem": {
+					"description":  "Memory to allocate to each service instance.",
+					"type": "number",
+					"default": 2048.0,
+					"minimum": 1024.0
+				}
+			},
+			"required": [
+				"cpus",
+				"mem"
+			]
+		},
+		"storage": {
+			"type": "object",
+			"description": "influxdb storage configuration properties",
+			"properties":{
+				"host_volume_influxdb": {
+					"description": "If using non-persistent volumes (local volumes), this sets the location of a volume on the host to be used for the influxdb service to store the contents of the influxdb. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/service_name`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents. NOTE: if you don't change the default /tmp value, YOUR DATA WILL NOT BE SAVED IN ANY WAY.",
+					"type": "string",
+					"default": "/tmp"
+				},     
+				"persistence": {
+					"type": "object",
+					"description": "Enable persistent storage.",
+					"properties": {    
+						"enable": {
+							"description": "Enable or disable persistent storage.",
+							"type": "boolean",
+							"default": false                    
+						},
+						"volume_mode_influxdb": {
+							"description": "Choose your mode: RW, R -> default RW.",
+							"type": "string",
+							"default": "RW"
+						}
+					}
+				}
+			}
+		},
+		"networking": {
+			"type": "object",
+			"description": "influxdb networking configuration properties",
+			"properties": {
+				"port_api": {
+					"description": "Port number to be used for api communication internally to the cluster.",
+					"type": "number",
+					"default": 8086
+				},
+				"external_access": {
+					"type": "object",
+					"description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+					"properties": {
+						"enable": {
+							"description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+							"type": "boolean",
+							"default": false
+						},
+						"external_public_agent_ip": {
+							"description": "For external access, dns to be used for Marathon-LB vHost: For example use your public slave elb dns.",
+							"type": "string",
+							"default": ""
+						},
+						"external_access_port": {
+							"description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+							"type": "number",
+							"default": 18086
+						}
+					}
+				}
+			}
+		},
+		"configuration": {
+			"type": "object",
+			"description": "influxdb networking configuration properties",
+			"properties": {
+				"INFLUXDB_RETENTION_ENABLED": {
+					"description": "Set to false to prevent InfluxDB from enforcing retention policies.",
+					"type": "boolean",
+					"default": true
+				},
+				"INFLUXDB_RETENTION_CHECK_INTERVAL": {
+					"description": "The rate at which InfluxDB checks to enforce a retention policy.",
+					"type": "string",
+					"default": "30m0s"
+				},
+				"INFLUXDB_MONITOR_STORE_DATABASE": {
+					"description": "The destination database for recorded statistics.",
+					"type": "string",
+					"default": "_internal"
+				}
+			}
+		}
+	}
+}

--- a/repo/packages/I/influxdb/1/marathon.json.mustache
+++ b/repo/packages/I/influxdb/1/marathon.json.mustache
@@ -1,0 +1,66 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "instances": 1,
+  "env": {  
+    "INFLUXDB_RETENTION_ENABLED": "{{configuration.INFLUXDB_RETENTION_ENABLED}}",
+    "INFLUXDB_RETENTION_CHECK_INTERVAL": "{{configuration.INFLUXDB_RETENTION_CHECK_INTERVAL}}",
+    "INFLUXDB_MONITOR_STORE_DATABASE": "{{configuration.INFLUXDB_MONITOR_STORE_DATABASE}}"
+  },
+  "container": {
+    "type": "DOCKER",
+    {{#storage.persistence.enable}}
+    "volumes": [{
+      "containerPath": "/var/lib/influxdb",
+      "hostPath": "{{storage.host_volume_influxdb}}/{{service.name}}",
+      "mode": "{{storage.persistence.volume_mode_influxdb}}"
+      }
+    ],
+    {{/storage.persistence.enable}}
+    "docker": {
+      "image": "{{resource.assets.container.docker.influxdb-docker}}",
+      "network": "BRIDGE",
+      "portMappings": [
+        {
+        "containerPort": 8086,
+        "hostPort": 0,
+        {{#networking.external_access.enable}}
+        "servicePort": {{networking.external_access.external_access_port}},
+        {{/networking.external_access.enable}}
+        "protocol": "tcp",
+        "name": "influxdb-api",
+        "labels": {
+          "VIP_0": "/{{service.name}}:{{networking.port_api}}"
+          }
+        }
+      ],
+      "forcePullImage": true
+    }
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/ping",
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "timeoutSeconds": 20,
+      "maxConsecutiveFailures": 3,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "labels": {
+    "DCOS_PACKAGE_VERSION": "1.4",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    {{#networking.external_access.enable}}
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_VHOST": "{{networking.external_access.external_public_agent_ip}}",
+    {{/networking.external_access.enable}}
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/I/influxdb/1/package.json
+++ b/repo/packages/I/influxdb/1/package.json
@@ -1,0 +1,20 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.7",
+  "name": "influxdb",
+  "version": "1.4",
+  "scm": "https://github.com/influxdata/influxdb",
+  "maintainer": "https://dcos.io/community",
+  "website": "https://github.com/influxdata/influxdb",
+  "description": "InfluxDB is an open-source time series database developed by InfluxData as part of their time series platform. It is written in Go and optimized for fast, high-availability storage and retrieval of time series data in fields such as operations monitoring, application metrics, Internet of Things sensor data, and real-time analytics.\n\nThis package can be used alongside the DC/OS 'cadvisor' and 'grafana' packages for a cluster-wide monitoring solution.\n\nInstallation Documentation: https://github.com/dcos/examples/tree/master/cadvisor-influxdb-grafana\n\nNote: Since InfluxDB 1.3.0 the admin-api is depcrecated and no longer used\n\nNote: You need to manually create your database, e.g. with Chronograf",
+  "tags": ["docker", "influxdb", "database", "monitoring"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nAdvanced Installation options notes\n\nstorage / persistence: create local persistent volumes for internal storage files to survive across restarts or failures. \n\nstorage / host_volume: if /tmp for example is used it will try to mount /tmp/influxdb (make sure the influxdb folder exists within your host_volum /tmp) if persistence is not selected, this package can use a local volume in the host for storage, like a local directory or an NFS mount. The parameter host_volume controls the path in the host in which these volumes will be created, which MUST be the same on all nodes of the cluster.\n\nNOTE: If you didn't select persistence in the storage section, or provided a valid value for host_volume on installation,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n\nnetworking / port: This DC/OS service can be accessed from any other application through a NAMED VIP in the format service_name.marathon.l4lb.thisdcos.directory:port. Check status of the VIP in the Network tab of the DC/OS Dashboard (Enterprise DC/OS only).\n\nnetworking / external_access: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / external_access_port: port to be used in Marathon-LB for accessing the service. \n\nnetworking / external_public_agent_ip: dns for Marathon-LB, typically set to your public agents public ip.\n\n Access your InfluxDB Server e.g. from your laptop with Chronograf: docker run -p 8888:8888 chronograf --influxdb-url=http://<public_agent_ip>",
+ "postInstallNotes": "Service installed.",
+ "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed from the agent where the service was deployed.",
+  "licenses": [
+    {
+      "name": "Apache License",
+      "url": "http://en.wikipedia.org/wiki/Apache_License"
+    }
+  ]
+}

--- a/repo/packages/I/influxdb/1/resource.json
+++ b/repo/packages/I/influxdb/1/resource.json
@@ -1,0 +1,17 @@
+{
+  "images": {
+    "icon-small": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-influxdb-small.png",
+    "icon-medium": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-influxdb-medium.png",
+    "icon-large": "https://s3.amazonaws.com/downloads.mesosphere.io/universe/assets/icon-service-influxdb-large.png",
+     "screenshots": [
+     "https://raw.githubusercontent.com/Kentik/docker-monitor/master/screenshots/influxdb-screenshot.png"
+   ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "influxdb-docker": "influxdb:1.4"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Bump to 1.4 version by switching from the deprecated tutum/influxdb:0.13 to the official influxdb:1.4

Notes:

* Updated the README.md with new instructions
* Added 'Configuration' section to configure influxdb via env variables 
* Fixed persistence as it was broken (removed external drivers as they broke the installation/where not working)
** Persistence with external drivers in `0` with version `0.13` but not supported in `1.4`
*** If persistence with external drivers needed please open an issue and I will work on it