### PR TITLE
Bump DC/OS Beakerx 0.8.1 to 0.9.1

### DIFF
--- a/repo/packages/B/beakerx/0/package.json
+++ b/repo/packages/B/beakerx/0/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "3.0",
   "minDcosReleaseVersion": "1.9",
   "name": "beakerx",
-  "version": "0.8.1",
+  "version": "0.9.1",
   "scm": "https://github.com/twosigma/beakerx",
   "maintainer": "https://dcos.io/community",
   "website": "http://beakerx.com",

--- a/repo/packages/B/beakerx/0/resource.json
+++ b/repo/packages/B/beakerx/0/resource.json
@@ -10,7 +10,7 @@
   "assets": {
     "container": {
       "docker": {
-        "beakerx-docker": "beakerx/beakerx"
+        "beakerx-docker": "mesosphere/dcos-beakerx:0.9.1"
       }
     }
   }


### PR DESCRIPTION
Bump to 0.9.1
* Use of mesosphere docker hub repo