### PR TITLE
Exhibitor-DCOS UI Update

### DIFF
--- a/repo/packages/E/exhibitor/3/config.json
+++ b/repo/packages/E/exhibitor/3/config.json
@@ -1,0 +1,101 @@
+{
+  "properties": {
+    "exhibitor": {
+      "additionalProperties": false,
+      "description": "Exhibitor specific configuration properties",
+      "properties": {
+        "app-id": {
+          "default": "/exhibitor-dcos",
+          "description": "Name of the Exhibitor task in Marathon",
+          "type": "string"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each Exhibitor instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "http-port": {
+          "default": 31885,
+          "description": "The port on which the exhibitor UI listens.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "instances": {
+          "default": 3,
+          "description": "Number of Exhibitor instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "jvm_opts": {
+          "default": "-Xmx512m",
+          "description": "JVM opts for Exhibitor",
+          "type": "string"
+        },
+        "mem": {
+          "default": 3072.0,
+          "description": "Memory (MiB) to allocate to each Exhibitor instance.",
+          "minimum": 1024.0,
+          "type": "number"
+        },
+        "volume-size": {
+          "default": 10240,
+          "description": "Size of data volume (MiB) to allocate to each Exhibitor instance.",
+          "minimum": 1024,
+          "type": "number"
+        },
+        "zk_servers": {
+          "default": "master.mesos:2181",
+          "description": "Parent ZooKeeper URL for storing state. The framework name is joined to the path of this value. Format: zk://host1:port1,host2:port2,.../path",
+          "type": "string"
+        },
+        "zookeeper": {
+          "description": "ZooKeeper specific configuration properties",
+          "properties": {
+            "jvm_opts": {
+              "default": "-XX:+PrintCommandLineFlags -XX:+PrintGC -XX:+PrintGCCause -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+PrintGCApplicationConcurrentTime -XX:+PrintGCApplicationStoppedTime -XX:+PrintTenuringDistribution -XX:+PrintAdaptiveSizePolicy -Xmx2g -Xms2g -XX:+AlwaysPreTouch -Xss512k",
+              "description": "JVM opts for Exhibitor",
+              "type": "string"
+            },
+            "client-port": {
+              "default": 31886,
+              "description": "The port clients use to talk to the zookeeper cluster.",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "peer-port": {
+              "default": 31887,
+              "description": "The port zookeeper peers talk with eachother on.",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "leader-port": {
+              "default": 31888,
+              "description": "The port zookeeper peers talk to the leader on.",
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "jvm_opts",
+            "client-port",
+            "peer-port",
+            "leader-port"
+          ],
+          "type":"object"
+        }
+      },
+      "required": [
+        "app-id",
+        "cpus",
+        "http-port",
+        "instances",
+        "zk_servers",
+        "jvm_opts",
+        "mem"
+      ],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/E/exhibitor/3/marathon.json.mustache
+++ b/repo/packages/E/exhibitor/3/marathon.json.mustache
@@ -1,0 +1,55 @@
+{
+  "id": "{{exhibitor.app-id}}",
+  "cpus": {{exhibitor.cpus}},
+  "mem": {{exhibitor.mem}},
+  "instances": {{exhibitor.instances}},
+  "ports": [
+    {{exhibitor.http-port}},
+    {{exhibitor.zookeeper.client-port}},
+    {{exhibitor.zookeeper.peer-port}},
+    {{exhibitor.zookeeper.leader-port}}
+  ],
+  "requirePorts": true,
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.exhibitor-dcos-docker}}",
+      "network": "HOST"
+    },
+    "volumes": [
+    {
+      "containerPath": "/var/lib/zookeeper",
+      "hostPath": "data",
+      "mode": "RW"
+    },
+    {
+      "containerPath": "data",
+      "mode": "RW",
+      "persistent": {
+        "size": {{exhibitor.volume-size}}
+      }
+    }
+    ]
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/exhibitor/v1/cluster/state",
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 60,
+      "portIndex": 0,
+      "timeoutSeconds": 5,
+      "maxConsecutiveFailures": 3
+    }
+  ],
+  "env": {
+    "EXHIBITOR_JVM_OPTS": "{{exhibitor.jvm_opts}}",
+    "ZK_JVM_OPTS": "{{exhibitor.zookeeper.jvm_opts}}"
+  },
+  "cmd": "/exhibitor-wrapper -c zookeeper --headingtext \"{{exhibitor.app-id}}\" --zkconfigconnect {{exhibitor.zk_servers}} --zkconfigzpath \"/exhibitor-dcos{{exhibitor.app-id}}\"",
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{exhibitor.app-id}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  }
+}

--- a/repo/packages/E/exhibitor/3/package.json
+++ b/repo/packages/E/exhibitor/3/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "2.0",
+  "name": "exhibitor",
+  "version": "1.0.1",
+  "scm": "https://github.com/netflix/exhibitor",
+  "maintainer": "https://dcos.io/community",
+  "description": "ZooKeeper co-process for instance monitoring, backup/recovery, cleanup and visualization.",
+  "framework": false,
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/Netflix/exhibitor/blob/master/LICENSE.txt"
+    }
+  ],
+  "tags": ["zookeeper"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. We recommend a minimum of three nodes with 3GB of RAM available.",
+  "postInstallNotes": "Exhibitor DCOS Service has been successfully installed!",
+  "postUninstallNotes": "The Exhibitor DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at TODO to clean up any persisted state"
+}

--- a/repo/packages/E/exhibitor/3/resource.json
+++ b/repo/packages/E/exhibitor/3/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "exhibitor-dcos-docker": "mesosphere/exhibitor-dcos:v1.0.1"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-exhibitor-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-exhibitor-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-exhibitor-large.png"
+  }
+}


### PR DESCRIPTION
same service as index 2 except 
* added the service endpt information for the UI
* fix the version to v1.0.1 instead of latest

This enables the ability when launched to access the exhibitor ui at:   `{dcos_url}/service/{service_name}/exhibitor/v1/ui/index.html`
the default being:
`{dcos_url}/service/exhibitor-dcos/exhibitor/v1/ui/index.html`
