### PR TITLE
Update kafka-manager to 1.3.3.15

### DIFF
--- a/repo/packages/K/kafka-manager/1/config.json
+++ b/repo/packages/K/kafka-manager/1/config.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "service":{
+      "type":"object",
+      "description": "DC/OS service configuration properties",
+      "properties":{
+        "name" : {
+          "description":"The name of the kafka-manager service instance.",
+          "type":"string",
+          "default":"kafka-manager"
+        },
+        "cpus": {
+          "description": "CPU shares to allocate",
+          "type": "number",
+          "default": 1.0,
+          "minimum": 0.1
+        },
+        "mem": {
+          "description": "Memory to allocate",
+          "type": "number",
+          "default": 1024.0,
+          "minimum": 1024.0
+        },
+        "instances": {
+          "description": "Number of desired instances",
+          "type": "integer",
+          "default": 1
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "instances"
+      ]
+    },
+    "kafka-manager": {
+      "description": "Kafka-manager configuration properties",
+      "type": "object",
+      "properties": {
+        "zk": {
+          "type": "string",
+          "description": "Zookeeper URL for Kafka-manager",
+          "default": "zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181"
+        },
+        "application_secret": {
+          "description": "The application secret key is used to secure cryptographics functions",
+          "type": "string"
+        },
+        "zk-base-path": {
+          "description": "Base path for storing configuration in ZooKeeper",
+          "type": "string"
+        },
+        "config": {
+          "description": "Path to kafka-manager config",
+          "type": "string",
+          "default": "./conf/application.conf"
+        },
+        "zk-args": {
+          "description": "Kafka manager extra arguments",
+          "type": "string"
+        },
+        "loglevel": {
+          "description": "Java log level",
+          "type": "string",
+          "default": "INFO"
+        }
+      },
+      "required": [
+        "zk",
+        "application_secret"
+      ]
+    },
+    "marathon-lb":{
+      "type": "object",
+      "description": "Kafka-manager works best when deployed on a virtual host",
+      "properties": {
+        "enable": {
+          "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+          "type": "boolean",
+          "default": true
+        },
+        "group": {
+          "description": "HAProxy group.",
+          "type": "string",
+          "default": "external"
+        },
+        "external_access_port": {
+          "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+          "type": "number",
+          "default": 13005
+        },
+        "virtual_host": {
+          "description": "For external access, Virtual Host URL to be used in the external load balancer.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/K/kafka-manager/1/marathon.json.mustache
+++ b/repo/packages/K/kafka-manager/1/marathon.json.mustache
@@ -1,0 +1,58 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "instances": {{service.instances}},
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.kafka-manager-docker}}",
+      "forcePullImage": true,
+      "network": "BRIDGE",
+      "portMappings": [
+        {
+          "containerPort": 9000,
+          "hostPort": 0,
+          {{#marathon-lb.enable}}
+          "servicePort": {{marathon-lb.external_access_port}},
+          {{/marathon-lb.enable}}
+          "protocol": "tcp"
+        }
+      ]
+    }
+  },
+  "healthChecks": [
+    {
+      "gracePeriodSeconds": 120,
+      "intervalSeconds": 30,
+      "maxConsecutiveFailures": 0,
+      "path": "/api/health",
+      "portIndex": 0,
+      "protocol": "MESOS_HTTP",
+      "timeoutSeconds": 5
+    }
+  ],
+  "env": {
+    "ZK_HOSTS": "{{kafka-manager.zk}}",
+    {{^kafka-manager.zk-base-path}}
+    "BASE_ZK_PATH": "/{{service.name}}",
+    {{/kafka-manager.zk-base-path}}
+    {{#kafka-manager.zk-base-path}}
+    "BASE_ZK_PATH": "{{kafka-manager.zk-base-path}}",
+    {{/kafka-manager.zk-base-path}}
+    "KAFKA_MANAGER_ARGS": "{{kafka-manager.zk-args}}",
+    "APPLICATION_SECRET": "{{kafka-manager.application_secret}}",
+    "KAFKA_MANAGER_CONFIG": "{{kafka-manager.config}}",
+    "HTTP_CONTEXT": "/",
+    "KAFKA_MANAGER_LOGLEVEL": "{{kafka-manager.loglevel}}"
+  },
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    {{#marathon-lb.enable}}
+    "HAPROXY_GROUP": "{{marathon-lb.group}}",
+    "HAPROXY_0_VHOST": "{{marathon-lb.virtual_host}}",
+    {{/marathon-lb.enable}}
+    "DCOS_PACKAGE_VERSION": "{{package.version}}"
+  }
+}

--- a/repo/packages/K/kafka-manager/1/package.json
+++ b/repo/packages/K/kafka-manager/1/package.json
@@ -1,0 +1,20 @@
+{
+  "packagingVersion": "4.0",
+  "name": "kafka-manager",
+  "version": "1.1.0-1.3.3.15",
+  "minDcosReleaseVersion": "1.9",
+  "scm": "https://github.com/yahoo/kafka-manager",
+  "maintainer": "https://github.com/deric/kafka-manager-docker",
+  "description": "A web-based tool for managing Apache Kafka clusters. Kafka-manager supports Kafka versions up to 0.11.0.0. The web UI should be deployed on a virtual host, routing to different base path is currently not supported. Use e.g. Marathon-LB to access kafka-manager web interface.",
+  "framework": false,
+  "tags": ["message", "broker", "messaging", "management", "kafka", "manager"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. You need a live kafka cluster (Kafka or Confluent).",
+  "postInstallNotes": "kafka-manager has been installed. Persistent data are stored in the zookeeper cluster you defined under /${service.name} znode.",
+  "postUninstallNotes": "kafka-manager has been uninstalled. Please note that persistent data are still in your zookeeper cluster, under /${service.name} znode, and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/yahoo/kafka-manager/master/LICENCE"
+    }
+  ]
+}

--- a/repo/packages/K/kafka-manager/1/package.json
+++ b/repo/packages/K/kafka-manager/1/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "4.0",
   "name": "kafka-manager",
-  "version": "1.1.0-1.3.3.15",
+  "version": "1.1.0-1.3.3.16",
   "minDcosReleaseVersion": "1.9",
   "scm": "https://github.com/yahoo/kafka-manager",
   "maintainer": "https://github.com/deric/kafka-manager-docker",

--- a/repo/packages/K/kafka-manager/1/resource.json
+++ b/repo/packages/K/kafka-manager/1/resource.json
@@ -10,7 +10,7 @@
   "assets": {
     "container": {
       "docker": {
-        "kafka-manager-docker": "deric/kafka-manager:1.3.3.15"
+        "kafka-manager-docker": "deric/kafka-manager:1.3.3.16"
       }
     }
   }

--- a/repo/packages/K/kafka-manager/1/resource.json
+++ b/repo/packages/K/kafka-manager/1/resource.json
@@ -1,0 +1,17 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-large.png",
+    "screenshots": [
+      "https://raw.githubusercontent.com/yahoo/kafka-manager/master/img/topic-list.png"
+    ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "kafka-manager-docker": "deric/kafka-manager:1.3.3.15"
+      }
+    }
+  }
+}


### PR DESCRIPTION
In the end quite major package refactoring. Kafka-manager was updated from `1.3.0.8` -> `1.3.3.15`. Now supports kafka 0.10 and 0.11. Previously used Docker image is no longer maintained, so I've created a new one.
```
diff --git a/repo/packages/K/kafka-manager/0/config.json b/repo/packages/K/kafka-manager/1/config.json
index 59d8687..459e9c1 100644
--- a/repo/packages/K/kafka-manager/0/config.json
+++ b/repo/packages/K/kafka-manager/1/config.json
@@ -3,55 +3,99 @@
   "type": "object",
   "properties": {
     "service":{
-        "type":"object",
-        "description": "DC/OS service configuration properties",
-        "properties":{
-            "name" : {
-                "description":"The name of the kafka-manager service instance.",
-                "type":"string",
-                "default":"kafka-manager"
-            }
+      "type":"object",
+      "description": "DC/OS service configuration properties",
+      "properties":{
+        "name" : {
+          "description":"The name of the kafka-manager service instance.",
+          "type":"string",
+          "default":"kafka-manager"
+        },
+        "cpus": {
+          "description": "CPU shares to allocate",
+          "type": "number",
+          "default": 1.0,
+          "minimum": 0.1
+        },
+        "mem": {
+          "description": "Memory to allocate",
+          "type": "number",
+          "default": 1024.0,
+          "minimum": 1024.0
+        },
+        "instances": {
+          "description": "Number of desired instances",
+          "type": "integer",
+          "default": 1
         }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "instances"
+      ]
     },
     "kafka-manager": {
-      "additionalProperties": false,
       "description": "Kafka-manager configuration properties",
       "type": "object",
       "properties": {
-        "cpus": {
-            "description": "CPU shares to allocate",
-            "type": "number",
-            "default": 1.0,
-            "minimum": 0.1
+        "zk": {
+          "type": "string",
+          "description": "Zookeeper URL for Kafka-manager",
+          "default": "zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181"
         },
-        "mem": {
-            "description": "Memory to allocate",
-            "type": "number",
-            "default": 1024.0,
-            "minimum": 1024.0
+        "application_secret": {
+          "description": "The application secret key is used to secure cryptographics functions",
+          "type": "string"
         },
-        "zk": {
-            "type": "string",
-            "description": "Zookeeper URL for Kafka-manager",
-            "default": "zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181"
+        "zk-base-path": {
+          "description": "Base path for storing configuration in ZooKeeper",
+          "type": "string"
         },
-        "instances": {
-            "description": "Number of desired instances",
-            "type": "integer",
-            "default": 1
+        "config": {
+          "description": "Path to kafka-manager config",
+          "type": "string",
+          "default": "./conf/application.conf"
         },
-        "application_secret": {
-            "description": "The application secret key is used to secure cryptographics functions",
-            "type": "string"
+        "zk-args": {
+          "description": "Kafka manager extra arguments",
+          "type": "string"
+        },
+        "loglevel": {
+          "description": "Java log level",
+          "type": "string",
+          "default": "INFO"
         }
       },
       "required": [
-        "cpus",
-        "mem",
-        "instances",
         "zk",
         "application_secret"
       ]
+    },
+    "marathon-lb":{
+      "type": "object",
+      "description": "Kafka-manager works best when deployed on a virtual host",
+      "properties": {
+        "enable": {
+          "description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+          "type": "boolean",
+          "default": true
+        },
+        "group": {
+          "description": "HAProxy group.",
+          "type": "string",
+          "default": "external"
+        },
+        "external_access_port": {
+          "description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+          "type": "number",
+          "default": 13005
+        },
+        "virtual_host": {
+          "description": "For external access, Virtual Host URL to be used in the external load balancer.",
+          "type": "string"
+        }
+      }
     }
   }
 }
diff --git a/repo/packages/K/kafka-manager/0/marathon.json.mustache b/repo/packages/K/kafka-manager/1/marathon.json.mustache
index 5ba7f2a..f9c91eb 100644
--- a/repo/packages/K/kafka-manager/0/marathon.json.mustache
+++ b/repo/packages/K/kafka-manager/1/marathon.json.mustache
@@ -1,8 +1,8 @@
 {
   "id": "{{service.name}}",
-  "cpus": {{kafka-manager.cpus}},
-  "mem": {{kafka-manager.mem}},
-  "instances": {{kafka-manager.instances}},
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "instances": {{service.instances}},
   "container": {
     "type": "DOCKER",
     "docker": {
@@ -13,6 +13,9 @@
         {
           "containerPort": 9000,
           "hostPort": 0,
+          {{#marathon-lb.enable}}
+          "servicePort": {{marathon-lb.external_access_port}},
+          {{/marathon-lb.enable}}
           "protocol": "tcp"
         }
       ]
@@ -23,20 +26,33 @@
       "gracePeriodSeconds": 120,
       "intervalSeconds": 30,
       "maxConsecutiveFailures": 0,
-      "path": "/",
+      "path": "/api/health",
       "portIndex": 0,
-      "protocol": "HTTP",
+      "protocol": "MESOS_HTTP",
       "timeoutSeconds": 5
     }
   ],
   "env": {
     "ZK_HOSTS": "{{kafka-manager.zk}}",
-    "KM_ARGS": "-Dkafka-manager.base-zk-path=/{{service.name}}",
-    "APPLICATION_SECRET": "{{kafka-manager.application_secret}}"
+    {{^kafka-manager.zk-base-path}}
+    "BASE_ZK_PATH": "/{{service.name}}",
+    {{/kafka-manager.zk-base-path}}
+    {{#kafka-manager.zk-base-path}}
+    "BASE_ZK_PATH": "{{kafka-manager.zk-base-path}}",
+    {{/kafka-manager.zk-base-path}}
+    "KAFKA_MANAGER_ARGS": "{{kafka-manager.zk-args}}",
+    "APPLICATION_SECRET": "{{kafka-manager.application_secret}}",
+    "KAFKA_MANAGER_CONFIG": "{{kafka-manager.config}}",
+    "HTTP_CONTEXT": "/",
+    "KAFKA_MANAGER_LOGLEVEL": "{{kafka-manager.loglevel}}"
   },
   "labels": {
     "DCOS_SERVICE_NAME": "{{service.name}}",
     "DCOS_SERVICE_SCHEME": "http",
-    "DCOS_SERVICE_PORT_INDEX": "0"
+    {{#marathon-lb.enable}}
+    "HAPROXY_GROUP": "{{marathon-lb.group}}",
+    "HAPROXY_0_VHOST": "{{marathon-lb.virtual_host}}",
+    {{/marathon-lb.enable}}
+    "DCOS_PACKAGE_VERSION": "{{package.version}}"
   }
 }
diff --git a/repo/packages/K/kafka-manager/0/package.json b/repo/packages/K/kafka-manager/1/package.json
index e7dfb88..1d80f87 100644
--- a/repo/packages/K/kafka-manager/0/package.json
+++ b/repo/packages/K/kafka-manager/1/package.json
@@ -1,12 +1,13 @@
 {
-  "packagingVersion": "2.0",
+  "packagingVersion": "4.0",
   "name": "kafka-manager",
-  "version": "1.3.0.8",
+  "version": "1.1.0-1.3.3.15",
+  "minDcosReleaseVersion": "1.9",
   "scm": "https://github.com/yahoo/kafka-manager",
-  "maintainer": "mesos@cotds.org",
-  "description": "A tool for managing Apache Kafka",
+  "maintainer": "https://github.com/deric/kafka-manager-docker",
+  "description": "A web-based tool for managing Apache Kafka clusters. Kafka-manager supports Kafka versions up to 0.11.0.0. The web UI should be deployed on a virtual host, routing to different base path is currently not supported. Use e.g. Marathon-LB to access kafka-manager web interface.",
   "framework": false,
-  "tags": ["message", "broker", "messaging", "management", "kafka"],
+  "tags": ["message", "broker", "messaging", "management", "kafka", "manager"],
   "preInstallNotes": "This DC/OS Service is currently in preview. You need a live kafka cluster (Kafka or Confluent).",
   "postInstallNotes": "kafka-manager has been installed. Persistent data are stored in the zookeeper cluster you defined under /${service.name} znode.",
   "postUninstallNotes": "kafka-manager has been uninstalled. Please note that persistent data are still in your zookeeper cluster, under /${service.name} znode, and will need to be manually removed.",
diff --git a/repo/packages/K/kafka-manager/0/resource.json b/repo/packages/K/kafka-manager/1/resource.json
index 666957b..d02e788 100644
--- a/repo/packages/K/kafka-manager/0/resource.json
+++ b/repo/packages/K/kafka-manager/1/resource.json
@@ -3,12 +3,14 @@
     "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-small.png",
     "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-medium.png",
     "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-kafka-large.png",
-    "screenshots": ["https://raw.githubusercontent.com/yahoo/kafka-manager/master/img/topic-list.png"]
+    "screenshots": [
+      "https://raw.githubusercontent.com/yahoo/kafka-manager/master/img/topic-list.png"
+    ]
   },
   "assets": {
     "container": {
       "docker": {
-        "kafka-manager-docker": "sheepkiller/kafka-manager:1.3.0.8"
+        "kafka-manager-docker": "deric/kafka-manager:1.3.3.15"
       }
     }
   }
```