### PR TITLE
Fix escaping difference in cosmos

### DIFF
--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -86,29 +86,6 @@ def render_universe_by_version(outdir, packages, version):
     :rtype: None
     """
 
-    # Prior to 1.10, Cosmos had a rendering bug that required
-    # stringified JSON to be doubly escaped. This was corrected
-    # in 1.10, but it means that packages with stringified JSON parameters
-    # that need to bridge versions must be accomodated.
-    #
-    # < 1.9 style escaping:
-    # \\\"field\\\": \\\"value\\\"
-    #
-    # >= 1.10 style escaping:
-    # \"field\": \"value\"
-    if LooseVersion(version) < LooseVersion("1.10"):
-        for package in packages:
-            if "config" in package and "properties" in package["config"]:
-                # The rough shape of a config file is:
-                # {
-                #   "schema": ...,
-                #   "properties": { }
-                # }
-                # Send just the top level properties in to the recursive
-                # function json_escape_compatibility.
-                package["config"]["properties"] = json_escape_compatibility(
-                    package["config"]["properties"])
-
     if LooseVersion(version) < LooseVersion("1.8"):
         render_zip_universe_by_version(outdir, packages, version)
     else:
@@ -227,6 +204,27 @@ def filter_and_downgrade_packages_by_version(packages, version):
     ]
 
     if LooseVersion(version) < LooseVersion('1.10'):
+        # Prior to 1.10, Cosmos had a rendering bug that required
+        # stringified JSON to be doubly escaped. This was corrected
+        # in 1.10, but it means that packages with stringified JSON parameters
+        # that need to bridge versions must be accomodated.
+        #
+        # < 1.9 style escaping:
+        # \\\"field\\\": \\\"value\\\"
+        #
+        # >= 1.10 style escaping:
+        # \"field\": \"value\"
+        for package in packages:
+            if "config" in package and "properties" in package["config"]:
+                # The rough shape of a config file is:
+                # {
+                #   "schema": ...,
+                #   "properties": { }
+                # }
+                # Send just the top level properties in to the recursive
+                # function json_escape_compatibility.
+                package["config"]["properties"] = json_escape_compatibility(
+                    package["config"]["properties"])
         packages = [downgrade_package_to_v3(package) for package in packages]
     return packages
 

--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -287,7 +287,7 @@ def read_marathon_template(path):
 
 
 def read_config(path):
-    """Reads the resource.json as a dict
+    """Reads the config.json as a dict
 
     :param path: path to the package
     :type path: pathlib.Path

--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -115,9 +115,9 @@ def json_escape_compatibility(schema: collections.OrderedDict) -> collections.Or
         if "description" in value:
             value["description"] = escape_json_string(value["description"])
 
-        if value["type"] == "string":
+        if value["type"] == "string" and "default" in value:
             value["default"] = escape_json_string(value["default"])
-        elif value["type"] == "object":
+        elif value["type"] == "object" and "properties" in value:
             value["properties"] = json_escape_compatibility(value["properties"])
 
     return schema


### PR DESCRIPTION
 Prior to 1.10, Cosmos had a rendering bug (fixed by https://github.com/dcos/cosmos/commit/42c35b13527586daeba3359d1ed0602a59e7708d) that required
 stringified JSON to be doubly escaped. This was corrected
 in 1.10, but it means that packages with stringified JSON parameters
 that need to bridge versions must be accomodated.
```
 < 1.9 style escaping:
 \\\"field\\\": \\\"value\\\"

 >= 1.10 style escaping:
 \"field\": \"value\"
```

This uses a regex to detect \" and replace it with \\\" if version < 1.10. I can rewrite it as a parser if we're worried about having a regex.