### PR TITLE
Release cockroachdb 1.1.3-1.1.3 (automated commit)

### DIFF
--- a/repo/packages/C/cockroachdb/1/config.json
+++ b/repo/packages/C/cockroachdb/1/config.json
@@ -1,0 +1,182 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "title": "Service name",
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "cockroachdb"
+        },
+        "user": {
+          "title": "User",
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "version": {
+          "title": "CockroachDB version",
+          "description": "Production release version of CockroachDB",
+          "type": "string",
+          "default": "1.1.3"
+        },
+        "cache_size": {
+          "title": "CockroachDB cache size",
+          "description": "Cache size to be used by CockroachDB",
+          "type": "string",
+          "default": "25%"
+        },
+        "max_sql_memory": {
+          "title": "CockroachDB max SQL memory",
+          "description": "Maximum amount of memory for CockroachDB to use for processing SQL queries",
+          "type": "string",
+          "default": "25%"
+        },
+        "http_port": {
+          "title": "CockroachDB HTTP Port",
+          "description": "Port for CockroachDB admin UI",
+          "type": "number",
+          "default": 80
+        },
+        "pg_port": {
+          "title": "CockroachDB PG Port",
+          "description": "Port for CockroachDB client communication",
+          "type": "number",
+          "default": 26257
+        },
+        "container_http_port": {
+          "title": "Container HTTP Port",
+          "description": "Container port for CockroachDB admin UI. This port MUST be available on the host machine.",
+          "type": "number",
+          "default": 8123
+        },
+        "container_pg_port": {
+          "title": "Container PG Port",
+          "description": "Container port for CockroachDB client communication. This port MUST be available on the host machine.",
+          "type": "number",
+          "default": 26257
+        },
+        "virtual_network": {
+          "description": "Enable DC/OS Virtual Network",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "name",
+        "user"
+      ]
+    },
+    "node": {
+      "description": "Template pod configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of Template pods to run",
+          "type": "integer",
+          "default": 3
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": "hostname:UNIQUE"
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Template pod CPU requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Template pod mem requirements (in MB)",
+          "type": "integer",
+          "default": 3000
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Template pod persistent disk requirements (in MB)",
+          "type": "integer",
+          "default": 5000
+        },
+        "disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "disk_type"
+      ]
+    },
+    "side": {
+      "description": "Template pod configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of Template pods to run",
+          "type": "integer",
+          "default": 1
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Template pod CPU requirements",
+          "type": "number",
+          "default": 1
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Template pod mem requirements (in MB)",
+          "type": "integer",
+          "default": 1000
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Template pod persistent disk requirements (in MB)",
+          "type": "integer",
+          "default": 5000
+        },
+        "disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "disk_type"
+      ]
+    }
+  }
+}

--- a/repo/packages/C/cockroachdb/1/marathon.json.mustache
+++ b/repo/packages/C/cockroachdb/1/marathon.json.mustache
@@ -1,0 +1,100 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./cockroachdb-scheduler/bin/cockroachdb ./cockroachdb-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "CONFIG_TEMPLATE_PATH": "cockroachdb-scheduler",
+
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "COCKROACH_URI": "{{resource.assets.uris.cockroach-binary}}/cockroach-v{{service.version}}.linux-amd64.tgz",
+    "COCKROACH_VERSION": "cockroach-v{{service.version}}.linux-amd64",
+    "COCKROACH_CACHE_SIZE": "{{service.cache_size}}",
+    "COCKROACH_MAX_SQL_MEMORY": "{{service.max_sql_memory}}",
+    "COCKROACH_HTTP_PORT": "{{service.http_port}}",
+    "COCKROACH_PG_PORT": "{{service.pg_port}}",
+    "CONTAINER_HTTP_PORT": "{{service.container_http_port}}",
+    "CONTAINER_PG_PORT": "{{service.container_pg_port}}",
+
+    "NODE_COUNT": "{{node.count}}",
+    "NODE_PLACEMENT": "{{node.placement_constraint}}",
+    {{#service.virtual_network}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    {{/service.virtual_network}}
+    "NODE_CPUS": "{{node.cpus}}",
+    "NODE_MEM": "{{node.mem}}",
+    "NODE_DISK": "{{node.disk}}",
+    "NODE_DISK_TYPE": "{{node.disk_type}}",
+    "SIDE_COUNT": "{{side.count}}",
+    "SIDE_CPUS": "{{side.cpus}}",
+    "SIDE_MEM": "{{side.mem}}",
+    "SIDE_DISK": "{{side.disk}}",
+    "SIDE_DISK_TYPE": "{{side.disk_type}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.service_account_secret}}
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/C/cockroachdb/1/package.json
+++ b/repo/packages/C/cockroachdb/1/package.json
@@ -1,0 +1,18 @@
+{
+  "description": "CockroachDB is a distributed relational database that is scalable, survivable, and strongly consistent. Service Guide is available at: https://github.com/dcos/examples/tree/master/cockroachdb/1.9 The source code for CockroachDB Enterprise is packaged in the same binary as CockroachDB Core.\n\n\tCustomers interested in the CockroachDB Enterprise license should contact https://www.cockroachlabs.com/pricing/sales/",
+  "framework": true,
+  "maintainer": "support@cockroachlabs.com",
+  "minDcosReleaseVersion": "1.9",
+  "name": "cockroachdb",
+  "packagingVersion": "4.0",
+  "postInstallNotes": "CockroachDB is being installed!\n\n\tDocumentation: https://www.cockroachlabs.com/docs\n\tIssues: contact https://www.cockroachlabs.com/docs/support-resources.html\n\tRelease Notes: https://www.cockroachlabs.com/docs/releases/v1.1.3.html",
+  "postUninstallNotes": "CockroachDB has been uninstalled.",
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production! For a replicated cluster, please use at least 3 nodes to ensure availability with 1 CPU and 2 GB of RAM per node.",
+  "selected": false,
+  "tags": [
+    "cockroachdb",
+    "sql",
+    "database"
+  ],
+  "version": "1.1.3-1.1.3"
+}

--- a/repo/packages/C/cockroachdb/1/resource.json
+++ b/repo/packages/C/cockroachdb/1/resource.json
@@ -1,0 +1,57 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
+      "scheduler-zip": "dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/cockroachdb-scheduler.zip",
+      "executor-zip": "dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/executor.zip",
+      "bootstrap-zip": "dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/bootstrap.zip",
+      "cockroach-binary": "https://binaries.cockroachdb.com"
+    }
+  },
+  "images": {
+    "icon-small": "http://i.imgur.com/FsEREZI.png",
+    "icon-medium": "http://i.imgur.com/1DvX5di.png?1",
+    "icon-large": "http://i.imgur.com/P1mjjGK.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "b3c91c3c5b058015d85fa079f246dd6869d2ca454b32ff55a7ae9283300d3038"
+            }
+          ],
+          "kind": "executable",
+          "url": "dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-cockroachdb-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "84a6786ef013b59d5c6411685d042eaaf47a9a7c57edb2b2c2b746e34c76baa9"
+            }
+          ],
+          "kind": "executable",
+          "url": "dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-cockroachdb-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "0118fa48af299250af664bbad06d8b995b06d26a9209d41571a5320bf658d40a"
+            }
+          ],
+          "kind": "executable",
+          "url": "dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-cockroachdb.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Description:
Update CockroachDB package to v1.1.3

Changes since revision 0:
0 files added: []
0 files removed: []
4 files changed:

```
--- 0/config.json
+++ 1/config.json
@@ -17,14 +17,12 @@
           "type": "string",
           "default": "root"
         },
-        "principal": {
-          "title": "Custom principal (optional)",
-          "description": "The principal for the service instance, or empty to use the default.",
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
           "type": "string",
           "default": ""
         },
-        "secret_name": {
-          "title": "Credential secret name (optional)",
+        "service_account_secret": {
           "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
           "type": "string",
           "default": ""
@@ -33,7 +31,19 @@
           "title": "CockroachDB version",
           "description": "Production release version of CockroachDB",
           "type": "string",
-          "default": "1.0.2"
+          "default": "1.1.3"
+        },
+        "cache_size": {
+          "title": "CockroachDB cache size",
+          "description": "Cache size to be used by CockroachDB",
+          "type": "string",
+          "default": "25%"
+        },
+        "max_sql_memory": {
+          "title": "CockroachDB max SQL memory",
+          "description": "Maximum amount of memory for CockroachDB to use for processing SQL queries",
+          "type": "string",
+          "default": "25%"
         },
         "http_port": {
           "title": "CockroachDB HTTP Port",
--- 0/marathon.json.mustache
+++ 1/marathon.json.mustache
@@ -12,22 +12,24 @@
     "DCOS_SERVICE_PORT_INDEX": "0",
     "DCOS_SERVICE_SCHEME": "http"
   },
-  {{#service.secret_name}}
+  {{#service.service_account_secret}}
   "secrets": {
     "serviceCredential": {
-      "source": "{{service.secret_name}}"
+      "source": "{{service.service_account_secret}}"
     }
   },
-  {{/service.secret_name}}
+  {{/service.service_account_secret}}
   "env": {
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     "CONFIG_TEMPLATE_PATH": "cockroachdb-scheduler",

     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_USER": "{{service.user}}",
-    "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
     "COCKROACH_URI": "{{resource.assets.uris.cockroach-binary}}/cockroach-v{{service.version}}.linux-amd64.tgz",
     "COCKROACH_VERSION": "cockroach-v{{service.version}}.linux-amd64",
+    "COCKROACH_CACHE_SIZE": "{{service.cache_size}}",
+    "COCKROACH_MAX_SQL_MEMORY": "{{service.max_sql_memory}}",
     "COCKROACH_HTTP_PORT": "{{service.http_port}}",
     "COCKROACH_PG_PORT": "{{service.pg_port}}",
     "CONTAINER_HTTP_PORT": "{{service.container_http_port}}",
@@ -42,20 +44,20 @@
     "NODE_MEM": "{{node.mem}}",
     "NODE_DISK": "{{node.disk}}",
     "NODE_DISK_TYPE": "{{node.disk_type}}",
-
     "SIDE_COUNT": "{{side.count}}",
     "SIDE_CPUS": "{{side.cpus}}",
     "SIDE_MEM": "{{side.mem}}",
     "SIDE_DISK": "{{side.disk}}",
     "SIDE_DISK_TYPE": "{{side.disk_type}}",

-    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
-    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
-    {{#service.secret_name}}
+    {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
     "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
-    {{/service.secret_name}}
+    {{/service.service_account_secret}}
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
   },
   "uris": [
--- 0/package.json
+++ 1/package.json
@@ -1,11 +1,11 @@
 {
-  "description": "CockroachDB is a distributed relational database that is scalable, survivable, and strongly consistent. Service Guide is available at: https://github.com/dcos/examples/tree/master/cockroachdb/1.9. The source code for CockroachDB Enterprise is packaged in the same binary as CockroachDB Core.\n\n\tCustomers interested in the CockroachDB Enterprise license should contact https://www.cockroachlabs.com/pricing/sales/",
+  "description": "CockroachDB is a distributed relational database that is scalable, survivable, and strongly consistent. Service Guide is available at: https://github.com/dcos/examples/tree/master/cockroachdb/1.9 The source code for CockroachDB Enterprise is packaged in the same binary as CockroachDB Core.\n\n\tCustomers interested in the CockroachDB Enterprise license should contact https://www.cockroachlabs.com/pricing/sales/",
   "framework": true,
   "maintainer": "support@cockroachlabs.com",
   "minDcosReleaseVersion": "1.9",
   "name": "cockroachdb",
-  "packagingVersion": "3.0",
-  "postInstallNotes": "CockroachDB is being installed!\n\n\tDocumentation: https://www.cockroachlabs.com/docs\n\tIssues: contact https://www.cockroachlabs.com/docs/support-resources.html\n\tRelease Notes:https://www.cockroachlabs.com/docs/v1.0.2.html",
+  "packagingVersion": "4.0",
+  "postInstallNotes": "CockroachDB is being installed!\n\n\tDocumentation: https://www.cockroachlabs.com/docs\n\tIssues: contact https://www.cockroachlabs.com/docs/support-resources.html\n\tRelease Notes: https://www.cockroachlabs.com/docs/releases/v1.1.3.html",
   "postUninstallNotes": "CockroachDB has been uninstalled.",
   "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production! For a replicated cluster, please use at least 3 nodes to ensure availability with 1 CPU and 2 GB of RAM per node.",
   "selected": false,
@@ -14,5 +14,5 @@
     "sql",
     "database"
   ],
-  "version": "1.0.0-1.0.2"
+  "version": "1.1.3-1.1.3"
 }
--- 0/resource.json
+++ 1/resource.json
@@ -3,9 +3,9 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
-      "scheduler-zip": "http://cockroach-artifacts.s3-us-west-2.amazonaws.com/cockroachdb/assets/1.0.0-1.0.2/cockroachdb-scheduler.zip",
-      "executor-zip": "http://cockroach-artifacts.s3-us-west-2.amazonaws.com/cockroachdb/assets/1.0.0-1.0.2/executor.zip",
-      "bootstrap-zip": "http://cockroach-artifacts.s3-us-west-2.amazonaws.com/cockroachdb/assets/1.0.0-1.0.2/bootstrap.zip",
+      "scheduler-zip": "dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/cockroachdb-scheduler.zip",
+      "executor-zip": "dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/executor.zip",
+      "bootstrap-zip": "dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/bootstrap.zip",
       "cockroach-binary": "https://binaries.cockroachdb.com"
     }
   },
@@ -21,11 +21,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "a5d7a01ee36ac8b839f5873ca7ba62be1d31841f5750e9b07a0cb0c47861fc0b"
+              "value": "b3c91c3c5b058015d85fa079f246dd6869d2ca454b32ff55a7ae9283300d3038"
             }
           ],
           "kind": "executable",
-          "url": "http://cockroach-artifacts.s3-us-west-2.amazonaws.com/cockroachdb/assets/1.0.0-1.0.2/dcos-cockroachdb-darwin"
+          "url": "dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-cockroachdb-darwin"
         }
       },
       "linux": {
@@ -33,11 +33,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "8786ca9b48235662775a971349a1a41aad24854921418304d0af4efb0e6fe46c"
+              "value": "84a6786ef013b59d5c6411685d042eaaf47a9a7c57edb2b2c2b746e34c76baa9"
             }
           ],
           "kind": "executable",
-          "url": "http://cockroach-artifacts.s3-us-west-2.amazonaws.com/cockroachdb/assets/1.0.0-1.0.2/dcos-cockroachdb-linux"
+          "url": "dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-cockroachdb-linux"
         }
       },
       "windows": {
@@ -45,11 +45,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "5f9fda10961f8016bd6896d56c9878a4381eeb9e1f60dc1319a031849a11106e"
+              "value": "0118fa48af299250af664bbad06d8b995b06d26a9209d41571a5320bf658d40a"
             }
           ],
           "kind": "executable",
-          "url": "http://cockroach-artifacts.s3-us-west-2.amazonaws.com/cockroachdb/assets/1.0.0-1.0.2/dcos-cockroachdb.exe"
+          "url": "dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-cockroachdb.exe"
         }
       }
     }
```