### PR TITLE
Improve printing of jsonschema validation errors

### DIFF
--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -649,7 +649,11 @@ def validate_repo_with_schema(repo_json_data, repo_version):
     :return: list of validation errors ( length == zero => No errors)
     """
     validator = jsonschema.Draft4Validator(_load_jsonschema(repo_version))
-    return list(validator.iter_errors(repo_json_data))
+    errors = []
+    for error in validator.iter_errors(repo_json_data):
+        for suberror in sorted(error.context, key=lambda e: e.schema_path):
+            errors.append('{}: {}'.format(list(suberror.schema_path), suberror.message))
+    return errors
 
 
 def _validate_repo(file_path, version):
@@ -673,10 +677,10 @@ def _validate_repo(file_path, version):
     errors = validate_repo_with_schema(repo, repo_version)
     if len(errors) != 0:
         sys.exit(
-            'ERROR\n\nRepo {} version {} validation error: {}'.format(
+            'ERROR\n\nRepo {} version {} validation errors: {}'.format(
                 file_path,
                 repo_version,
-                errors
+                '\n'.join(errors)
             )
         )
 


### PR DESCRIPTION
As recommended by the jsonschema docs in
http://python-jsonschema.readthedocs.io/en/latest/errors/

This makes the `./scripts/build.sh` errors actually actionable. Before this change, my broken config file from https://github.com/mesosphere/universe/pull/1579 gave this error that just said the schema was invalid without saying why:

```
Repo /Users/alex/go/src/github.com/mesosphere/universe/scripts/../target/repo-up-to-1.10.json version v4 validation error: [<ValidationError: '{\'packagingVersion\': \'4.0\', \'minDcosReleaseVersion\': \'1.10\', \'name\': \'cockroachdb\', \'version\': \'1.1.3-1.1.3\', \'maintainer\': \'support@cockroachlabs.com\', \'description\': \'CockroachDB is a distributed relational database that is scalable, survivable, and strongly consistent. Service Guide is available at: https://github.com/dcos/examples/tree/master/cockroachdb/1.9 The source code for CockroachDB Enterprise is packaged in the same binary as CockroachDB Core.\\n\\n\\tCustomers interested in the CockroachDB Enterprise license should contact https://www.cockroachlabs.com/pricing/sales/\', \'selected\': False, \'framework\': True, \'tags\': [\'cockroachdb\', \'sql\', \'database\'], \'preInstallNotes\': \'This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production! For a replicated cluster, please use at least 3 nodes to ensure availability with 1 CPU and 2 GB of RAM per node.\', \'postInstallNotes\': \'CockroachDB is being installed!\\n\\n\\tDocumentation: https://www.cockroachlabs.com/docs\\n\\tIssues: contact https://www.cockroachlabs.com/docs/support-resources.html\\n\\tRelease Notes: https://www.cockroachlabs.com/docs/releases/v1.1.3.html\', \'postUninstallNotes\': \'CockroachDB has been uninstalled.\', \'releaseVersion\': 1, \'resource\': {\'assets\': {\'uris\': {\'jre-tar-gz\': \'https://downloads.mesosphere.com/java/jre-8u152-linux-x64.tar.gz\', \'libmesos-bundle-tar-gz\': \'https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz\', \'scheduler-zip\': \'dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/cockroachdb-scheduler.zip\', \'executor-zip\': \'dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/executor.zip\', \'bootstrap-zip\': \'dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/bootstrap.zip\', \'cockroach-binary\': \'https://binaries.cockroachdb.com\'}}, \'images\': {\'icon-small\': \'http://i.imgur.com/FsEREZI.png\', \'icon-medium\': \'http://i.imgur.com/1DvX5di.png?1\', \'icon-large\': \'http://i.imgur.com/P1mjjGK.png\'}, \'cli\': {\'binaries\': {\'darwin\': {\'x86-64\': {\'contentHash\': [{\'algo\': \'sha256\', \'value\': \'f5745070204246de70e9b7c4f671409a6c393e0c3f0f8810145067a79cc4bf1f\'}], \'kind\': \'executable\', \'url\': \'dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli-darwin\'}}, \'linux\': {\'x86-64\': {\'contentHash\': [{\'algo\': \'sha256\', \'value\': \'fdf652995cee7aa004494f132e1458e4c939cd9d13b8a9bc4cfb153e45a10ceb\'}], \'kind\': \'executable\', \'url\': \'dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli-linux\'}}, \'windows\': {\'x86-64\': {\'contentHash\': [{\'algo\': \'sha256\', \'value\': \'f542e37ca285825c72a3103f7b7f4e3c687124422d60656563dd7a2cb93b578e\'}], \'kind\': \'executable\', \'url\': \'dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli.exe\'}}}}}, \'marathon\': {\'v2AppMustacheTemplate\': \'ewogICJpZCI6ICJ7e3NlcnZpY2UubmFtZX19IiwKICAiY3B1cyI6IDEuMCwKICAibWVtIjogMTAyNCwKICAiaW5zdGFuY2VzIjogMSwKICAiY21kIjogImV4cG9ydCBMRF9MSUJSQVJZX1BBVEg9JE1FU09TX1NBTkRCT1gvbGlibWVzb3MtYnVuZGxlL2xpYjokTERfTElCUkFSWV9QQVRIOyBleHBvcnQgTUVTT1NfTkFUSVZFX0pBVkFfTElCUkFSWT0kKGxzICRNRVNPU19TQU5EQk9YL2xpYm1lc29zLWJ1bmRsZS9saWIvbGlibWVzb3MtKi5zbyk7IGV4cG9ydCBKQVZBX0hPTUU9JChscyAtZCAkTUVTT1NfU0FOREJPWC9qcmUqLyk7IGV4cG9ydCBKQVZBX0hPTUU9JHtKQVZBX0hPTUUlL307IGV4cG9ydCBQQVRIPSQobHMgLWQgJEpBVkFfSE9NRS9iaW4pOiRQQVRIICYmICBleHBvcnQgSkFWQV9PUFRTPVwiLVhtczI1Nk0gLVhteDUxMk0gLVhYOi1IZWFwRHVtcE9uT3V0T2ZNZW1vcnlFcnJvclwiICYmICAuL2NvY2tyb2FjaGRiLXNjaGVkdWxlci9iaW4vY29ja3JvYWNoZGIgLi9jb2Nrcm9hY2hkYi1zY2hlZHVsZXIvc3ZjLnltbCIsCiAgImxhYmVscyI6IHsKICAgICJEQ09TX0NPTU1PTlNfQVBJX1ZFUlNJT04iOiAidjEiLAogICAgIkRDT1NfUEFDS0FHRV9GUkFNRVdPUktfTkFNRSI6ICJ7e3NlcnZpY2UubmFtZX19IiwKICAgICJNQVJBVEhPTl9TSU5HTEVfSU5TVEFOQ0VfQVBQIjogInRydWUiLAogICAgIkRDT1NfU0VSVklDRV9OQU1FIjogInt7c2VydmljZS5uYW1lfX0iLAogICAgIkRDT1NfU0VSVklDRV9QT1JUX0lOREVYIjogIjAiLAogICAgIkRDT1NfU0VSVklDRV9TQ0hFTUUiOiAiaHR0cCIKICB9LAogIHt7I3NlcnZpY2Uuc2VydmljZV9hY2NvdW50X3NlY3JldH19CiAgInNlY3JldHMiOiB7CiAgICAic2VydmljZUNyZWRlbnRpYWwiOiB7CiAgICAgICJzb3VyY2UiOiAie3tzZXJ2aWNlLnNlcnZpY2VfYWNjb3VudF9zZWNyZXR9fSIKICAgIH0KICB9LAogIHt7L3NlcnZpY2Uuc2VydmljZV9hY2NvdW50X3NlY3JldH19CiAgImVudiI6IHsKICAgICJCT09UU1RSQVBfVVJJIjogInt7cmVzb3VyY2UuYXNzZXRzLnVyaXMuYm9vdHN0cmFwLXppcH19IiwKICAgICJDT05GSUdfVEVNUExBVEVfUEFUSCI6ICJjb2Nrcm9hY2hkYi1zY2hlZHVsZXIiLAoKICAgICJGUkFNRVdPUktfTkFNRSI6ICJ7e3NlcnZpY2UubmFtZX19IiwKICAgICJGUkFNRVdPUktfVVNFUiI6ICJ7e3NlcnZpY2UudXNlcn19IiwKICAgICJGUkFNRVdPUktfUFJJTkNJUEFMIjogInt7c2VydmljZS5zZXJ2aWNlX2FjY291bnR9fSIsCiAgICAiQ09DS1JPQUNIX1VSSSI6ICJ7e3Jlc291cmNlLmFzc2V0cy51cmlzLmNvY2tyb2FjaC1iaW5hcnl9fS9jb2Nrcm9hY2gtdnt7c2VydmljZS52ZXJzaW9ufX0ubGludXgtYW1kNjQudGd6IiwKICAgICJDT0NLUk9BQ0hfVkVSU0lPTiI6ICJjb2Nrcm9hY2gtdnt7c2VydmljZS52ZXJzaW9ufX0ubGludXgtYW1kNjQiLAogICAgIkNPQ0tST0FDSF9DQUNIRV9TSVpFIjogInt7c2VydmljZS5jYWNoZV9zaXplfX0iLAogICAgIkNPQ0tST0FDSF9NQVhfU1FMX01FTU9SWSI6ICJ7e3NlcnZpY2UubWF4X3NxbF9tZW1vcnl9fSIsCiAgICAiQ09DS1JPQUNIX0hUVFBfUE9SVCI6ICJ7e3NlcnZpY2UuaHR0cF9wb3J0fX0iLAogICAgIkNPQ0tST0FDSF9QR19QT1JUIjogInt7c2VydmljZS5wZ19wb3J0fX0iLAogICAgIkNPTlRBSU5FUl9IVFRQX1BPUlQiOiAie3tzZXJ2aWNlLmNvbnRhaW5lcl9odHRwX3BvcnR9fSIsCiAgICAiQ09OVEFJTkVSX1BHX1BPUlQiOiAie3tzZXJ2aWNlLmNvbnRhaW5lcl9wZ19wb3J0fX0iLAoKICAgICJOT0RFX0NPVU5UIjogInt7bm9kZS5jb3VudH19IiwKICAgICJOT0RFX1BMQUNFTUVOVCI6ICJ7e25vZGUucGxhY2VtZW50X2NvbnN0cmFpbnR9fSIsCiAgICB7eyNzZXJ2aWNlLnZpcnR1YWxfbmV0d29ya319CiAgICAiRU5BQkxFX1ZJUlRVQUxfTkVUV09SSyI6ICJ5ZXMiLAogICAge3svc2VydmljZS52aXJ0dWFsX25ldHdvcmt9fQogICAgIk5PREVfQ1BVUyI6ICJ7e25vZGUuY3B1c319IiwKICAgICJOT0RFX01FTSI6ICJ7e25vZGUubWVtfX0iLAogICAgIk5PREVfRElTSyI6ICJ7e25vZGUuZGlza319IiwKICAgICJOT0RFX0RJU0tfVFlQRSI6ICJ7e25vZGUuZGlza190eXBlfX0iLAogICAgIlNJREVfQ09VTlQiOiAie3tzaWRlLmNvdW50fX0iLAogICAgIlNJREVfQ1BVUyI6ICJ7e3NpZGUuY3B1c319IiwKICAgICJTSURFX01FTSI6ICJ7e3NpZGUubWVtfX0iLAogICAgIlNJREVfRElTSyI6ICJ7e3NpZGUuZGlza319IiwKICAgICJTSURFX0RJU0tfVFlQRSI6ICJ7e3NpZGUuZGlza190eXBlfX0iLAoKICAgIHt7I3NlcnZpY2Uuc2VydmljZV9hY2NvdW50X3NlY3JldH19CiAgICAiRENPU19TRVJWSUNFX0FDQ09VTlRfQ1JFREVOVElBTCI6IHsgInNlY3JldCI6ICJzZXJ2aWNlQ3JlZGVudGlhbCIgfSwKICAgICJNRVNPU19NT0RVTEVTIjogIntcImxpYnJhcmllc1wiOiBbe1wiZmlsZVwiOiBcImxpYmRjb3Nfc2VjdXJpdHkuc29cIiwgXCJtb2R1bGVzXCI6IFt7XCJuYW1lXCI6IFwiY29tX21lc29zcGhlcmVfZGNvc19DbGFzc2ljUlBDQXV0aGVudGljYXRlZVwifV19XX0iLAogICAgIk1FU09TX0FVVEhFTlRJQ0FURUUiOiAiY29tX21lc29zcGhlcmVfZGNvc19DbGFzc2ljUlBDQXV0aGVudGljYXRlZSIsCiAgICB7ey9zZXJ2aWNlLnNlcnZpY2VfYWNjb3VudF9zZWNyZXR9fQoKICAgICJKQVZBX1VSSSI6ICJ7e3Jlc291cmNlLmFzc2V0cy51cmlzLmpyZS10YXItZ3p9fSIsCiAgICAiRVhFQ1VUT1JfVVJJIjogInt7cmVzb3VyY2UuYXNzZXRzLnVyaXMuZXhlY3V0b3ItemlwfX0iLAogICAgIkxJQk1FU09TX1VSSSI6ICJ7e3Jlc291cmNlLmFzc2V0cy51cmlzLmxpYm1lc29zLWJ1bmRsZS10YXItZ3p9fSIKICB9LAogICJ1cmlzIjogWwogICAgInt7cmVzb3VyY2UuYXNzZXRzLnVyaXMuanJlLXRhci1nen19IiwKICAgICJ7e3Jlc291cmNlLmFzc2V0cy51cmlzLnNjaGVkdWxlci16aXB9fSIsCiAgICAie3tyZXNvdXJjZS5hc3NldHMudXJpcy5saWJtZXNvcy1idW5kbGUtdGFyLWd6fX0iCiAgXSwKICAidXBncmFkZVN0cmF0ZWd5Ijp7CiAgICAibWluaW11bUhlYWx0aENhcGFjaXR5IjogMCwKICAgICJtYXhpbXVtT3ZlckNhcGFjaXR5IjogMAogIH0sCiAgImhlYWx0aENoZWNrcyI6IFsKICAgIHsKICAgICAgInByb3RvY29sIjogIkhUVFAiLAogICAgICAicGF0aCI6ICIvdjEvcGxhbnMvZGVwbG95IiwKICAgICAgImdyYWNlUGVyaW9kU2Vjb25kcyI6IDkwMCwKICAgICAgImludGVydmFsU2Vjb25kcyI6IDMwLAogICAgICAicG9ydEluZGV4IjogMCwKICAgICAgInRpbWVvdXRTZWNvbmRzIjogMzAsCiAgICAgICJtYXhDb25zZWN1dGl2ZUZhaWx1cmVzIjogMAogICAgfSwKICAgIHsKICAgICAgInByb3RvY29sIjogIkhUVFAiLAogICAgICAicGF0aCI6ICIvdjEvcGxhbnMvcmVjb3ZlcnkiLAogICAgICAiZ3JhY2VQZXJpb2RTZWNvbmRzIjogOTAwLAogICAgICAiaW50ZXJ2YWxTZWNvbmRzIjogMzAsCiAgICAgICJwb3J0SW5kZXgiOiAwLAogICAgICAidGltZW91dFNlY29uZHMiOiAzMCwKICAgICAgIm1heENvbnNlY3V0aXZlRmFpbHVyZXMiOiAwCiAgICB9CiAgXSwKICAicG9ydERlZmluaXRpb25zIjogWwogICAgewogICAgICAicG9ydCI6IDAsCiAgICAgICJwcm90b2NvbCI6ICJ0Y3AiLAogICAgICAibmFtZSI6ICJhcGkiLAogICAgICAibGFiZWxzIjogeyAiVklQXzAiOiAiL2FwaS57e3NlcnZpY2UubmFtZX19OjgwIiB9CiAgICB9CiAgXQp9Cg==\'}, \'config\': {\'type\': \'object\', \'properties\': {\'service\': {\'type\': \'object\', \'description\': \'DC/OS service configuration properties\', \'properties\': {\'name\': {\'title\': \'Service name\', \'description\': \'The name of the service instance\', \'type\': \'string\', \'default\': \'cockroachdb\'}, \'user\': {\'title\': \'User\', \'description\': \'The user that the service will run as.\', \'type\': \'string\', \'default\': \'root\'}, \'service_account\': {\'description\': \'The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.\', \'type\': \'string\', \'default\': \'\'}, \'service_account_secret\': {\'description\': \'Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.\', \'type\': \'string\', \'default\': \'\'}, \'version\': {\'title\': \'CockroachDB version\', \'description\': \'Production release version of CockroachDB\', \'type\': \'string\', \'default\': \'1.1.3\'}, \'cache_size\': {\'title\': \'CockroachDB cache size\', \'description\': \'Cache size to be used by CockroachDB\', \'type\': \'string\', \'default\': \'25%\'}, \'max_sql_memory\': {\'title\': \'CockroachDB max SQL memory\', \'description\': \'Maximum amount of memory for CockroachDB to use for processing SQL queries\', \'type\': \'string\', \'default\': \'25%\'}, \'http_port\': {\'title\': \'CockroachDB HTTP Port\', \'description\': \'Port for CockroachDB admin UI\', \'type\': \'number\', \'default\': 80}, \'pg_port\': {\'title\': \'CockroachDB PG Port\', \'description\': \'Port for CockroachDB client communication\', \'type\': \'number\', \'default\': 26257}, \'container_http_port\': {\'title\': \'Container HTTP Port\', \'description\': \'Container port for CockroachDB admin UI. This port MUST be available on the host machine.\', \'type\': \'number\', \'default\': 8123}, \'container_pg_port\': {\'title\': \'Container PG Port\', \'description\': \'Container port for CockroachDB client communication. This port MUST be available on the host machine.\', \'type\': \'number\', \'default\': 26257}, \'virtual_network\': {\'description\': \'Enable DC/OS Virtual Network\', \'type\': \'boolean\', \'default\': False}}, \'required\': [\'name\', \'user\']}, \'node\': {\'description\': \'Template pod configuration properties\', \'type\': \'object\', \'properties\': {\'count\': {\'title\': \'Node count\', \'description\': \'Number of Template pods to run\', \'type\': \'integer\', \'default\': 3}, \'placement_constraint\': {\'title\': \'Placement constraint\', \'description\': "Marathon-style placement constraint for nodes. Example: \'hostname:UNIQUE\'", \'type\': \'string\', \'default\': \'hostname:UNIQUE\'}, \'cpus\': {\'title\': \'CPU count\', \'description\': \'Template pod CPU requirements\', \'type\': \'number\', \'default\': 1.0}, \'mem\': {\'title\': \'Memory size (MB)\', \'description\': \'Template pod mem requirements (in MB)\', \'type\': \'integer\', \'default\': 3000}, \'disk\': {\'title\': \'Disk size (MB)\', \'description\': \'Template pod persistent disk requirements (in MB)\', \'type\': \'integer\', \'default\': 5000}, \'disk_type\': {\'title\': \'Disk type [ROOT, MOUNT]\', \'description\': \'Mount volumes require preconfiguration in DC/OS\', \'enum\': [\'ROOT\', \'MOUNT\'], \'default\': \'ROOT\'}}, \'required\': [\'count\', \'cpus\', \'mem\', \'disk\', \'disk_type\']}, \'side\': {\'description\': \'Template pod configuration properties\', \'type\': \'object\', \'properties\': {\'count\': {\'title\': \'Node count\', \'description\': \'Number of Template pods to run\', \'type\': \'integer\', \'default\': 1}, \'cpus\': {\'title\': \'CPU count\', \'description\': \'Template pod CPU requirements\', \'type\': \'number\', \'default\': 1}, \'mem\': {\'title\': \'Memory size (MB)\', \'description\': \'Template pod mem requirements (in MB)\', \'type\': \'integer\', \'default\': 1000}, \'disk\': {\'title\': \'Disk size (MB)\', \'description\': \'Template pod persistent disk requirements (in MB)\', \'type\': \'integer\', \'default\': 5000}, \'disk_type\': {\'title\': \'Disk type [ROOT, MOUNT]\', \'description\': \'Mount volumes require preconfiguration in DC/OS\', \'enum\': [\'ROOT\', \'MOUNT\'], \'default\': \'ROOT\'}}, \'required\': [\'count\', \'cpus\', \'mem\', \'disk\', \'disk_type\']}}}} is not valid under any of the given schemas'>]
```

After the change, it prints out this much more actionable error:

```
Repo /Users/alex/go/src/github.com/mesosphere/universe/scripts/../target/repo-up-to-1.10.json version v4 validation errors: [0, 'additionalProperties']: Additional properties are not allowed ('minDcosReleaseVersion' was unexpected)
[0, 'properties', 'packagingVersion', 'enum']: '4.0' is not one of ['2.0']
[0, 'properties', 'resource', 'additionalProperties']: Additional properties are not allowed ('cli' was unexpected)
[1, 'properties', 'packagingVersion', 'enum']: '4.0' is not one of ['3.0']
[1, 'properties', 'resource', 'properties', 'cli', 'properties', 'binaries', 'properties', 'darwin', 'properties', 'x86-64', 'properties', 'url', 'allOf', 1, 'pattern']: 'dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli-darwin' does not match '^https?://'
[1, 'properties', 'resource', 'properties', 'cli', 'properties', 'binaries', 'properties', 'linux', 'properties', 'x86-64', 'properties', 'url', 'allOf', 1, 'pattern']: 'dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli-linux' does not match '^https?://'
[1, 'properties', 'resource', 'properties', 'cli', 'properties', 'binaries', 'properties', 'windows', 'properties', 'x86-64', 'properties', 'url', 'allOf', 1, 'pattern']: 'dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli.exe' does not match '^https?://'
[2, 'properties', 'resource', 'properties', 'cli', 'properties', 'binaries', 'properties', 'darwin', 'properties', 'x86-64', 'properties', 'url', 'allOf', 1, 'pattern']: 'dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli-darwin' does not match '^https?://'
[2, 'properties', 'resource', 'properties', 'cli', 'properties', 'binaries', 'properties', 'linux', 'properties', 'x86-64', 'properties', 'url', 'allOf', 1, 'pattern']: 'dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli-linux' does not match '^https?://'
[2, 'properties', 'resource', 'properties', 'cli', 'properties', 'binaries', 'properties', 'windows', 'properties', 'x86-64', 'properties', 'url', 'allOf', 1, 'pattern']: 'dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli.exe' does not match '^https?://'
```

@takirala