### PR TITLE
Fix S3 URLs in CockroachDB package.

### DIFF
--- a/repo/packages/C/cockroachdb/1/resource.json
+++ b/repo/packages/C/cockroachdb/1/resource.json
@@ -3,9 +3,9 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u152-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
-      "scheduler-zip": "https://dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/cockroachdb-scheduler.zip",
-      "executor-zip": "https://dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/executor.zip",
-      "bootstrap-zip": "https://dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/bootstrap.zip",
+      "scheduler-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/1.1.3-1.1.3/cockroachdb-scheduler.zip",
+      "executor-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/1.1.3-1.1.3/executor.zip",
+      "bootstrap-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/1.1.3-1.1.3/bootstrap.zip",
       "cockroach-binary": "https://binaries.cockroachdb.com"
     }
   },
@@ -25,7 +25,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli-darwin"
+          "url": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -37,7 +37,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli-linux"
+          "url": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -49,7 +49,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://dcos-cockroachdb.s3-us-east-1.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli.exe"
+          "url": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/1.1.3-1.1.3/dcos-service-cli.exe"
         }
       }
     }


### PR DESCRIPTION
@ryadav88 I'm sorry for getting this wrong the first time -- region us-east-1 is apparently unique amongst S3 regions in not supporting the `s3-<region>.amazonaws.com` URLs ([official docs](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region), [second source](https://stackoverflow.com/questions/26604977/url-for-public-amazon-s3-bucket)). It's doubly weird, even, because `s3.us-east-1.amazonaws.com` works despite not being documented, but `s3-us-east-1` doesn't...

I'm not sure whether this is something that should merit making a new version of the package or just updating the existing one, but the existing one is unable to download its resources.