### PR TITLE
Correct SHAs for beta-confluent-kafka

### DIFF
--- a/repo/packages/B/beta-confluent-kafka/6/resource.json
+++ b/repo/packages/B/beta-confluent-kafka/6/resource.json
@@ -27,7 +27,7 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "6cbf83f66646cc7e3dc85c22a3c1d600108e822e96fac2f59b7db2590b97b7bc"
+              "value": "9f57666a357d6d280504cc4a838fb5394179f1e72d36bdebaa06b3910fdf03c6"
             }
           ],
           "kind": "executable",
@@ -39,7 +39,7 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "c2b958cfe578be7859de077ca698446968f2fd0a1d72c610b29fa924a0503517"
+              "value": "63d4a03ab9c737687b45faf8de9af37aa3013799a3d514250e571a7505fc3a82"
             }
           ],
           "kind": "executable",
@@ -51,7 +51,7 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "4d105450e34ac6c8da280c400b91939111904359cb9307bef5c259d4ef964be1"
+              "value": "eae5dfe8f90dcfe47ffba68363e2501ee782ce0434a6a026f8906240807ee10b"
             }
           ],
           "kind": "executable",


### PR DESCRIPTION
This PR corrects the SHAs for the `beta-confluent-kafka` CLI artefacts that were added as part of #1592.