### PR TITLE
Create beta-marathon-lb Package

### DIFF
--- a/repo/packages/B/beta-marathon-lb/0/config.json
+++ b/repo/packages/B/beta-marathon-lb/0/config.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "marathon-lb": {
+      "properties": {
+        "auto-assign-service-ports": {
+          "default": false,
+          "description": "Auto assign service ports for tasks which use IP-per-task. See https://github.com/mesosphere/marathon-lb#mesos-with-ip-per-task-support for details.",
+          "type": "boolean"
+        },
+        "bind-http-https": {
+          "default": true,
+          "description": "Reserve ports 80 and 443 for the LB. Use this if you intend to use virtual hosts.",
+          "type": "boolean"
+        },
+        "cpus": {
+          "default": 2,
+          "description": "CPU shares to allocate to each marathon-lb instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "haproxy_global_default_options": {
+          "description": "Default global options for HAProxy.",
+          "type": "string",
+          "default": "redispatch,http-server-close,dontlognull"
+        },
+        "haproxy-group": {
+          "default": "external",
+          "description": "HAProxy group parameter. Matches with HAPROXY_GROUP in the app labels.",
+          "type": "string"
+        },
+        "haproxy-map": {
+          "default": true,
+          "description": "Enable HAProxy VHost maps for fast VHost routing.",
+          "type": "boolean"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "mem": {
+          "default": 1024.0,
+          "description": "Memory (MB) to allocate to each marathon-lb task.",
+          "minimum": 256.0,
+          "type": "number"
+        },
+        "minimumHealthCapacity": {
+          "default": 0.5,
+          "description": "Minimum health capacity.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "maximumOverCapacity": {
+          "default": 0.2,
+          "description": "Maximum over capacity.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "name": {
+          "default": "marathon-lb",
+          "description": "Name for this LB instance",
+          "type": "string"
+        },
+        "parameters": {
+            "description": "Docker parameters",
+            "type": "array",
+            "items": {
+               "type": "object",
+               "properties": {
+                   "key": {
+                       "type": "string"
+                   },
+                   "value": {
+                       "type": "string"
+                   }
+               },
+               "required": [
+                   "key",
+                   "value"
+               ]
+           },
+           "default": []
+        },
+        "role": {
+          "default": "slave_public",
+          "description": "Deploy marathon-lb only on nodes with this role.",
+          "type": "string"
+        },
+        "ssl-cert": {
+          "description": "TLS Cert and private key for HTTPS.",
+          "type": "string"
+        },
+        "strict-mode": {
+          "default": false,
+          "description": "Enable strict mode. This requires that you explicitly enable each backend with `HAPROXY_{n}_ENABLED=true`.",
+          "type": "boolean"
+        },
+        "sysctl-params": {
+          "default": "net.ipv4.tcp_tw_reuse=1 net.ipv4.tcp_fin_timeout=30 net.ipv4.tcp_max_syn_backlog=10240 net.ipv4.tcp_max_tw_buckets=400000 net.ipv4.tcp_max_orphans=60000 net.core.somaxconn=10000",
+          "description": "sysctl params to set at startup for HAProxy.",
+          "type": "string"
+        },
+        "container-syslogd": {
+          "default": false,
+          "description": "Enable verbose syslogd logging to container stdout. This will also capture all HAProxy http connection and other logs.",
+          "type": "boolean"
+        },
+        "max-reload-retries": {
+          "default": 10,
+          "description": "Max reload retries before failure. Reloads happen every --reload-interval seconds. Set to 0 to disable or -1 for infinite retries.",
+          "type": "integer"
+        },
+        "reload-interval": {
+          "default": 10,
+          "description": "When retry-reload enabled, wait this long before attempting another reload.",
+          "type": "integer"
+        },
+        "template-url": {
+          "default": "",
+          "description": "URL to tarball containing a directory templates/ to customize haproxy config.",
+          "type": "string"
+        },
+        "marathon-uri": {
+          "default": "http://marathon.mesos:8080",
+          "description": "URI of Marathon instance",
+          "type": "string"
+        },
+        "secret_name": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": ["cpus", "mem", "haproxy-group", "instances", "name"],
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/B/beta-marathon-lb/0/config.json
+++ b/repo/packages/B/beta-marathon-lb/0/config.json
@@ -58,6 +58,11 @@
           "minimum": 0,
           "type": "number"
         },
+        "mount-dev-log": {
+          "default": true,
+          "description": "Mount /dev/log into the container.",
+          "type": "boolean"
+        },
         "name": {
           "default": "marathon-lb",
           "description": "Name for this LB instance",

--- a/repo/packages/B/beta-marathon-lb/0/marathon.json.mustache
+++ b/repo/packages/B/beta-marathon-lb/0/marathon.json.mustache
@@ -1,0 +1,264 @@
+{
+  "id": "{{marathon-lb.name}}",
+  "instances": {{marathon-lb.instances}},
+  "cpus": {{marathon-lb.cpus}},
+  "mem": {{marathon-lb.mem}},
+  "maintainer": "support@mesosphere.io",
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "{{resource.assets.container.docker.marathon-lb-docker}}",
+      "network": "HOST",
+      "privileged": true,
+      "parameters": [
+      {{#marathon-lb.parameters}}
+        {
+          "key": "{{key}}",
+          "value": "{{value}}"
+        },
+      {{/marathon-lb.parameters}}
+        {
+          "key": "label",
+          "value": "created_by=marathon"
+        },
+        {
+          "key": "label",
+          "value": "dcos_pkg_name=marathon-lb"
+        }
+      ]
+    }
+  },
+  {{#marathon-lb.role}}
+  "acceptedResourceRoles": [
+    "{{marathon-lb.role}}"
+  ],
+  {{/marathon-lb.role}}
+  "healthChecks": [
+    {
+      "path": "/_haproxy_health_check",
+  {{#marathon-lb.bind-http-https}}
+      "portIndex": 2,
+  {{/marathon-lb.bind-http-https}}
+  {{^marathon-lb.bind-http-https}}
+      "portIndex": 0,
+  {{/marathon-lb.bind-http-https}}
+      "protocol": "HTTP",
+      "gracePeriodSeconds": 60,
+      "intervalSeconds": 5,
+      "timeoutSeconds": 2,
+      "maxConsecutiveFailures": 2,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": {{marathon-lb.minimumHealthCapacity}},
+    "maximumOverCapacity": {{marathon-lb.maximumOverCapacity}}
+  },
+  "args":[
+    "sse",
+    "-m", "{{marathon-lb.marathon-uri}}",
+    "--health-check",
+  {{^marathon-lb.bind-http-https}}
+    "--dont-bind-http-https",
+  {{/marathon-lb.bind-http-https}}
+  {{#marathon-lb.haproxy-map}}
+    "--haproxy-map",
+  {{/marathon-lb.haproxy-map}}
+  {{#marathon-lb.auto-assign-service-ports}}
+    "--min-serv-port-ip-per-task", "10101",
+    "--max-serv-port-ip-per-task", "10150",
+  {{/marathon-lb.auto-assign-service-ports}}
+  {{#marathon-lb.strict-mode}}
+    "--strict-mode",
+  {{/marathon-lb.strict-mode}}
+    "--max-reload-retries", "{{marathon-lb.max-reload-retries}}",
+    "--reload-interval", "{{marathon-lb.reload-interval}}",
+    "--group", "{{marathon-lb.haproxy-group}}"
+  ],
+  "requirePorts":true,
+  {{#marathon-lb.template-url}}
+  "uris": [ "{{marathon-lb.template-url}}" ],
+  {{/marathon-lb.template-url}}
+  "env": {
+    {{#marathon-lb.secret_name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    {{/marathon-lb.secret_name}}
+    {{#marathon-lb.haproxy_global_default_options}}
+    "HAPROXY_GLOBAL_DEFAULT_OPTIONS": "{{marathon-lb.haproxy_global_default_options}}",
+    {{/marathon-lb.haproxy_global_default_options}}
+    "HAPROXY_SSL_CERT": "{{marathon-lb.ssl-cert}}",
+    {{#marathon-lb.container-syslogd}}
+    "HAPROXY_SYSLOGD": "{{marathon-lb.container-syslogd}}",
+    {{/marathon-lb.container-syslogd}}
+    "HAPROXY_SYSCTL_PARAMS": "{{marathon-lb.sysctl-params}}"
+  },
+  {{#marathon-lb.secret_name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{marathon-lb.secret_name}}"
+    }
+  },
+  {{/marathon-lb.secret_name}}
+  "ports": [
+  {{#marathon-lb.bind-http-https}}
+    80,
+    443,
+  {{/marathon-lb.bind-http-https}}
+    9090,
+    9091,
+    10000,
+    10001,
+    10002,
+    10003,
+    10004,
+    10005,
+    10006,
+    10007,
+    10008,
+    10009,
+    10010,
+    10011,
+    10012,
+    10013,
+    10014,
+    10015,
+    10016,
+    10017,
+    10018,
+    10019,
+    10020,
+    10021,
+    10022,
+    10023,
+    10024,
+    10025,
+    10026,
+    10027,
+    10028,
+    10029,
+    10030,
+    10031,
+    10032,
+    10033,
+    10034,
+    10035,
+    10036,
+    10037,
+    10038,
+    10039,
+    10040,
+    10041,
+    10042,
+    10043,
+    10044,
+    10045,
+    10046,
+    10047,
+    10048,
+    10049,
+    10050,
+    10051,
+    10052,
+    10053,
+    10054,
+    10055,
+    10056,
+    10057,
+    10058,
+    10059,
+    10060,
+    10061,
+    10062,
+    10063,
+    10064,
+    10065,
+    10066,
+    10067,
+    10068,
+    10069,
+    10070,
+    10071,
+    10072,
+    10073,
+    10074,
+    10075,
+    10076,
+    10077,
+    10078,
+    10079,
+    10080,
+    10081,
+    10082,
+    10083,
+    10084,
+    10085,
+    10086,
+    10087,
+    10088,
+    10089,
+    10090,
+    10091,
+    10092,
+    10093,
+    10094,
+    10095,
+    10096,
+    10097,
+    10098,
+    10099,
+    10100
+  {{#marathon-lb.auto-assign-service-ports}}
+    ,
+    10101,
+    10102,
+    10103,
+    10104,
+    10105,
+    10106,
+    10107,
+    10108,
+    10109,
+    10110,
+    10111,
+    10112,
+    10113,
+    10114,
+    10115,
+    10116,
+    10117,
+    10118,
+    10119,
+    10120,
+    10121,
+    10122,
+    10123,
+    10124,
+    10125,
+    10126,
+    10127,
+    10128,
+    10129,
+    10130,
+    10131,
+    10132,
+    10133,
+    10134,
+    10135,
+    10136,
+    10137,
+    10138,
+    10139,
+    10140,
+    10141,
+    10142,
+    10143,
+    10144,
+    10145,
+    10146,
+    10147,
+    10148,
+    10149,
+    10150
+  {{/marathon-lb.auto-assign-service-ports}}
+  ]
+}

--- a/repo/packages/B/beta-marathon-lb/0/marathon.json.mustache
+++ b/repo/packages/B/beta-marathon-lb/0/marathon.json.mustache
@@ -6,6 +6,15 @@
   "maintainer": "support@mesosphere.io",
   "container": {
     "type": "DOCKER",
+    {{#marathon-lb.mount-dev-log}}
+    "volumes": [
+      {
+        "containerPath": "/dev/log",
+        "hostPath": "/dev/log",
+        "mode": "RW"
+      }
+    ],
+    {{/marathon-lb.mount-dev-log}}
     "docker": {
       "image": "{{resource.assets.container.docker.marathon-lb-docker}}",
       "network": "HOST",

--- a/repo/packages/B/beta-marathon-lb/0/package.json
+++ b/repo/packages/B/beta-marathon-lb/0/package.json
@@ -1,6 +1,6 @@
 {
   "packagingVersion": "4.0",
-  "name": "marathon-lb",
+  "name": "beta-marathon-lb",
   "version": "1.20.0-beta-1",
   "minDcosReleaseVersion": "1.9",
   "scm": "https://github.com/mesosphere/marathon-lb",

--- a/repo/packages/B/beta-marathon-lb/0/package.json
+++ b/repo/packages/B/beta-marathon-lb/0/package.json
@@ -1,0 +1,23 @@
+{
+  "packagingVersion": "4.0",
+  "name": "marathon-lb",
+  "version": "1.20.0-beta-1",
+  "minDcosReleaseVersion": "1.9",
+  "scm": "https://github.com/mesosphere/marathon-lb",
+  "description": "HAProxy configured using Marathon state",
+  "maintainer": "support@mesosphere.io",
+  "tags": ["loadbalancer", "service-discovery", "reverse-proxy", "proxy", "haproxy"],
+  "preInstallNotes": "We recommend at least 2 CPUs and 1GiB of RAM for each Marathon-LB instance. \n\n*NOTE*: For additional ```Enterprise Edition``` DC/OS instructions, see https://docs.mesosphere.com/administration/id-and-access-mgt/service-auth/mlb-auth/",
+  "postInstallNotes": "Marathon-lb DC/OS Service has been successfully installed!\nSee https://github.com/mesosphere/marathon-lb for documentation.",
+  "postUninstallNotes": "Marathon-lb DC/OS Service has been uninstalled and will no longer run.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/mesosphere/marathon/blob/master/LICENSE"
+    },
+    {
+      "name": "GNU General Public License version 2",
+      "url": "http://www.haproxy.org/download/1.6/doc/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/B/beta-marathon-lb/0/resource.json
+++ b/repo/packages/B/beta-marathon-lb/0/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-marathonlb-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-marathonlb-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-marathonlb-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "marathon-lb-docker": "mesosphere/marathon-lb:v1.12.0-beta-1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Create separate beta-marathon-lb package to test significant changes to Marathon-LB (in this case, new version of HAProxy: 1.8.2).

This is distinct from marathon-lb-rc, which is believed to be ready for release unless other bugs are found.