### PR TITLE
[datadog] fix healthcheck on 1.10 + update to 5.20.2

### DIFF
--- a/repo/packages/D/datadog/5/config.json
+++ b/repo/packages/D/datadog/5/config.json
@@ -1,0 +1,49 @@
+{
+    "properties": {
+        "datadog": {
+            "description": "Datadog specific configuration properties",
+            "properties": {
+                "api_key": {
+                    "description": "Your Datadog API key.",
+                    "type": "string"
+                },
+                "app_id": {
+                    "default": "datadog-agent",
+                    "description": "Marathon Application ID",
+                    "type": "string"
+                },
+                "cpus": {
+                    "default": 0.05,
+                    "description": "CPU shares to allocate to each Marathon instance.",
+                    "minimum": 0.0,
+                    "type": "number"
+                },
+                "instances": {
+                    "default": 1,
+                    "description": "Number of Marathon instances to run.",
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "mem": {
+                    "default": 256.0,
+                    "description": "Memory (MB) to allocate to each Marathon task.",
+                    "minimum": 256.0,
+                    "type": "number"
+                },
+                "statsd_port": {
+                    "default": 8125,
+                    "description": "statsD port",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "api_key"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "datadog"
+    ],
+    "type": "object"
+}

--- a/repo/packages/D/datadog/5/marathon.json.mustache
+++ b/repo/packages/D/datadog/5/marathon.json.mustache
@@ -1,0 +1,59 @@
+{
+    "id": "{{datadog.app_id}}",
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.dd-agent}}",
+            "parameters": [
+                {
+                    "key": "env", "value": "API_KEY={{datadog.api_key}}"
+                },
+                {
+                    "key": "env", "value": "MESOS_SLAVE=true"
+                },
+                {
+                    "key": "env", "value": "SD_BACKEND=docker"
+                }
+            ],
+            "network": "BRIDGE",
+            "portMappings": [
+                { "hostPort": {{datadog.statsd_port}}, "containerPort": 8125, "protocol": "udp" }
+            ]
+        },
+        "volumes": [
+            {
+                "containerPath": "/var/run/docker.sock",
+                "hostPath": "/var/run/docker.sock",
+                "mode": "RO"
+            },
+            {
+                "containerPath": "/host/proc",
+                "hostPath": "/proc",
+                "mode": "RO"
+            },
+            {
+                "containerPath": "/host/sys/fs/cgroup",
+                "hostPath": "/sys/fs/cgroup",
+                "mode": "RO"
+            }
+        ]
+    },
+    "cpus": {{datadog.cpus}},
+    "mem": {{datadog.mem}},
+    "instances": {{datadog.instances}},
+    "acceptedResourceRoles": ["slave_public", "*"],
+    "constraints": [
+        ["hostname", "UNIQUE"],
+        ["hostname", "GROUP_BY"]
+    ],
+    "healthChecks": [
+        {
+            "protocol": "COMMAND",
+            "command": { "value": "/probe.sh" },
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ]
+}

--- a/repo/packages/D/datadog/5/package.json
+++ b/repo/packages/D/datadog/5/package.json
@@ -1,0 +1,24 @@
+{
+    "packagingVersion": "3.0",
+    "minDcosReleaseVersion" : "1.8",
+    "description": "Datadog is a hosted monitoring service for cloud-scale infrastructure and applications",
+    "framework": false,
+    "licenses": [
+        {
+            "name": "Simplified BSD license",
+            "url": "https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE"
+        }
+    ],
+    "maintainer": "package@datadoghq.com",
+    "name": "datadog",
+    "postInstallNotes": "Datadog on DCOS successfully installed.\nHead over to https://app.datadoghq.com to monitor your DCOS cluster.",
+    "postUninstallNotes": "Datadog on DCOS successfully uninstalled.\n.",
+    "preInstallNotes": "This DC/OS Service is currently in preview. \n Pass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api \nAlso pass the number of Mesos slaves as an option (datadog.instances).\nMarathon will make sure that the Datadog Agent runs only once per slave.",
+    "scm": "https://github.com/datadog/dd-agent.git",
+    "tags": [
+        "datadog",
+        "monitoring"
+    ],
+    "version": "5.20.2",
+    "website": "https://www.datadoghq.com/"
+}

--- a/repo/packages/D/datadog/5/resource.json
+++ b/repo/packages/D/datadog/5/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "dd-agent": "datadog/docker-dd-agent:12.4.5202"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-large.png"
+  }
+}


### PR DESCRIPTION
# Changes

- To work around the [DCOS 1.10 regression in marathon](https://jira.mesosphere.com/browse/MARATHON-7894), remove the fixed container name so the healthcheck will report OK
- Update version 5.20.2 (latest)
- Update metadata

See https://github.com/mesosphere/universe/pull/1430 for more context.

# Diff from rev 4
```diff
diff -u 4/marathon.json.mustache 5/marathon.json.mustache
--- 4/marathon.json.mustache	2017-12-15 17:01:08.000000000 +0100
+++ 5/marathon.json.mustache	2018-01-02 16:32:24.000000000 +0100
@@ -3,12 +3,9 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "{{resource.assets.container.docker.a5669b334fa2}}",
+            "image": "{{resource.assets.container.docker.dd-agent}}",
             "parameters": [
                 {
-                    "key": "name", "value": "dd-agent"
-                },
-                {
                     "key": "env", "value": "API_KEY={{datadog.api_key}}"
                 },
                 {
```
Remove fixed container name, use constant handle for image name.
```diff
diff -u 4/package.json 5/package.json
--- 4/package.json	2017-12-15 17:01:08.000000000 +0100
+++ 5/package.json	2018-01-02 16:32:14.000000000 +0100
@@ -13,12 +13,12 @@
     "name": "datadog",
     "postInstallNotes": "Datadog on DCOS successfully installed.\nHead over to https://app.datadoghq.com to monitor your DCOS cluster.",
     "postUninstallNotes": "Datadog on DCOS successfully uninstalled.\n.",
-    "preInstallNotes": "This DC/OS Service is currently in preview. \n Pass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api \nAlso pass the number of Mesos slaves as an option (datadog.instances).\nMarathon will make sure that the Datadog Agent runs only once per slave.\nDatadog package doesn't work on 1.10 clusters. This is a known issue and will be fixed by the Datadog team in the next revision.",
+    "preInstallNotes": "This DC/OS Service is currently in preview. \n Pass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api \nAlso pass the number of Mesos slaves as an option (datadog.instances).\nMarathon will make sure that the Datadog Agent runs only once per slave.",
     "scm": "https://github.com/datadog/dd-agent.git",
     "tags": [
         "datadog",
         "monitoring"
     ],
-    "version": "5.18.1",
+    "version": "5.20.2",
     "website": "https://www.datadoghq.com/"
 }
```
Update metadata and remove 1.10 compatibility note.
```diff
diff -u 4/resource.json 5/resource.json
--- 4/resource.json	2017-12-15 17:01:08.000000000 +0100
+++ 5/resource.json	2018-01-02 16:31:10.000000000 +0100
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "a5669b334fa2": "datadog/docker-dd-agent:12.4.5181"
+        "dd-agent": "datadog/docker-dd-agent:12.4.5202"
       }
     }
   },
```
Update version and use fixed handle for easier updates.