### PR TITLE
[DCOS-20214] Fix escape cascade

### DIFF
--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -70,7 +70,7 @@ def main():
     # create universe-by-version files for `dcos_versions`
     dcos_versions = ["1.6.1", "1.7", "1.8", "1.9", "1.10", "1.11"]
     [render_universe_by_version(
-        args.outdir, packages, version) for version in dcos_versions]
+        args.outdir, copy.deepcopy(packages), version) for version in dcos_versions]
 
 
 def render_universe_by_version(outdir, packages, version):


### PR DESCRIPTION
This PR is speculative, and requires that it be true that all processing necessary for a package is done as that package moves through gen_universe a single time (with a DC/OS version specified) and that the current cascading behavior is not required.