### PR TITLE
Bad interpreter error due to shebang length limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,10 @@ Full Instructions:
 
   ```bash
   scripts/build.sh
+  
+  OR
+  
+  scripts/build.sh /tmp/universe-venv (to override the python virtual env directory)
   ```
 
 3. Verify all build steps completed successfully
@@ -432,6 +436,10 @@ Docker image" status report to view the build results.
 1. Validate and build the Universe artifacts
   ```bash
   scripts/build.sh
+  
+  OR
+  
+  scripts/build.sh /tmp/universe-venv (to override the python virtual env directory)
   ```
 
 2. Build the Universe Server Docker image

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,7 +1,39 @@
 #!/bin/bash
 set -o errexit -o nounset -o pipefail
 
+####################
+#    VARIABLES     #
+####################
+
+SCRIPT_NAME=$(basename $0)
+
+####################
+#    FUNCTIONS     #
+####################
+
+# Usage function
+usage() {
+  echo "Usage : ${SCRIPT_NAME} [<VENV_BASE_DIR>]"
+  echo "Help  : ${SCRIPT_NAME} -h"
+  exit 1
+}
+
+####################
+#       MAIN       #
+####################
+
+if [ $# -ne 0 -a $# -ne 1 ]; then
+  usage
+fi
+
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ $# -ge 1 ]; then
+  VENV_BASE_DIR="$1"
+else
+  VENV_BASE_DIR="$SCRIPTS_DIR/target"
+fi
+
 REPO_BASE_DIR=${SCRIPTS_DIR}/..
 
 echo "Building the universe!"
@@ -9,15 +41,15 @@ echo "Building the universe!"
 mkdir -p ${REPO_BASE_DIR}/target/
 
 # Create a new virtual environment
-rm -rf ${REPO_BASE_DIR}/target/venv
-python3 -m venv ${REPO_BASE_DIR}/target/venv
+rm -rf ${VENV_BASE_DIR}/venv
+python3 -m venv ${VENV_BASE_DIR}/venv
 
 # Install dependencies
-${REPO_BASE_DIR}/target/venv/bin/pip install -r ${SCRIPTS_DIR}/requirements/requirements.txt
+${VENV_BASE_DIR}/venv/bin/pip install -r "${SCRIPTS_DIR}"/requirements/requirements.txt
 
-"${REPO_BASE_DIR}"/target/venv/bin/python3 "$SCRIPTS_DIR"/validate_packages.py
-"${REPO_BASE_DIR}"/target/venv/bin/python3 "$SCRIPTS_DIR"/gen_universe.py \
+"${VENV_BASE_DIR}"/venv/bin/python3 "$SCRIPTS_DIR"/validate_packages.py
+"${VENV_BASE_DIR}"/venv/bin/python3 "$SCRIPTS_DIR"/gen_universe.py \
   --repository="${REPO_BASE_DIR}"/repo/packages/ --out-dir="${REPO_BASE_DIR}"/target/
 
 # Delete virtual environment
-rm -rf ${REPO_BASE_DIR}/target/venv
+rm -rf ${VENV_BASE_DIR}/venv


### PR DESCRIPTION
Hello,

I would like to build the universe docker image using jenkins.
In jenkins the workspace is generated automatically and the path to this workspace is often very long.
Script build.sh use python virtual env which generates scripts with virtual interpreters. The length of interpreters path is higher than the limit fixed in the kernel.
The execution of the script displays the error below:
> Building the universe!
./scripts/build.sh: /home/jenkins/workspace/CIO-CICD_universe_master-62XQSPXRQGRFDUWO5R43GFK7YEQ3S6PLPSKHLOAQLZIWNKFP7HWQ/dcos-universe/scripts/target/venv/bin/pip: /home/jenkins/workspace/CIO-CICD_universe_master-62XQSPXRQGRFDUWO5R43GFK7YEQ3S: bad interpreter: No such file or directory

So I pushed this pull request to be able to set the path to the virtual env in argument.
If you execute the script build.sh without any argument the behavior will be the same as before.
If you execute the script build.sh with one argument, it will use this argument as the base path for virtual env.

Regards,