### PR TITLE
Jenkins Content Security Policy configuration

### DIFF
--- a/repo/packages/J/jenkins/24/config.json
+++ b/repo/packages/J/jenkins/24/config.json
@@ -131,6 +131,11 @@
                 "docker-credentials-uri": {
                     "description": "An optional URI to be fetched and extracted that contains docker credentials (e.g. file:///etc/docker/docker.tar.gz).",
                     "type": "string"
+                },
+                "content-security-policy": {
+                    "description": "Jenkins Content Security Policy (see: https://wiki.jenkins.io/display/JENKINS/Configuring+Content+Security+Policy)",
+                    "type": "string",
+                    "default": "sandbox; default-src 'none'; img-src 'self'; style-src 'self';"
                 }
             }
         }

--- a/repo/packages/J/jenkins/24/config.json
+++ b/repo/packages/J/jenkins/24/config.json
@@ -6,7 +6,7 @@
             "type": "object",
             "properties": {
                 "name": {
-                    "description": "The name of the service to display in the DC/OS dashboard.",
+                    "description": "The name of the service to display in the DC/OS dashboard. Cannot contain any of the following: uppercases, underscores, slashes, #s",
                     "type": "string",
                     "default": "jenkins"
                 },

--- a/repo/packages/J/jenkins/24/marathon.json.mustache
+++ b/repo/packages/J/jenkins/24/marathon.json.mustache
@@ -27,6 +27,7 @@
       {{/networking.virtual-host}}
       "JVM_OPTS": "{{advanced.jvm-opts}}",
       "JENKINS_OPTS": "{{advanced.jenkins-opts}}",
+      "JENKINS_CSP_OPTS": "{{{advanced.content-security-policy}}}",
       "SSH_KNOWN_HOSTS": "{{networking.known-hosts}}"
   },
   "portDefinitions": [
@@ -40,7 +41,7 @@
            "image": "{{advanced.docker-image}}",
        {{/advanced.docker-image}}
        {{^advanced.docker-image}}
-           "image": "{{resource.assets.container.docker.jenkins-340-2892}}",
+           "image": "{{resource.assets.container.docker.jenkins-341-2892}}",
        {{/advanced.docker-image}}
            "network" : "HOST"
        },

--- a/repo/packages/J/jenkins/24/package.json
+++ b/repo/packages/J/jenkins/24/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "3.0",
   "name": "jenkins",
-  "version": "3.4.0-2.89.2",
+  "version": "3.4.1-2.89.2",
   "minDcosReleaseVersion": "1.8",
   "scm": "https://github.com/mesosphere/dcos-jenkins-service.git",
   "maintainer": "support@mesosphere.io",

--- a/repo/packages/J/jenkins/24/resource.json
+++ b/repo/packages/J/jenkins/24/resource.json
@@ -7,7 +7,7 @@
   "assets": {
     "container": {
       "docker": {
-        "jenkins-340-2892": "mesosphere/jenkins:3.4.0-2.89.2"
+        "jenkins-341-2892": "mesosphere/jenkins:3.4.1-2.89.2"
       }
     }
   }


### PR DESCRIPTION
Pass through the Jenkins Content Security Policy from the Universe configuration to the underlying package. See also: https://github.com/mesosphere/dcos-jenkins-service/pull/163