### PR TITLE
Changed releaseVersion to temporarily remove Eremetic.

### DIFF
--- a/repo/packages/E/eremetic/0/package.json
+++ b/repo/packages/E/eremetic/0/package.json
@@ -9,7 +9,7 @@
     }
   ],
   "maintainer" : "dcos-support@appliedis.com",
-  "minDcosReleaseVersion": "1.8",
+  "minDcosReleaseVersion": "999",
   "name": "eremetic",
   "packagingVersion": "3.0",
   "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production!",


### PR DESCRIPTION
If Eremetic package is deployed under a Marathon deployment group, it can cause the mesos-master process to crash and take Marathon down with it. Temporarily removing package from the Universe until the edge case that causes this can be resolved.
See https://jira.mesosphere.com/browse/COPS-2254