### PR TITLE
Release dcos-enterprise-cli 1.4.0

### DIFF
--- a/repo/packages/D/dcos-enterprise-cli/16/package.json
+++ b/repo/packages/D/dcos-enterprise-cli/16/package.json
@@ -1,0 +1,10 @@
+{
+  "packagingVersion": "3.0",
+  "name": "dcos-enterprise-cli",
+  "version": "1.4.0",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.11",
+  "description": "Enterprise DC/OS CLI",
+  "tags": [ "mesosphere", "enterprise", "subcommand" ],
+  "selected": true
+}

--- a/repo/packages/D/dcos-enterprise-cli/16/resource.json
+++ b/repo/packages/D/dcos-enterprise-cli/16/resource.json
@@ -1,0 +1,45 @@
+{
+    "assets": {
+    },
+
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "e714aa01a4484b934ab241f31f90bd3d99fd5eb935a315b895c4a6b510cfca84"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/darwin/x86-64/1.4.0/e714aa01a4484b934ab241f31f90bd3d99fd5eb935a315b895c4a6b510cfca84/dcos-enterprise-cli"
+                }
+            },
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "8535ec9761de2aafa5a8e0d7df03fb73bc854a2434b0332eb4b88d7c7caf3568"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/linux/x86-64/1.4.0/8535ec9761de2aafa5a8e0d7df03fb73bc854a2434b0332eb4b88d7c7caf3568/dcos-enterprise-cli"
+                }
+            },
+            "windows": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "9de817c931de5c9b54ddad561b94ced4559be0d41429ba0ced2ede89813142b5"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/windows/x86-64/1.4.0/9de817c931de5c9b54ddad561b94ced4559be0d41429ba0ced2ede89813142b5/dcos-enterprise-cli"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This includes the new `license` command and switches the `backup` command from Python to the Golang based one.