### PR TITLE
Release dcos-enterprise-cli 1.4.1

### DIFF
--- a/repo/packages/D/dcos-enterprise-cli/16/package.json
+++ b/repo/packages/D/dcos-enterprise-cli/16/package.json
@@ -1,0 +1,10 @@
+{
+  "packagingVersion": "3.0",
+  "name": "dcos-enterprise-cli",
+  "version": "1.4.1",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.11",
+  "description": "Enterprise DC/OS CLI",
+  "tags": [ "mesosphere", "enterprise", "subcommand" ],
+  "selected": true
+}

--- a/repo/packages/D/dcos-enterprise-cli/16/resource.json
+++ b/repo/packages/D/dcos-enterprise-cli/16/resource.json
@@ -1,0 +1,45 @@
+{
+    "assets": {
+    },
+
+    "cli": {
+        "binaries": {
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "be6fee90caa02764364842805d1dbf3eda131c8b7d2a66295361467bcdbf0c3e"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/linux/x86-64/1.4.1/be6fee90caa02764364842805d1dbf3eda131c8b7d2a66295361467bcdbf0c3e/dcos-enterprise-cli"
+                }
+            },
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "9664e17e82cb80dbfe39feffbff000a58ccd6becbbe4a02534def5ead57077ba"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/darwin/x86-64/1.4.1/9664e17e82cb80dbfe39feffbff000a58ccd6becbbe4a02534def5ead57077ba/dcos-enterprise-cli"
+                }
+            },
+            "windows": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "23e5d2a0404086b1e19c5c9f9ec213bcab95aa8c8865802cf1ad0b6087ee9581"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/windows/x86-64/1.4.1/23e5d2a0404086b1e19c5c9f9ec213bcab95aa8c8865802cf1ad0b6087ee9581/dcos-enterprise-cli"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This includes the new `license` command and switches the `backup` command from Python to the Golang based one.

It also includes a fix for the DCOS-20606 regression in `security`.