### PR TITLE
Eremetic framework fix

### DIFF
--- a/repo/packages/E/eremetic/0/config.json
+++ b/repo/packages/E/eremetic/0/config.json
@@ -9,7 +9,8 @@
         "framework-name": {
           "description": "The name of the Eremetic scheduler and service instance",
           "type": "string",
-          "default": "eremetic"
+          "default": "eremetic",
+          "pattern": "^[a-zA-Z0-9-]+$"
         },
         "cpus": {
           "description": "Number of cores allocated to Eremetic instance",

--- a/repo/packages/E/eremetic/0/marathon.json.mustache
+++ b/repo/packages/E/eremetic/0/marathon.json.mustache
@@ -43,8 +43,8 @@
 		"DATABASE_DRIVER": "zk",
 		"LOGLEVEL": "{{eremetic.log-level}}",
 		"QUEUE_SIZE": "{{eremetic.queue-size}}",
-		"FRAMEWORK_ID": "{{eremetic.framework-name}}1",
-		"URL_PREFIX": "/service/eremetic"
+		"FRAMEWORK_ID": "{{eremetic.framework-name}}",
+		"URL_PREFIX": "/service/{{eremetic.framework-name}}"
 	},
  	"labels": {
 		"DCOS_PACKAGE_FRAMEWORK_NAME": "{{eremetic.framework-name}}",

--- a/repo/packages/E/eremetic/0/package.json
+++ b/repo/packages/E/eremetic/0/package.json
@@ -9,7 +9,7 @@
     }
   ],
   "maintainer" : "dcos-support@appliedis.com",
-  "minDcosReleaseVersion": "999",
+  "minDcosReleaseVersion": "1.8",
   "name": "eremetic",
   "packagingVersion": "3.0",
   "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production!",


### PR DESCRIPTION
#1684: Resolves issue of framework id being specified with a '/' in the name. Prohibits specifying / in the `framework-name` config.json field.