### PR TITLE
[INFINITY-3076] Correct link in hello-world postUninstallNotes

### DIFF
--- a/repo/packages/B/beta-hello-world/0/package.json
+++ b/repo/packages/B/beta-hello-world/0/package.json
@@ -16,5 +16,5 @@
     ],
     "preInstallNotes": "This DC/OS Service is currently in preview.",
     "postInstallNotes": "The DC/OS hello-world service is being installed!\n\n\tDocumentation: https://github.com/mesosphere/dcos-commons/blob/master/frameworks/helloworld/README.md\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
 }

--- a/repo/packages/H/hello-world/100/package.json
+++ b/repo/packages/H/hello-world/100/package.json
@@ -20,5 +20,5 @@
   ],
   "preInstallNotes": "This DC/OS Service is currently in preview.",
   "postInstallNotes": "The DC/OS hello-world service is being installed!\n\n\tDocumentation: https://github.com/mesosphere/dcos-commons/blob/master/frameworks/helloworld/README.md\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
 }

--- a/repo/packages/H/hello-world/14/package.json
+++ b/repo/packages/H/hello-world/14/package.json
@@ -20,5 +20,5 @@
     ],
     "preInstallNotes": "This DC/OS Service is currently in preview.",
     "postInstallNotes": "The DC/OS hello-world service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/hello-world/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
 }

--- a/repo/packages/H/hello-world/15/package.json
+++ b/repo/packages/H/hello-world/15/package.json
@@ -20,5 +20,5 @@
     ],
     "preInstallNotes": "This DC/OS Service is currently in preview.",
     "postInstallNotes": "The DC/OS hello-world service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/hello-world/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
 }

--- a/repo/packages/H/hello-world/16/package.json
+++ b/repo/packages/H/hello-world/16/package.json
@@ -20,5 +20,5 @@
     ],
     "preInstallNotes": "This DC/OS Service is currently in preview.",
     "postInstallNotes": "The DC/OS hello-world service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/hello-world/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS hello-world service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/1.9/deploying-services/uninstall/#framework-cleaner to remove any persistent state if required."
 }


### PR DESCRIPTION
This PR corrects the `postUninstallNotes` for `hello-world` packages where the link to the `framework-cleaner` documentation was invalid.