### PR TITLE
Bump dcos-enterprise-cli to 1.4.2

### DIFF
--- a/repo/packages/D/dcos-enterprise-cli/17/package.json
+++ b/repo/packages/D/dcos-enterprise-cli/17/package.json
@@ -1,0 +1,10 @@
+{
+  "packagingVersion": "3.0",
+  "name": "dcos-enterprise-cli",
+  "version": "1.4.2",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.11",
+  "description": "Enterprise DC/OS CLI",
+  "tags": [ "mesosphere", "enterprise", "subcommand" ],
+  "selected": true
+}

--- a/repo/packages/D/dcos-enterprise-cli/17/resource.json
+++ b/repo/packages/D/dcos-enterprise-cli/17/resource.json
@@ -1,0 +1,45 @@
+{
+    "assets": {
+    },
+
+    "cli": {
+        "binaries": {
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "eda2e2e985de6c65b4967d622dc4fda21bd9b9e0740eeb309755421cf6b312bd"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/linux/x86-64/1.4.2/eda2e2e985de6c65b4967d622dc4fda21bd9b9e0740eeb309755421cf6b312bd/dcos-enterprise-cli"
+                }
+            },
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "b7f8357f960ada93c7ffc068b6e2dd670795b4973c55973a25592af7d87ec6a8"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/darwin/x86-64/1.4.2/b7f8357f960ada93c7ffc068b6e2dd670795b4973c55973a25592af7d87ec6a8/dcos-enterprise-cli"
+                }
+            },
+            "windows": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "5882b5aa7e32494c21ffcf4cf33873682d908587a74bb17e08d8666ef664613c"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/windows/x86-64/1.4.2/5882b5aa7e32494c21ffcf4cf33873682d908587a74bb17e08d8666ef664613c/dcos-enterprise-cli"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This improves error messages and fixes an exit code issue on some exceptions.