### PR TITLE
json scheme fix

### DIFF
--- a/repo/packages/B/beakerx/2/config.json
+++ b/repo/packages/B/beakerx/2/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
   "properties": {
     "service": {
       "type": "object",


### PR DESCRIPTION
issue is the json-schema definition for this package is missing an expected field in 1.11. 

The config.json should have type: object in the top level

causing a problem in the UI where everything will work expect form or config values won’t render

