### PR TITLE
Release dcos-enterprise-cli 1.4.3

### DIFF
--- a/repo/packages/D/dcos-enterprise-cli/18/package.json
+++ b/repo/packages/D/dcos-enterprise-cli/18/package.json
@@ -1,0 +1,10 @@
+{
+  "packagingVersion": "3.0",
+  "name": "dcos-enterprise-cli",
+  "version": "1.4.3",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.11",
+  "description": "Enterprise DC/OS CLI",
+  "tags": [ "mesosphere", "enterprise", "subcommand" ],
+  "selected": true
+}

--- a/repo/packages/D/dcos-enterprise-cli/18/resource.json
+++ b/repo/packages/D/dcos-enterprise-cli/18/resource.json
@@ -1,0 +1,45 @@
+{
+    "assets": {
+    },
+
+    "cli": {
+        "binaries": {
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "5f9f28ba39bec883a3f82d652a549dc06138f77b81c71aa6417d95d4024e55b7"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/linux/x86-64/1.4.3/5f9f28ba39bec883a3f82d652a549dc06138f77b81c71aa6417d95d4024e55b7/dcos-enterprise-cli"
+                }
+            },
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "c934ddb9624c27ad7723d234edb7fc9060d8a70dc43f5c7f99855c63dae0aac8"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/darwin/x86-64/1.4.3/c934ddb9624c27ad7723d234edb7fc9060d8a70dc43f5c7f99855c63dae0aac8/dcos-enterprise-cli"
+                }
+            },
+            "windows": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "1e1de506bde35384bdf300324d7fe0981e38aaf71b58a6a3ed1f30beca60980e"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.mesosphere.io/cli/binaries/windows/x86-64/1.4.3/1e1de506bde35384bdf300324d7fe0981e38aaf71b58a6a3ed1f30beca60980e/dcos-enterprise-cli"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
It bumps dcos-licensing-cli to :

- Fail when using --breaches with --terms simultaneously
- Retrieve all audit data when no license is passed
- Use custom error messages in case of 404