### PR TITLE
[datadog] update package to install Agent 6

### DIFF
--- a/repo/packages/D/datadog/6/config.json
+++ b/repo/packages/D/datadog/6/config.json
@@ -12,17 +12,17 @@
                     "description": "Marathon Application ID",
                     "type": "string"
                 },
-                "cpus": {
-                    "default": 0.05,
-                    "description": "CPU shares to allocate to each Marathon instance.",
-                    "minimum": 0.0,
-                    "type": "number"
-                },
                 "instances": {
                     "default": 1,
                     "description": "Number of Marathon instances to run.",
                     "minimum": 1,
                     "type": "integer"
+                },
+                "cpus": {
+                    "default": 0.05,
+                    "description": "CPU shares to allocate to each Marathon instance.",
+                    "minimum": 0.0,
+                    "type": "number"
                 },
                 "mem": {
                     "default": 256.0,
@@ -30,15 +30,21 @@
                     "minimum": 256.0,
                     "type": "number"
                 },
-                "statsd_non_local": {
-                    "default": false,
-                    "description": "Allow statsD non-local traffic (Agent6)",
-                    "type": "boolean"
-                },
-                "statsd_port": {
-                    "default": 8125,
-                    "description": "statsD port",
-                    "type": "integer"
+                "dogstatsd": {
+                  "description": "Dogstatsd (custom metrics) options",
+                  "type": "object",
+                  "properties": {
+                    "non_local_traffic": {
+                        "default": false,
+                        "description": "Allow statsD non-local traffic",
+                        "type": "boolean"
+                    },
+                    "port": {
+                        "default": 8125,
+                        "description": "UDP port to listen to",
+                        "type": "integer"
+                    }
+                  }
                 }
             },
             "required": [

--- a/repo/packages/D/datadog/6/config.json
+++ b/repo/packages/D/datadog/6/config.json
@@ -1,0 +1,54 @@
+{
+    "properties": {
+        "datadog": {
+            "description": "Datadog specific configuration properties",
+            "properties": {
+                "api_key": {
+                    "description": "Your Datadog API key.",
+                    "type": "string"
+                },
+                "app_id": {
+                    "default": "datadog-agent",
+                    "description": "Marathon Application ID",
+                    "type": "string"
+                },
+                "cpus": {
+                    "default": 0.05,
+                    "description": "CPU shares to allocate to each Marathon instance.",
+                    "minimum": 0.0,
+                    "type": "number"
+                },
+                "instances": {
+                    "default": 1,
+                    "description": "Number of Marathon instances to run.",
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "mem": {
+                    "default": 256.0,
+                    "description": "Memory (MB) to allocate to each Marathon task.",
+                    "minimum": 256.0,
+                    "type": "number"
+                },
+                "statsd_non_local": {
+                    "default": false,
+                    "description": "Allow statsD non-local traffic (Agent6)",
+                    "type": "boolean"
+                },
+                "statsd_port": {
+                    "default": 8125,
+                    "description": "statsD port",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "api_key"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "datadog"
+    ],
+    "type": "object"
+}

--- a/repo/packages/D/datadog/6/config.json
+++ b/repo/packages/D/datadog/6/config.json
@@ -1,8 +1,13 @@
 {
     "properties": {
         "datadog": {
-            "description": "Datadog specific configuration properties",
+            "description": "Datadog Agent configuration",
             "properties": {
+                "use_agent_5": {
+                    "description": "Install version 5.21 of the Agent",
+                    "type": "boolean",
+                    "default": false
+                },
                 "api_key": {
                     "description": "Your Datadog API key.",
                     "type": "string"

--- a/repo/packages/D/datadog/6/marathon.json.mustache
+++ b/repo/packages/D/datadog/6/marathon.json.mustache
@@ -14,9 +14,11 @@
                 {
                     "key": "env", "value": "DD_API_KEY={{datadog.api_key}}"
                 },
+                {{#datadog.use_agent_5}}
                 {
                     "key": "env", "value": "SD_BACKEND=docker"
                 },
+                {{/datadog.use_agent_5}}
                 {{#datadog.dogstatsd.non_local_traffic}}
                 {
                     "key": "env", "value": "DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true"

--- a/repo/packages/D/datadog/6/marathon.json.mustache
+++ b/repo/packages/D/datadog/6/marathon.json.mustache
@@ -11,19 +11,21 @@
                 {
                     "key": "env", "value": "SD_BACKEND=docker"
                 },
-                {{#statsd_non_local}}
+                {{#datadog.dogstatsd.non_local_traffic}}
                 {
                     "key": "env", "value": "DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true"
                 },
-                {{/statsd_non_local}}
+                {{/datadog.dogstatsd.non_local_traffic}}
                 {
                     "key": "env", "value": "MESOS_SLAVE=true"
                 }
             ],
-            "network": "BRIDGE",
             "portMappings": [
-                { "hostPort": {{datadog.statsd_port}}, "containerPort": 8125, "protocol": "udp" }
-            ]
+                {{#datadog.dogstatsd.non_local_traffic}}
+                { "hostPort": {{datadog.dogstatsd.port}}, "containerPort": 8125, "protocol": "udp" }
+                {{/datadog.dogstatsd.non_local_traffic}}
+            ],
+            "network": "BRIDGE"
         },
         "volumes": [
             {

--- a/repo/packages/D/datadog/6/marathon.json.mustache
+++ b/repo/packages/D/datadog/6/marathon.json.mustache
@@ -1,0 +1,64 @@
+{
+    "id": "{{datadog.app_id}}",
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            "image": "{{resource.assets.container.docker.dd-agent}}",
+            "parameters": [
+                {
+                    "key": "env", "value": "DD_API_KEY={{datadog.api_key}}"
+                },
+                {
+                    "key": "env", "value": "SD_BACKEND=docker"
+                },
+                {{#statsd_non_local}}
+                {
+                    "key": "env", "value": "DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true"
+                },
+                {{/statsd_non_local}}
+                {
+                    "key": "env", "value": "MESOS_SLAVE=true"
+                }
+            ],
+            "network": "BRIDGE",
+            "portMappings": [
+                { "hostPort": {{datadog.statsd_port}}, "containerPort": 8125, "protocol": "udp" }
+            ]
+        },
+        "volumes": [
+            {
+                "containerPath": "/var/run/docker.sock",
+                "hostPath": "/var/run/docker.sock",
+                "mode": "RO"
+            },
+            {
+                "containerPath": "/host/proc",
+                "hostPath": "/proc",
+                "mode": "RO"
+            },
+            {
+                "containerPath": "/host/sys/fs/cgroup",
+                "hostPath": "/sys/fs/cgroup",
+                "mode": "RO"
+            }
+        ]
+    },
+    "cpus": {{datadog.cpus}},
+    "mem": {{datadog.mem}},
+    "instances": {{datadog.instances}},
+    "acceptedResourceRoles": ["slave_public", "*"],
+    "constraints": [
+        ["hostname", "UNIQUE"],
+        ["hostname", "GROUP_BY"]
+    ],
+    "healthChecks": [
+        {
+            "protocol": "COMMAND",
+            "command": { "value": "/probe.sh" },
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ]
+}

--- a/repo/packages/D/datadog/6/marathon.json.mustache
+++ b/repo/packages/D/datadog/6/marathon.json.mustache
@@ -3,7 +3,13 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "{{resource.assets.container.docker.dd-agent}}",
+            {{#datadog.use_agent_5}}
+            "image": "{{resource.assets.container.docker.agent5}}",
+            {{/datadog.use_agent_5}}
+            {{^datadog.use_agent_5}}
+            "image": "{{resource.assets.container.docker.agent6}}",
+            "forcePullImage": true,
+            {{/datadog.use_agent_5}}
             "parameters": [
                 {
                     "key": "env", "value": "DD_API_KEY={{datadog.api_key}}"

--- a/repo/packages/D/datadog/6/package.json
+++ b/repo/packages/D/datadog/6/package.json
@@ -1,0 +1,24 @@
+{
+    "packagingVersion": "3.0",
+    "minDcosReleaseVersion" : "1.8",
+    "description": "Datadog is a hosted monitoring service for cloud-scale infrastructure and applications",
+    "framework": false,
+    "licenses": [
+        {
+            "name": "Apache License 2.0",
+            "url": "https://github.com/DataDog/datadog-agent/blob/master/LICENSE"
+        }
+    ],
+    "maintainer": "package@datadoghq.com",
+    "name": "datadog",
+    "postInstallNotes": "Datadog on DCOS successfully installed.\nHead over to https://app.datadoghq.com to monitor your DCOS cluster.",
+    "postUninstallNotes": "Datadog on DCOS successfully uninstalled.\n.",
+    "preInstallNotes": "This DC/OS Service is currently in preview. \n Pass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api \nAlso pass the number of Mesos slaves as an option (datadog.instances).\nMarathon will make sure that the Datadog Agent runs only once per slave.",
+    "scm": "https://github.com/datadog/dd-agent.git",
+    "tags": [
+        "datadog",
+        "monitoring"
+    ],
+    "version": "6.0.0rc1",
+    "website": "https://www.datadoghq.com/"
+}

--- a/repo/packages/D/datadog/6/package.json
+++ b/repo/packages/D/datadog/6/package.json
@@ -13,8 +13,8 @@
     "name": "datadog",
     "postInstallNotes": "Datadog on DCOS successfully installed.\nHead over to https://app.datadoghq.com to monitor your DCOS cluster.",
     "postUninstallNotes": "Datadog on DCOS successfully uninstalled.\n.",
-    "preInstallNotes": "This DC/OS Service is currently in preview. \n Pass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api \nAlso pass the number of Mesos slaves as an option (datadog.instances).\nMarathon will make sure that the Datadog Agent runs only once per slave.",
-    "scm": "https://github.com/datadog/dd-agent.git",
+    "preInstallNotes": "This package installs the new Agent 6 by default. You can revert to Agent 5 by enabling datadog.use_agent_5.\n\nPass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api\n\nAlso pass the number of Mesos slaves as an option (datadog.instances), Marathon will make sure that the Datadog Agent runs only once per slave.\n\nSee https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md for available options.",
+    "scm": "https://github.com/datadog/datadog-agent.git",
     "tags": [
         "datadog",
         "monitoring"

--- a/repo/packages/D/datadog/6/resource.json
+++ b/repo/packages/D/datadog/6/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "dd-agent": "datadog/agent-dev:master"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/universe/assets/icon-service-datadog-large.png"
+  }
+}

--- a/repo/packages/D/datadog/6/resource.json
+++ b/repo/packages/D/datadog/6/resource.json
@@ -2,7 +2,8 @@
   "assets": {
     "container": {
       "docker": {
-        "dd-agent": "datadog/agent-dev:master"
+        "agent5": "datadog/docker-dd-agent:12.5.5212",
+        "agent6": "datadog/agent:latest"
       }
     }
   },


### PR DESCRIPTION
Differences from package version 5:

- Enable installation of `6.0.0rc1` by default, add a `use_agent_5` option to install agent 5.21 instead
- Agent6 changes the default behaviour from listening to all interfaces for statsd packets to localhost only. Adding a `non_local_traffic` option to enable listening on all interfaces to allow ingestion of custom metrics from other containers. Removing the port mapping if the option is `false`
- The `API_KEY` envvar does not work with Agent6, moving to `DD_API_KEY` that both versions handle
- Disabling the unused `SD_BACKEND` envvar for Agent6
- Updating licence and metadata

```diff
diff -u 5/config.json 6/config.json
--- 5/config.json	2018-02-12 17:28:28.000000000 +0100
+++ 6/config.json	2018-02-13 16:12:36.000000000 +0100
@@ -1,8 +1,13 @@
 {
     "properties": {
         "datadog": {
-            "description": "Datadog specific configuration properties",
+            "description": "Datadog Agent configuration",
             "properties": {
+                "use_agent_5": {
+                    "description": "Install version 5.21 of the Agent",
+                    "type": "boolean",
+                    "default": false
+                },
                 "api_key": {
                     "description": "Your Datadog API key.",
                     "type": "string"
@@ -12,28 +17,39 @@
                     "description": "Marathon Application ID",
                     "type": "string"
                 },
-                "cpus": {
-                    "default": 0.05,
-                    "description": "CPU shares to allocate to each Marathon instance.",
-                    "minimum": 0.0,
-                    "type": "number"
-                },
                 "instances": {
                     "default": 1,
                     "description": "Number of Marathon instances to run.",
                     "minimum": 1,
                     "type": "integer"
                 },
+                "cpus": {
+                    "default": 0.05,
+                    "description": "CPU shares to allocate to each Marathon instance.",
+                    "minimum": 0.0,
+                    "type": "number"
+                },
                 "mem": {
                     "default": 256.0,
                     "description": "Memory (MB) to allocate to each Marathon task.",
                     "minimum": 256.0,
                     "type": "number"
                 },
-                "statsd_port": {
-                    "default": 8125,
-                    "description": "statsD port",
-                    "type": "integer"
+                "dogstatsd": {
+                  "description": "Dogstatsd (custom metrics) options",
+                  "type": "object",
+                  "properties": {
+                    "non_local_traffic": {
+                        "default": false,
+                        "description": "Allow statsD non-local traffic",
+                        "type": "boolean"
+                    },
+                    "port": {
+                        "default": 8125,
+                        "description": "UDP port to listen to",
+                        "type": "integer"
+                    }
+                  }
                 }
             },
             "required": [
diff -u 5/marathon.json.mustache 6/marathon.json.mustache
--- 5/marathon.json.mustache	2018-02-12 17:28:28.000000000 +0100
+++ 6/marathon.json.mustache	2018-02-13 17:13:35.000000000 +0100
@@ -3,22 +3,37 @@
     "container": {
         "type": "DOCKER",
         "docker": {
-            "image": "{{resource.assets.container.docker.dd-agent}}",
+            {{#datadog.use_agent_5}}
+            "image": "{{resource.assets.container.docker.agent5}}",
+            {{/datadog.use_agent_5}}
+            {{^datadog.use_agent_5}}
+            "image": "{{resource.assets.container.docker.agent6}}",
+            "forcePullImage": true,
+            {{/datadog.use_agent_5}}
             "parameters": [
                 {
-                    "key": "env", "value": "API_KEY={{datadog.api_key}}"
+                    "key": "env", "value": "DD_API_KEY={{datadog.api_key}}"
                 },
+                {{#datadog.use_agent_5}}
                 {
-                    "key": "env", "value": "MESOS_SLAVE=true"
+                    "key": "env", "value": "SD_BACKEND=docker"
                 },
+                {{/datadog.use_agent_5}}
+                {{#datadog.dogstatsd.non_local_traffic}}
                 {
-                    "key": "env", "value": "SD_BACKEND=docker"
+                    "key": "env", "value": "DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true"
+                },
+                {{/datadog.dogstatsd.non_local_traffic}}
+                {
+                    "key": "env", "value": "MESOS_SLAVE=true"
                 }
             ],
-            "network": "BRIDGE",
             "portMappings": [
-                { "hostPort": {{datadog.statsd_port}}, "containerPort": 8125, "protocol": "udp" }
-            ]
+                {{#datadog.dogstatsd.non_local_traffic}}
+                { "hostPort": {{datadog.dogstatsd.port}}, "containerPort": 8125, "protocol": "udp" }
+                {{/datadog.dogstatsd.non_local_traffic}}
+            ],
+            "network": "BRIDGE"
         },
         "volumes": [
             {
diff -u 5/package.json 6/package.json
--- 5/package.json	2018-02-12 17:28:28.000000000 +0100
+++ 6/package.json	2018-02-13 17:00:13.000000000 +0100
@@ -5,20 +5,20 @@
     "framework": false,
     "licenses": [
         {
-            "name": "Simplified BSD license",
-            "url": "https://raw.githubusercontent.com/DataDog/dd-agent/master/LICENSE"
+            "name": "Apache License 2.0",
+            "url": "https://github.com/DataDog/datadog-agent/blob/master/LICENSE"
         }
     ],
     "maintainer": "package@datadoghq.com",
     "name": "datadog",
     "postInstallNotes": "Datadog on DCOS successfully installed.\nHead over to https://app.datadoghq.com to monitor your DCOS cluster.",
     "postUninstallNotes": "Datadog on DCOS successfully uninstalled.\n.",
-    "preInstallNotes": "This DC/OS Service is currently in preview. \n Pass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api \nAlso pass the number of Mesos slaves as an option (datadog.instances).\nMarathon will make sure that the Datadog Agent runs only once per slave.",
-    "scm": "https://github.com/datadog/dd-agent.git",
+    "preInstallNotes": "This package installs the new Agent 6 by default. You can revert to Agent 5 by enabling datadog.use_agent_5.\n\nPass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api\n\nAlso pass the number of Mesos slaves as an option (datadog.instances), Marathon will make sure that the Datadog Agent runs only once per slave.\n\nSee https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md for available options.",
+    "scm": "https://github.com/datadog/datadog-agent.git",
     "tags": [
         "datadog",
         "monitoring"
     ],
-    "version": "5.20.2",
+    "version": "6.0.0rc1",
     "website": "https://www.datadoghq.com/"
 }
diff -u 5/resource.json 6/resource.json
--- 5/resource.json	2018-02-12 17:28:28.000000000 +0100
+++ 6/resource.json	2018-02-13 16:01:41.000000000 +0100
@@ -2,7 +2,8 @@
   "assets": {
     "container": {
       "docker": {
-        "dd-agent": "datadog/docker-dd-agent:12.4.5202"
+        "agent5": "datadog/docker-dd-agent:12.5.5212",
+        "agent6": "datadog/agent:latest"
       }
     }
   },
```