### PR TITLE
Update Traefik to 1.5.3

### DIFF
--- a/repo/packages/T/traefik/1/config.json
+++ b/repo/packages/T/traefik/1/config.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "service": {
+      "properties": {
+        "name": {
+          "default": "traefik",
+          "description": "Name of the Traefik instance",
+          "type": "string"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each Traefik instance.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "mem": {
+          "default": 128.0,
+          "description": "Memory (MB) to allocate to each Traefik task.",
+          "minimum": 64.0,
+          "type": "number"
+        },
+        "instances": {
+          "default": 1,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "user": {
+          "description": "The user that runs the Traefik service and owns the Mesos sandbox.",
+          "type": "string",
+          "default": "root"
+        },
+        "role": {
+          "default": "slave_public",
+          "description": "Deploy Traefik only on nodes with this role.",
+          "type": "string"
+        },
+        "minimumHealthCapacity": {
+          "default": 0.0,
+          "description": "Minimum health capacity.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "maximumOverCapacity": {
+          "default": 0.2,
+          "description": "Maximum over capacity.",
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    },
+    "traefik": {
+      "description": "Traefik configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "http-address": {
+          "default": "",
+          "description": "Leave empty for listening on all interfaces.",
+          "type": "string"
+        },
+        "http-port": {
+          "default": 80,
+          "description": "HTTP port.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "https-enable": {
+          "default": true,
+          "description": "Enable HTTPS endpoint.",
+          "type": "boolean"
+        },
+        "https-address": {
+          "default": "",
+          "description": "Leave empty for listening on all interfaces.",
+          "type": "string"
+        },
+        "https-port": {
+          "default": 443,
+          "description": "HTTPS port.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "admin-enable": {
+          "default": true,
+          "description": "Enable admin (web UI) endpoint.",
+          "type": "boolean"
+        },
+        "admin-address": {
+          "default": "",
+          "description": "Leave empty for listening on all interfaces.",
+          "type": "string"
+        },
+        "admin-port": {
+          "default": 8080,
+          "description": "Web admin port.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "secret-name": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "config-file": {
+          "description": "Path to additional Traefik config file. Directive will be ignored if file doesn't exist upon service start.",
+          "type": "string",
+          "default": "/etc/traefik/rules.toml"
+        },
+        "watch-config-file": {
+          "description": "Watch config file for changes.",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "marathon": {
+      "description": "Marathon configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "default": true,
+          "description": "Use Marathon endpoint.",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "default": "http://marathon.mesos:8080",
+          "description": "Marathon endpoint, multiple instances separate by comma.",
+          "type": "string"
+        },
+        "watch": {
+          "default": true,
+          "description": "Watch changes in Marathon.",
+          "type": "boolean"
+        },
+        "domain": {
+          "default": "marathon.localhost",
+          "description": "Default domain. Can be overridden by setting the 'traefik.domain' label on an application.",
+          "type": "string"
+        },
+        "marathonlb-compatibility": {
+          "default": false,
+          "description": "Enable compatibility with marathon-lb labels.",
+          "type": "boolean"
+        },
+        "expose": {
+          "default": false,
+          "description": "Expose Marathon apps by default in Traefik.",
+          "type": "boolean"
+        },
+        "respect-readiness-checks": {
+          "default": true,
+          "description": "During deployment Traefik will respect readiness checks if defined in Marathon.",
+          "type": "boolean"
+        },
+        "groups-as-subdomains": {
+          "default": false,
+          "description": "Convert Marathon groups to subdomains.",
+          "type": "boolean"
+        },
+        "dialer-timeout": {
+          "default": "60s",
+          "description": "Amount of time to allow the Marathon provider to wait to open a TCP connection to a Marathon master.",
+          "type": "string"
+        },
+        "keep-alive": {
+          "default": "10s",
+          "description": "Set the TCP Keep Alive interval for the Marathon HTTP Client.",
+          "type": "string"
+        },
+        "force-task-hostname": {
+          "default": false,
+          "description": "By default, a task's IP address (as returned by the Marathon API) is used as backend server if an IP-per-task configuration can be found; otherwise, the name of the host running the task is used. The latter behavior can be enforced by enabling this switch.",
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/T/traefik/1/marathon.json.mustache
+++ b/repo/packages/T/traefik/1/marathon.json.mustache
@@ -1,0 +1,87 @@
+{
+  "id": "{{service.name}}",
+  "instances": {{service.instances}},
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "user": "{{service.user}}",
+  "cmd": "bash bootstrap.sh && ./traefik_linux-amd64 -c traefik.toml",
+  "uris": [
+    "{{resource.assets.uris.traefik-bin}}",
+    "{{resource.assets.uris.bootstrap-sh}}"
+  ],
+  {{#service.role}}
+  "acceptedResourceRoles": [
+    "{{service.role}}"
+  ],
+  {{/service.role}}
+  "healthChecks": [
+    {{#traefik.admin-enable}}
+    {
+      "path": "/health",
+      "portIndex": 1,
+      "protocol": "MESOS_HTTP",
+      "gracePeriodSeconds": 20,
+      "intervalSeconds": 5,
+      "timeoutSeconds": 2,
+      "maxConsecutiveFailures": 2,
+      "ignoreHttp1xx": false
+    }
+    {{/traefik.admin-enable}}
+  ],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": {{service.minimumHealthCapacity}},
+    "maximumOverCapacity": {{service.maximumOverCapacity}}
+  },
+  "requirePorts":true,
+  "env": {
+    "TRAEFIK_HTTP_ADDRESS": "{{traefik.http-address}}",
+    "TRAEFIK_HTTP_PORT": "{{traefik.http-port}}",
+    "TRAEFIK_HTTPS_ENABLE": "{{traefik.https-enable}}",
+    "TRAEFIK_HTTPS_PORT": "{{traefik.https-port}}",
+    "TRAEFIK_HTTPS_ADDRESS": "{{traefik.https-address}}",
+    "TRAEFIK_ADMIN_ENABLE": "{{traefik.admin-enable}}",
+    "TRAEFIK_ADMIN_PORT": "{{traefik.admin-port}}",
+    "TRAEFIK_ADMIN_ADDRESS": "{{traefik.admin-address}}",
+    "TRAEFIK_FILE_NAME": "{{traefik.config-file}}",
+    "TRAEFIK_FILE_WATCH": "{{traefik.watch-config-file}}",
+    "TRAEFIK_MARATHON_ENABLE": "{{marathon.enable}}",
+    "TRAEFIK_MARATHON_ENDPOINT": "{{marathon.endpoint}}",
+    "TRAEFIK_MARATHON_WATCH": "{{marathon.watch}}",
+    "TRAEFIK_MARATHON_DOMAIN": "{{marathon.domain}}",
+    "TRAEFIK_MARATHONLB_COMPATIBILITY": "{{marathon.marathonlb-compatibility}}",
+    "TRAEFIK_MARATHON_GROUPS_AS_SUBDOMAINS": "{{marathon.groups-as-subdomains}}",
+    "TRAEFIK_MARATHON_DIALER_TIMEOUT": "{{marathon.dialer-timeout}}",
+    "TRAEFIK_MARATHON_KEEP_ALIVE": "{{marathon.keep-alive}}",
+    "TRAEFIK_MARATHON_FORCE_TASK_HOSTNAME": "{{marathon.force-task-hostname}}",
+    "TRAEFIK_MARATHON_RESPECT_READINESS_CHECKS": "{{marathon.respect-readiness-checks}}",
+    {{#traefik.secret-name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    {{/traefik.secret-name}}
+    "TRAEFIK_MARATHON_EXPOSE": "{{marathon.expose}}"
+  },
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_PACKAGE_VERSION": "{{package.version}}",
+    {{#traefik.admin-enable}}
+    "DCOS_SERVICE_PORT_INDEX": "1",
+    {{/traefik.admin-enable}}
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  },
+  {{#traefik.secret-name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{traefik.secret-name}}"
+    }
+  },
+  {{/traefik.secret-name}}
+  "ports": [
+    {{traefik.http-port}}
+    {{#traefik.admin-enable}}
+    ,{{traefik.admin-port}}
+    {{/traefik.admin-enable}}
+    {{#traefik.https-enable}}
+    ,{{traefik.https-port}}
+    {{/traefik.https-enable}}
+  ]
+}

--- a/repo/packages/T/traefik/1/package.json
+++ b/repo/packages/T/traefik/1/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "4.0",
+  "name": "traefik",
+  "version": "1.0.1-1.5.3",
+  "minDcosReleaseVersion": "1.9",
+  "scm": "https://github.com/containous/traefik",
+  "description": "Traefik is a modern HTTP reverse proxy and load balancer written in go. It supports several backends (Docker, Swarm mode, Kubernetes, Marathon, Consul, Etcd, Rancher, Amazon ECS, and a lot more) to manage its configuration automatically and dynamically. \n\nSee https://docs.traefik.io for more information.",
+  "maintainer": "https://github.com/deric/dcos-traefik",
+  "tags": ["loadbalancer", "service-discovery", "reverse-proxy", "proxy", "traffic"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production!\n\n",
+  "postInstallNotes": "Traefik DC/OS Service has been successfully installed!\nSee https://docs.traefik.io for documentation.",
+  "postUninstallNotes": "Traefik DC/OS Service has been uninstalled and will no longer run.",
+  "licenses": [
+    {
+      "name": "MIT",
+      "url": "https://github.com/containous/traefik/blob/master/LICENSE.md"
+    }
+  ]
+}

--- a/repo/packages/T/traefik/1/resource.json
+++ b/repo/packages/T/traefik/1/resource.json
@@ -1,0 +1,13 @@
+{
+  "assets": {
+    "uris": {
+      "traefik-bin": "https://github.com/containous/traefik/releases/download/v1.5.3/traefik_linux-amd64",
+      "bootstrap-sh": "https://raw.githubusercontent.com/deric/dcos-traefik/v1.0.0/bootstrap.sh"
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/traefik-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/traefik-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/traefik-icon-large.png"
+  }
+}


### PR DESCRIPTION
Traefik 1.5.x brings many changes, notably:
* [Support for Marathon constraints](https://github.com/containous/traefik/pull/2388)
* [Dynamic certificates management](https://github.com/containous/traefik/pull/2233)
* [Fixed using hostname instead host's IP](https://github.com/containous/traefik/pull/2590)
* [go-marathon library update - mostly performance improvements](https://github.com/containous/traefik/pull/2585)

We're still waiting for full Marathon 1.5 API support.

```
index 642ddf51..1a9dbadf 100644
--- a/repo/packages/T/traefik/0/marathon.json.mustache
+++ b/repo/packages/T/traefik/1/marathon.json.mustache
@@ -62,7 +62,7 @@
   "labels": {
     "DCOS_SERVICE_NAME": "{{service.name}}",
     "DCOS_SERVICE_SCHEME": "http",
-    "DCOS_PACKAGE_VERSION": "1.0.0-1.4.4",
+    "DCOS_PACKAGE_VERSION": "{{package.version}}",
     {{#traefik.admin-enable}}
     "DCOS_SERVICE_PORT_INDEX": "1",
     {{/traefik.admin-enable}}
diff --git a/repo/packages/T/traefik/0/package.json b/repo/packages/T/traefik/1/package.json
index b0df074d..d8d5310f 100644
--- a/repo/packages/T/traefik/0/package.json
+++ b/repo/packages/T/traefik/1/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "4.0",
   "name": "traefik",
-  "version": "1.0.0-1.4.4",
+  "version": "1.0.1-1.5.3",
   "minDcosReleaseVersion": "1.9",
   "scm": "https://github.com/containous/traefik",
   "description": "Traefik is a modern HTTP reverse proxy and load balancer written in go. It supports several backends (Docker, Swarm mode, Kubernetes, Marathon, Consul, Etcd, Rancher, Amazon ECS, and a lot more) to manage its configuration automatically and dynamically. \n\nSee https://docs.traefik.io for more information.",
diff --git a/repo/packages/T/traefik/0/resource.json b/repo/packages/T/traefik/1/resource.json
index 923d99b8..c27dc8a0 100644
--- a/repo/packages/T/traefik/0/resource.json
+++ b/repo/packages/T/traefik/1/resource.json
@@ -1,8 +1,8 @@
 {
   "assets": {
     "uris": {
-      "traefik-bin": "https://github.com/containous/traefik/releases/download/v1.4.4/traefik_linux-amd64",
-      "bootstrap-sh": "https://raw.githubusercontent.com/deric/dcos-traefik/master/bootstrap.sh"
+      "traefik-bin": "https://github.com/containous/traefik/releases/download/v1.5.3/traefik_linux-amd64",
+      "bootstrap-sh": "https://raw.githubusercontent.com/deric/dcos-traefik/v1.0.0/bootstrap.sh"
     }
   },
   "images": {
```