### PR TITLE
New images beta spark history

### DIFF
--- a/repo/packages/B/beta-kubernetes/7/resource.json
+++ b/repo/packages/B/beta-kubernetes/7/resource.json
@@ -33,9 +33,9 @@
     }
   },
   "images": {
-    "icon-small": "https://downloads.mesosphere.com/kubernetes/assets/k8s-small-48x48.png",
-    "icon-medium": "https://downloads.mesosphere.com/kubernetes/assets/k8s-medium-96x96.png",
-    "icon-large": "https://downloads.mesosphere.com/kubernetes/assets/k8s-large-256x256.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/beta-kubernetes-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/beta-kubernetes-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/beta-kubernetes-icon-large.png"
   },
   "cli": {
     "binaries": {

--- a/repo/packages/B/beta-spark-history/0/resource.json
+++ b/repo/packages/B/beta-spark-history/0/resource.json
@@ -1,3 +1,7 @@
 {
-  "images": {}
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/beta-spark-history-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/beta-spark-history-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/beta-spark-history-icon-large.png"
+  }
 }

--- a/repo/packages/B/beta-spark-history/1/resource.json
+++ b/repo/packages/B/beta-spark-history/1/resource.json
@@ -1,3 +1,7 @@
 {
-  "images": {}
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/beta-spark-history-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/beta-spark-history-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/beta-spark-history-icon-large.png"
+  }
 }


### PR DESCRIPTION
beta-spark-history was missing in the new images package. This now got fixed.

Beside this `beta-kubernetes/7/resource.json` was still having the old image version