### PR TITLE
New Kibana package, that supports the usage of plugins

### DIFF
--- a/repo/packages/K/kibana/200/config.json
+++ b/repo/packages/K/kibana/200/config.json
@@ -1,0 +1,75 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "The name of the Kibana service instance",
+          "type": "string",
+          "default": "kibana"
+        },
+        "user": {
+          "description": "The user that runs the Kibana services and owns the Mesos sandbox.",
+          "type": "string",
+          "default": "nobody"
+        }
+      },
+      "required": [
+        "name",
+        "user"
+      ]
+    },
+    "kibana": {
+      "description": "Kibana service configuration properties",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "xpack_enabled": {
+          "description": "Whether or not to enable the commercial X-Pack plugin from kibana",
+          "type": "boolean",
+          "default": false
+        },
+        "plugins": {
+          "description": "An optional comma-separated list of plugin names, which will be installed in Kibana. These names may also be URLs to plugin ZIP files.",
+          "type": "string",
+          "default": ""
+        },
+        "elasticsearch_url": {
+          "description": "The URL of the Elasticsearch cluster to use for all your queries.",
+          "type": "string",
+          "default": "http://coordinator.elastic.l4lb.thisdcos.directory:9200"
+        },
+        "elasticsearch_tls": {
+          "description": "Enable TLS encryption for communicating with Elastic (required when Elastic has TLS support enabled, requires the X-Pack plugin).",
+          "type": "boolean",
+          "default": false
+        },
+        "user": {
+          "description": "kibana username to use for X-Pack authentication, if enabled",
+          "type": "string",
+          "default": "kibana"
+        },
+        "password": {
+          "description": "Password to use for X-Pack authentication, if enabled. Note that you are not setting the password here. You are specifying the credentials for Kibana to use when sending requests.",
+          "type": "string",
+          "default": "changeme"
+        },
+        "cpus": {
+          "description": "Kibana CPU requirements",
+          "type": "number",
+          "default": 0.5
+        },
+        "mem": {
+          "description": "Kibana mem requirements",
+          "type": "integer",
+          "default": 2048
+        }
+      },
+      "required": [
+        "elasticsearch_url"
+      ]
+    }
+  }
+}

--- a/repo/packages/K/kibana/200/marathon.json.mustache
+++ b/repo/packages/K/kibana/200/marathon.json.mustache
@@ -1,0 +1,53 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{kibana.cpus}},
+  "mem": {{kibana.mem}},
+  "instances": 1,
+  "user": "{{service.user}}",
+  "cmd": "echo -e \"elasticsearch.url: $ELASTICSEARCH_URL\nelasticsearch.username: $KIBANA_USER\nelasticsearch.password: $KIBANA_PASSWORD\nserver.host: 0.0.0.0\nserver.port: $PORT_KIBANA\nserver.basePath: /service/$FRAMEWORK_NAME\" > $MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/config/kibana.yml; if [ \"$XPACK_ENABLED\" = true ]; then echo -e \"\nxpack.security.encryptionKey: $MESOS_FRAMEWORK_ID\nxpack.reporting.encryptionKey: $MESOS_FRAMEWORK_ID\n\" >> $MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/config/kibana.yml; echo 'Installing X-Pack plugin...'; $MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/bin/kibana-plugin install file://$MESOS_SANDBOX/x-pack-$ELASTIC_VERSION.zip; fi; if [ ! -z \"$KIBANA_PLUGINS\" ]; then echo 'Installing Kibana plugins ...'; $MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/bin/kibana-plugin install \"$KIBANA_PLUGINS\"; fi; if [ \"$KIBANA_ELASTICSEARCH_TLS\" = true ]; then echo -e \"\nelasticsearch.ssl.certificateAuthorities: $MESOS_SANDBOX/.ssl/ca-bundle.crt\n\" >> $MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/config/kibana.yml; fi; env && $MESOS_SANDBOX/kibana-$ELASTIC_VERSION-linux-x86_64/bin/kibana",
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  "env": {
+    "ELASTIC_VERSION": "5.6.5",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "XPACK_ENABLED": "{{kibana.xpack_enabled}}",
+    "KIBANA_PLUGINS": "{{kibana.plugins}}",
+    "ELASTICSEARCH_URL": "{{kibana.elasticsearch_url}}",
+    {{#kibana.elasticsearch_tls}}
+    "KIBANA_ELASTICSEARCH_TLS": "{{kibana.elasticsearch_tls}}",
+    {{/kibana.elasticsearch_tls}}
+    "KIBANA_USER": "{{kibana.user}}",
+    "KIBANA_PASSWORD": "{{kibana.password}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.kibana-tar-gz}}",
+    "{{resource.assets.uris.xpack-zip}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "kibana",
+      "labels": { "VIP_0": "/web.{{service.name}}:80" }
+    }
+  ],
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ]
+}

--- a/repo/packages/K/kibana/200/package.json
+++ b/repo/packages/K/kibana/200/package.json
@@ -1,0 +1,25 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "2.2.0-5.6.5"
+  ],
+  "downgradesTo": [
+    "2.2.0-5.6.5"
+  ],
+  "minDcosReleaseVersion": "1.9",
+  "name": "kibana",
+  "version": "2.3.0-5.6.5",
+  "maintainer": "support@mesosphere.io",
+  "description": "Kibana 5, and optionally X-Pack",
+  "selected": true,
+  "framework": true,
+  "tags": [
+    "elastic",
+    "elasticsearch",
+    "kibana",
+    "x-pack"
+  ],
+  "preInstallNotes": "Default configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM",
+  "postInstallNotes": "The DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/services/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
+  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/elastic/uninstall to remove any persistent state if required."
+}

--- a/repo/packages/K/kibana/200/resource.json
+++ b/repo/packages/K/kibana/200/resource.json
@@ -1,0 +1,13 @@
+{
+  "assets": {
+    "uris": {
+      "kibana-tar-gz": "https://artifacts.elastic.co/downloads/kibana/kibana-5.6.5-linux-x86_64.tar.gz",
+      "xpack-zip": "https://artifacts.elastic.co/downloads/packs/x-pack/x-pack-5.6.5.zip"
+    }
+  },
+  "images": {
+    "icon-small": "https://static-www.elastic.co/assets/blt282ae2420e32fc38/icon-kibana-bb.svg",
+    "icon-medium": "https://static-www.elastic.co/assets/blt282ae2420e32fc38/icon-kibana-bb.svg",
+    "icon-large": "https://static-www.elastic.co/assets/blt282ae2420e32fc38/icon-kibana-bb.svg"
+  }
+}


### PR DESCRIPTION
This PR enables a new Kibana package option for specifying a Kibana plugin, which then will be downloaded, installed and activated during the deployment process.