### PR TITLE
[INFINITY-3441] Correct preInstallNotes for GA Kafka 2.1.0-1.0.0.

### DIFF
--- a/repo/packages/K/kafka/100/package.json
+++ b/repo/packages/K/kafka/100/package.json
@@ -19,7 +19,7 @@
     "kafka",
     "pubsub"
   ],
-  "preInstallNotes": "There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nDefault configuration requires 3 agent nodes each with: 1.0 CPU | 2048 MB MEM | 1 5000 MB Disk.",
+  "preInstallNotes": "Default configuration requires 3 agent nodes each with: 1.0 CPU | 2048 MB MEM | 1 5000 MB Disk",
   "postInstallNotes": "The DC/OS Apache Kafka service is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/kafka/\n\tIssues: https://docs.mesosphere.com/support/",
   "postUninstallNotes": "The DC/OS Apache Kafka service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/kafka/uninstall to remove any persistent state if required."
 }


### PR DESCRIPTION
The GA preinstall notes for Kafka were not updated.