### PR TITLE
Release percona-mongo 0.2.0-3.4.13 (automated commit)



### DIFF
--- a/repo/packages/P/percona-mongo/1/config.json
+++ b/repo/packages/P/percona-mongo/1/config.json
@@ -1,0 +1,861 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "title": "Service name",
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "percona-mongo"
+        },
+        "sleep": {
+          "description": "The sleep duration in seconds before tasks exit.",
+          "type": "integer",
+          "default": 1000
+        },
+        "user": {
+          "title": "User",
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root"
+        },
+        "principal": {
+          "title": "Custom principal (optional)",
+          "description": "The principal for the service instance, or empty to use the default.",
+          "type": "string",
+          "default": ""
+        },
+        "virtual_networks": {
+          "description": "Enable DC/OS Virtual Networking",
+          "type": "boolean",
+          "default": false
+        },
+        "secret_name": {
+          "title": "Credential secret name (optional)",
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        }
+      },
+      "required": [
+        "name",
+        "sleep",
+        "user"
+      ]
+    },
+    "mongodb": {
+      "description": "MongoDB server node configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "MongoDB server node cpu requirements",
+          "type": "number",
+          "default": 1
+        },
+        "mem": {
+          "description": "MongoDB server node mem requirements",
+          "type": "integer",
+          "default": 1024
+        },
+        "disk": {
+          "description": "MongoDB server node disk requirements, in megabytes",
+          "type": "integer",
+          "default": 1000
+        },
+        "diskType": {
+          "description": "MongoDB server node disk type, see DCOS documentation regarding Disk Resources for more info",
+          "type": "string",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "count": {
+          "description": "Number of MongoDB replica set members/nodes to run. 1, 3, 5 or 7 node count is possible",
+          "type": "integer",
+          "enum": [
+            1,
+            3,
+            5,
+            7
+          ],
+          "default": 3
+        },
+        "replicaSetName": {
+          "title": "replication.replicaSetName",
+          "description": "Name of the MongoDB ReplicaSet",
+          "type": "string",
+          "default": "rs"
+        },
+        "port": {
+          "description": "MongoDB server listening port",
+          "type": "integer",
+          "default": 27017
+        },
+        "version": {
+          "description": "Percona MongoDB server version. See Pre-Install Notes for supported versions, use other versions at your own risk!",
+          "type": "string",
+          "enum": [
+            "3.4.10",
+            "3.4.13"
+          ],
+          "default": "3.4.13"
+        },
+        "constraint": {
+          "description": "Marathon-style constraint for MongoDB server nodes (use empty string to override the default hostname UNIQUE behavior)",
+          "type": "string",
+          "default": "[['hostname', 'UNIQUE']]"
+        },
+        "backupUser": {
+          "description": "MongoDB backup user name",
+          "type": "string",
+          "default": "backup"
+        },
+        "backupPassword": {
+          "description": "MongoDB backup password",
+          "type": "string",
+          "default": "backuppassword"
+        },
+        "userAdminUser": {
+          "description": "MongoDB userAdmin user name",
+          "type": "string",
+          "default": "useradmin"
+        },
+        "userAdminPassword": {
+          "description": "MongoDB userAdmin password",
+          "type": "string",
+          "default": "useradminpassword"
+        },
+        "clusterAdminUser": {
+          "description": "MongoDB clusterAdmin user name",
+          "type": "string",
+          "default": "clusteradmin"
+        },
+        "clusterAdminPassword": {
+          "description": "MongoDB clusterAdmin password",
+          "type": "string",
+          "default": "clusteradminpassword"
+        },
+        "clusterMonitorUser": {
+          "description": "MongoDB clusterMonitor user name",
+          "type": "string",
+          "default": "clustermonitor"
+        },
+        "clusterMonitorPassword": {
+          "description": "MongoDB clusterMonitor password",
+          "type": "string",
+          "default": "clustermonitorpassword"
+        },
+        "key": {
+          "description": "The key to be used for intra-node communication, e.g. generated by 'openssl rand -base64 756'",
+          "type": "string",
+          "default": "VCeZ9zWjiNJQDZxXBZA4jfeI9YHUrWmRJDe7DKOG34b/mzER0hncruRlKLYT9HNUiU7ABxvNQ7jj1mSgmDpVt+XfKEpI3TTCJYjEAf/8G9Saeu8pdETCAd/l8xLZOAYbZd2yjhIWagiOjDz1i56GN+R51I11mSLUcGdhXVmSOCV6rrrqAtY+3+0KaWPFOnbkTHJdm3mPrts+oFT2VjGhg2yNzcfCI9FwEVPX3PWW5dbryEAHIBUapXSsMJcBFlD730DWk/MbEZSV/B/hkaFEDXgvEJszTLT6U9a2Dg4v7+eN97mK/87iKMDPIXZ5wzjbH9XNYHFVY5ensP6pmdscU9osY2MdCYhFotJHUJfGmMNbj2d1tvcc4GuFMqGcFrTyrr2E9QKm4QOtRnxLAeE2AIX0XbXxyEEbDGkKpJRLiiJRIREHh4VP6DZDzhntgcuOwWBhCLiRGDID0m1UyDe1qMXk+yy1mSRWAdfQtjXTVdS1o+AIBCxM0L0rM3rSto1PeA3CJcN1CjTfWq0t4t9mUOy4QO/juXaZCsvRDl8FKUsjnQfnocsRlWrqCGI7ONsbJdaEuiKxtu7H1WR0A+qdtBK/tZmTgbN9q0CCaP7Y1a48R5UHJAPS3HobOrqxNXEgYn+rhADUt0/ahRMuOBMTx/zm+VG8BFl8AmjOPQItvNOc9A08bKPg7lEqlzzcsTMa9QEJcW1sN9Io2F+ibKsiK9CdlPhPEUh2zMtex5e9LbT/102cmqJezq/16/xy9GYC7GwgYkrMoEbEfKdtUvVyQRijy4UE7bl9bdEgrIEY4Rs+TlR1zIRc8nl1RgL1pQp0V/gOuU/a5G5UMfIu9uZe5kgsS7T/8TQ3bzA9JpLVyCJx9rp8jvmcWO4RfOa6rKHT6pAjo1tf+VJ/mdJAwebxcpD/OPhEmfuTH5WqS3Vb/vWRbkFfC6nn+P2oB95+bF2yvA5PnkwswMTiI9Q/zSW8b4QrKyBXbd003c4FxplAGoQr2ukY"
+        },
+        "storageEngine": {
+          "title": "storage.engine",
+          "description": "Percona MongoDB storage engine (options: wiredTiger, rocksdb, mmapv1 or inMemory)",
+          "type": "string",
+          "enum": [
+            "wiredTiger",
+            "rocksdb",
+            "mmapv1",
+            "inMemory"
+          ],
+          "default": "wiredTiger"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "count",
+        "replicaSetName",
+        "port",
+        "version",
+        "constraint",
+        "backupUser",
+        "backupPassword",
+        "userAdminUser",
+        "userAdminPassword",
+        "clusterAdminUser",
+        "clusterAdminPassword",
+        "clusterMonitorUser",
+        "clusterMonitorPassword",
+        "key",
+        "storageEngine"
+      ]
+    },
+    "mongodb-advanced": {
+      "description": "MongoDB server advanced server configuration properties. Adjust with caution!",
+      "type": "object",
+      "properties": {
+        "openFileLimit": {
+          "title": "Open Files Limit (ulimit)",
+          "description": "Maximum number of open files inside the container ('NOFILE' ulimit setting)",
+          "type": "number",
+          "default": 64000
+        },
+        "processLimit": {
+          "title": "Max Processes Limit (ulimit)",
+          "description": "Maximum number of processes running inside the container ('NPROC' ulimit setting)",
+          "type": "number",
+          "default": 64000
+        },
+        "securityRedactClientLogData": {
+          "title": "security.redactClientLogData",
+          "description": "Prevents writing of potentially sensitive data stored on the database to the diagnostic log",
+          "type": "boolean",
+          "default": false
+        },
+        "storageIndexBuildRetry": {
+          "title": "storage.indexBuildRetry",
+          "description": "Specifies whether mongod rebuilds incomplete indexes on the next start up",
+          "type": "boolean",
+          "default": true
+        },
+        "storageJournalEnabled": {
+          "title": "storage.journal.enabled",
+          "description": "Enable or disable the durability journal to ensure data files remain valid and recoverable",
+          "type": "boolean",
+          "default": true
+        },
+        "storageJournalCommitIntervalMs": {
+          "title": "storage.journal.commitIntervalMs",
+          "description": "The maximum amount of time in milliseconds that the mongod process allows between journal operations",
+          "type": "integer",
+          "default": 100
+        },
+        "storageDirectoryPerDB": {
+          "title": "storage.directoryPerDB",
+          "description": "When true, MongoDB uses a separate directory to store data for each database",
+          "type": "boolean",
+          "default": false
+        },
+        "storageSyncPeriodSecs": {
+          "title": "storage.syncPeriodSecs",
+          "description": "The amount of time that can pass before MongoDB flushes data to the data files via an fsync operation",
+          "type": "integer",
+          "default": 60
+        },
+        "storageMMAPv1PreallocDataFiles": {
+          "title": "storage.mmapv1.preallocDataFiles",
+          "description": "Enables or disables the preallocation of data files. By default, MongoDB does not preallocate data files",
+          "type": "boolean",
+          "default": true
+        },
+        "storageMMAPv1NsSize": {
+          "title": "storage.mmapv1.nsSize",
+          "description": "The default size for namespace files, which are files that end in .ns. Each collection and index counts as a namespace",
+          "type": "integer",
+          "default": 16
+        },
+        "storageMMAPv1QuotaEnforced": {
+          "title": "storage.mmapv1.quota.enforced",
+          "description": "Enable or disable the enforcement of a maximum limit for the number data files each database can have",
+          "type": "boolean",
+          "default": false
+        },
+        "storageMMAPv1QuotaMaxFilesPerDB": {
+          "title": "storage.mmapv1.quota.maxFilesPerDB",
+          "description": "The limit on the number of data files per database",
+          "type": "integer",
+          "default": 8
+        },
+        "storageMMAPv1SmallFiles": {
+          "title": "storage.mmapv1.smallFiles",
+          "description": "When true, MongoDB uses a smaller default file size",
+          "type": "boolean",
+          "default": false
+        },
+        "storageRocksDBCompression": {
+          "title": "storage.rocksdb.compression",
+          "description": "Specifies the block compression algorithm for data collection. Possible values: none, snappy, zlib, lz4, lz4hc",
+          "type": "string",
+          "enum": [
+            "snappy",
+            "none",
+            "zlib",
+            "lz4",
+            "lz4hc"
+          ],
+          "default": "snappy"
+        },
+        "storageRocksDBMaxWriteMBPerSec": {
+          "title": "storage.rocksdb.maxWriteMBPerSec",
+          "description": "Specifies the maximum speed at which RocksDB writes to storage in megabytes per second. Decrease this value to reduce read latency spikes during compactions. However, reducing it too much might slow down writes",
+          "type": "integer",
+          "default": 1024
+        },
+        "storageRocksDBCrashSafeCounters": {
+          "title": "storage.rocksdb.crashSafeCounters",
+          "description": "Specifies whether to correct counters after a crash. Enabling this can affect write performance",
+          "type": "boolean",
+          "default": false
+        },
+        "storageWiredTigerEngineConfigJournalCompressor": {
+          "title": "storage.wiredTiger.engineConfig.journalCompressor",
+          "description": "The type of compression to use to compress WiredTiger journal data. Available compressors are: none, snappy, zlib",
+          "type": "string",
+          "enum": [
+            "snappy",
+            "none",
+            "zlib"
+          ],
+          "default": "snappy"
+        },
+        "storageWiredTigerEngineConfigDirectoryForIndexes": {
+          "title": "storage.wiredTiger.engineConfig.directoryForIndexes",
+          "description": "When true, mongod stores indexes and collections in separate subdirectories under the data (i.e. storage.dbPath) directory",
+          "type": "boolean",
+          "default": false
+        },
+        "storageWiredTigerCollectionConfigBlockCompressor": {
+          "title": "storage.wiredTiger.collectionConfig.blockCompressor",
+          "description": "The default type of compression to use to compress collection data. You can override this on a per-collection basis when creating collections. Available compressors are: none, snappy, zlib",
+          "type": "string",
+          "enum": [
+            "snappy",
+            "none",
+            "zlib"
+          ],
+          "default": "snappy"
+        },
+        "storageWiredTigerIndexConfigPrefixCompression": {
+          "title": "storage.wiredTiger.indexConfig.prefixCompression",
+          "description": "Specify true to enable prefix compression for index data, or false to disable prefix compression for index data",
+          "type": "boolean",
+          "default": true
+        },
+        "setParameterFailIndexKeyTooLong": {
+          "title": "setParameter: failIndexKeyTooLong",
+          "description": "Enable failing of updates and inserts that have indexed values longer than the Index Key Length Limit",
+          "type": "boolean",
+          "default": true
+        },
+        "setParameterMaxIndexBuildMemoryUsageMB": {
+          "title": "setParameter: maxIndexBuildMemoryUsageMB",
+          "description": "Limits the amount of memory that simultaneous foreground index builds on one collection may consume for the duration of the builds",
+          "type": "integer",
+          "default": 500
+        },
+        "setParameterLogUserIds": {
+          "title": "setParameter: logUserIds",
+          "description": "Enable logging of user IDs. 1 = true, 0 = false",
+          "enum": [
+            0,
+            1
+          ],
+          "type": "integer",
+          "default": 0
+        },
+        "setParameterTTLMonitorEnabled": {
+          "title": "setParameter: ttlMonitorEnabled",
+          "description": "Enable background thread that is responsible for deleting documents from collections with TTL indexes",
+          "type": "boolean",
+          "default": true
+        },
+        "setParameterTTLMonitorSleepSecs": {
+          "title": "setParameter: ttlMonitorSleepSecs",
+          "description": "Defines the number of seconds to wait between checking TTL Indexes for old documents and removing them",
+          "type": "integer",
+          "default": 60
+        },
+        "setParameterRocksDBConcurrentReadTransactions": {
+          "title": "setParameter: rocksdbConcurrentReadTransactions",
+          "description": "Maximum number of concurrently running read transactions in the RocksDB engine",
+          "type": "integer",
+          "default": 128
+        },
+        "setParameterRocksDBConcurrentWriteTransactions": {
+          "title": "setParameter: rocksdbConcurrentWriteTransactions",
+          "description": "Maximum number of concurrently running write transactions in the RocksDB engine",
+          "type": "integer",
+          "default": 128
+        },
+        "setParameterWiredTigerConcurrentReadTransactions": {
+          "title": "setParameter: wiredTigerConcurrentReadTransactions",
+          "description": "Maximum number of concurrently running read transactions in the WiredTiger engine",
+          "type": "integer",
+          "default": 128
+        },
+        "setParameterWiredTigerConcurrentWriteTransactions": {
+          "title": "setParameter: wiredTigerConcurrentWriteTransactions",
+          "description": "Maximum number of concurrently running write transactions in the WiredTiger engine",
+          "type": "integer",
+          "default": 128
+        },
+        "netMaxIncomingConnections": {
+          "title": "net.maxIncomingConnections",
+          "description": "Specify the maximum number of incoming connections",
+          "type": "number",
+          "default": 51200
+        },
+        "operationProfilingMode": {
+          "title": "operationProfiling.mode",
+          "description": "Percona MongoDB operation profiling mode (options: slowOp, all or off)",
+          "type": "string",
+          "enum": [
+            "slowOp",
+            "off",
+            "all"
+          ],
+          "default": "slowOp"
+        },
+        "operationProfilingSlowOpThresholdMs": {
+          "title": "operationProfiling.slowOpThresholdMs",
+          "description": "Percona MongoDB operation profiling slowOp mode threshold in milliseconds",
+          "type": "integer",
+          "default": 100
+        },
+        "operationProfilingRateLimit": {
+          "title": "operationProfiling.rateLimit",
+          "description": "Percona MongoDB operation profiling rate limiting value",
+          "type": "integer",
+          "default": 1
+        },
+        "replicationSecondaryIndexPrefetch": {
+          "title": "replication.secondaryIndexPrefetch",
+          "description": "The indexes that secondary members of a replica set load into memory before applying operations from the oplog",
+          "type": "string",
+          "enum": [
+            "none",
+            "_id_only",
+            "all"
+          ],
+          "default": "all"
+        },
+        "replicationEnableMajorityReadConcern": {
+          "title": "replication.enableMajorityReadConcern",
+          "description": "Enables read concern level of 'majority'",
+          "type": "boolean",
+          "default": false
+        },
+        "systemLogVerbosity": {
+          "title": "systemLog.verbosity",
+          "description": "The default log message verbosity level for components. The verbosity level determines the amount of Informational and Debug messages MongoDB outputs. The verbosity level can range from 0 to 5",
+          "type": "integer",
+          "enum": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "default": 0
+        },
+        "systemTraceAllExceptions": {
+          "title": "systemLog.traceAllExceptions",
+          "description": "Print verbose information for debugging. Use for additional logging for support-related troubleshooting",
+          "type": "boolean",
+          "default": false
+        },
+        "systemLogTimestampFormat": {
+          "title": "systemLog.timestampFormat",
+          "description": "The time format for timestamps in log messages. Specify one of the following values: ctime, iso8601-utc, iso8601-local",
+          "type": "string",
+          "enum": [
+            "iso8601-local",
+            "ctime",
+            "iso8601-utc"
+          ],
+          "default": "iso8601-local"
+        }
+      },
+      "required": [
+        "openFileLimit",
+        "processLimit",
+        "storageIndexBuildRetry",
+        "storageJournalEnabled",
+        "storageJournalCommitIntervalMs",
+        "storageDirectoryPerDB",
+        "storageSyncPeriodSecs",
+        "storageMMAPv1PreallocDataFiles",
+        "storageMMAPv1NsSize",
+        "storageMMAPv1QuotaEnforced",
+        "storageMMAPv1QuotaMaxFilesPerDB",
+        "storageMMAPv1SmallFiles",
+        "storageRocksDBCompression",
+        "storageRocksDBMaxWriteMBPerSec",
+        "storageRocksDBCrashSafeCounters",
+        "storageWiredTigerEngineConfigJournalCompressor",
+        "storageWiredTigerEngineConfigDirectoryForIndexes",
+        "storageWiredTigerCollectionConfigBlockCompressor",
+        "storageWiredTigerIndexConfigPrefixCompression",
+        "setParameterFailIndexKeyTooLong",
+        "setParameterMaxIndexBuildMemoryUsageMB",
+        "setParameterLogUserIds",
+        "setParameterTTLMonitorEnabled",
+        "setParameterTTLMonitorSleepSecs",
+        "setParameterRocksDBConcurrentReadTransactions",
+        "setParameterRocksDBConcurrentWriteTransactions",
+        "setParameterWiredTigerConcurrentReadTransactions",
+        "setParameterWiredTigerConcurrentWriteTransactions",
+        "netMaxIncomingConnections",
+        "operationProfilingMode",
+        "operationProfilingSlowOpThresholdMs",
+        "operationProfilingRateLimit",
+        "replicationSecondaryIndexPrefetch",
+        "replicationEnableMajorityReadConcern",
+        "systemLogVerbosity",
+        "systemTraceAllExceptions",
+        "systemLogTimestampFormat"
+      ]
+    },
+    "mongodb-auditlog": {
+      "description": "Percona Server for MongoDB AuditLog configuration properties. The audit log is written to the file 'auditLog.bson' in the MongoDB data path",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable PSMDB Audit Log",
+          "description": "Enables the Percona Server for MongoDB audit log feature",
+          "type": "boolean",
+          "default": false
+        },
+        "filter": {
+          "title": "auditLog.filter",
+          "description": "The filter document (in json style) to be used for filtering the Percona Server for MongoDB audit log",
+          "type": "string",
+          "default": "{}"
+        },
+        "auditAuthorizationSuccess": {
+          "title": "setParameter: auditAuthorizationSuccess",
+          "description": "Enables the logging of all read and write operations",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "enabled",
+        "filter",
+        "auditAuthorizationSuccess"
+      ]
+    },
+    "init": {
+      "description": "MongoDB init node configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "MongoDB init node cpu requirements",
+          "type": "number",
+          "default": 0.2
+        },
+        "mem": {
+          "description": "MongoDB init node mem requirements",
+          "type": "integer",
+          "default": 96
+        },
+        "initiateDelay": {
+          "description": "The delay before starting the ReplicaSet initialization, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "15s"
+        },
+        "maxConnectTries": {
+          "description": "The number of times to try to connect to a database host",
+          "type": "integer",
+          "default": 30
+        },
+        "maxInitReplsetTries": {
+          "description": "The number of times to try to initiate the replica set",
+          "type": "integer",
+          "default": 60
+        },
+        "maxAddUsersTries": {
+          "description": "The number of times to try to add database users",
+          "type": "integer",
+          "default": 60
+        },
+        "retrySleep": {
+          "description": "The duration to wait between retries",
+          "type": "string",
+          "default": "3s"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem"
+      ]
+    },
+    "watchdog": {
+      "description": "MongoDB watchdog node configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "MongoDB watchdog node cpu requirements",
+          "type": "number",
+          "default": 0.2
+        },
+        "mem": {
+          "description": "MongoDB watchdog node mem requirements",
+          "type": "integer",
+          "default": 96
+        },
+        "delayWatcherStart": {
+          "description": "Amount of time to delay starting replica set watchers, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "20s"
+        },
+        "apiPoll": {
+          "description": "DCOS API poll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "10s"
+        },
+        "apiTimeout": {
+          "description": "Pod API timeout than apiPoll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "5s"
+        },
+        "replsetPoll": {
+          "description": "MongoDB replica set state poll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "5s"
+        },
+        "replsetTimeout": {
+          "description": "MongoDB replica set timeout, should be less than replsetPoll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "3s"
+        },
+        "replsetConfUpdatePoll": {
+          "description": "MongoDB replica set config update frequency, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "10s"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem"
+      ]
+    },
+    "backup": {
+      "description": "Percona-Lab/mongodb_consistent_backup Backup configuration properties. Only mongodump-based backup and AWS S3 (for backup storage) is supported currently",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable backups",
+          "description": "Enable backups",
+          "type": "boolean",
+          "default": false
+        },
+        "hiddenSecondaryEnabled": {
+          "title": "Add dedicated MongoDB backup node",
+          "description": "Add a hidden-secondary MongoDB node dedicated to backup operations. This node cannot become primary and is invible to MongoDB drivers. The node will inherit any config options passed to the other mongod nodes",
+          "type": "boolean",
+          "default": true
+        },
+        "hiddenSecondaryCpus": {
+          "title": "Dedicated MongoDB backup node cpus",
+          "description": "MongoDB backup hidden-secondary node cpu requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "hiddenSecondaryMem": {
+          "title": "Dedicated MongoDB backup node mem",
+          "description": "MongoDB backup hidden-secondary node mem requirements, in megabytes",
+          "type": "integer",
+          "default": 1024
+        },
+        "backupCpus": {
+          "title": "Backup node cpus",
+          "description": "mongodb_consistent_backup node cpu requirements",
+          "type": "number",
+          "default": 2.0
+        },
+        "backupMem": {
+          "title": "Backup node mem",
+          "description": "mongodb_consistent_backup node mem requirements, in megabytes",
+          "type": "integer",
+          "default": 1024
+        },
+        "backupVersion": {
+          "title": "mongodb_consistent_backup version",
+          "description": "mongodb_consistent_backup version Dockerhub tag, see perconalab/mongodb_consistent_backup Dockerhub page for available versions. Version must be 1.3.0 or greater!",
+          "type": "string",
+          "default": "1.3.0"
+        },
+        "archiveMethod": {
+          "title": "archive.method",
+          "description": "mongodb_consistent_backup archive method (none or tar)",
+          "enum": [
+            "none",
+            "tar"
+          ],
+          "type": "string",
+          "default": "none"
+        },
+        "uploadThreads": {
+          "title": "upload.threads",
+          "description": "mongodb_consistent_backup upload thread count",
+          "type": "integer",
+          "default": 4
+        },
+        "uploadRetries": {
+          "title": "upload.retries",
+          "description": "mongodb_consistent_backup upload retry count",
+          "type": "integer",
+          "default": 5
+        },
+        "uploadS3Region": {
+          "title": "upload.s3.region",
+          "description": "mongodb_consistent_backup upload s3 region for upload",
+          "type": "string",
+          "default": "us-east-1"
+        },
+        "uploadS3AccessKey": {
+          "title": "upload.s3.access_key",
+          "description": "mongodb_consistent_backup upload s3 access key",
+          "type": "string",
+          "default": ""
+        },
+        "uploadS3SecretKey": {
+          "title": "upload.s3.secret_key",
+          "description": "mongodb_consistent_backup upload s3 secret key",
+          "type": "string",
+          "default": ""
+        },
+        "uploadS3BucketName": {
+          "title": "upload.s3.bucket_name",
+          "description": "mongodb_consistent_backup upload s3 bucket name",
+          "type": "string",
+          "default": ""
+        },
+        "uploadS3BucketPrefix": {
+          "title": "upload.s3.bucket_prefix",
+          "description": "mongodb_consistent_backup upload s3 bucket key prefix",
+          "type": "string",
+          "default": "/"
+        },
+        "uploadS3ObjectACL": {
+          "title": "upload.s3.object_acl",
+          "description": "mongodb_consistent_backup upload s3 object acl",
+          "type": "string",
+          "default": ""
+        },
+        "uploadS3UploadChunkSizeMb": {
+          "title": "upload.s3.chunk_size_mb",
+          "description": "mongodb_consistent_backup upload s3 chunk size in megabytes",
+          "type": "integer",
+          "default": 50
+        },
+        "verbose": {
+          "description": "Enable mongodb_consistent_backup verbose logging",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "enabled",
+        "hiddenSecondaryEnabled",
+        "hiddenSecondaryCpus",
+        "hiddenSecondaryMem",
+        "backupCpus",
+        "backupMem",
+        "backupVersion",
+        "archiveMethod",
+        "uploadThreads",
+        "uploadRetries",
+        "uploadS3Region",
+        "uploadS3BucketPrefix",
+        "uploadS3UploadChunkSizeMb",
+        "verbose"
+      ]
+    },
+    "percona-pmm": {
+      "description": "Percona PMM monitoring configuration properties. This section assumes you have setup a PMM server beforehand, ie: it does NOT create a PMM server!",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable Percona PMM monitoring",
+          "description": "Enable Percona Monitoring & Management (PMM) monitoring of MongoDB and Linux",
+          "type": "boolean",
+          "default": false
+        },
+        "enableQueryAnalytics": {
+          "title": "Enable PMM Query Analytics (QAN) for MongoDB",
+          "description": "Enable Percona PMM Query Analytics (QAN) for MongoDB. This feature uses query profiles to analyse MongoDB queries and commands",
+          "type": "boolean",
+          "default": true
+        },
+        "clientVersion": {
+          "title": "Percona PMM client version",
+          "description": "Percona PMM client version, currently only the versions displayed are supported!",
+          "type": "string",
+          "enum": [
+            "1.8.1"
+          ],
+          "default": "1.8.1"
+        },
+        "serverAddress": {
+          "title": "Percona PMM server address",
+          "description": "Percona PMM server address. Include a port number after a colon for non-standard ports, ie: 'pmm.my-domain.com:8080'",
+          "type": "string",
+          "default": "pmm-server.marathon.l4lb.thisdcos.directory:80"
+        },
+        "serverUseSSL": {
+          "title": "Use SSL connections",
+          "description": "Use SSL for communication with the PMM server",
+          "type": "boolean",
+          "default": false
+        },
+        "serverUseInsecureSSL": {
+          "title": "Use Insecure SSL connections",
+          "description": "Use SSL without validation for communication with the PMM server",
+          "type": "boolean",
+          "default": false
+        },
+        "serverUser": {
+          "title": "PMM Server username",
+          "description": "Username to be used for connections to the PMM Server. Automatically enables authentication",
+          "type": "string",
+          "default": ""
+        },
+        "serverPassword": {
+          "title": "PMM Server password",
+          "description": "Password to be used for connections to the PMM Server. A PMM Server username is required",
+          "type": "string",
+          "default": ""
+        },
+        "linuxMetricsExporterPort": {
+          "title": "PMM Client Linux metrics port",
+          "description": "Port to run the Linux operating system metrics exporter on, default of '0' will use a random, available port (recommended)",
+          "type": "integer",
+          "default": 0
+        },
+        "mongodbMetricsExporterPort": {
+          "title": "PMM Client MongoDB metrics port",
+          "description": "Port to run the MongoDB database metrics exporter on, default of '0' will use a random, available port (recommended)",
+          "type": "integer",
+          "default": 0
+        }
+      },
+      "required": [
+        "enabled",
+        "enableQueryAnalytics",
+        "clientVersion",
+        "serverAddress",
+        "serverUseSSL",
+        "serverUseInsecureSSL",
+        "linuxMetricsExporterPort",
+        "mongodbMetricsExporterPort"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/percona-mongo/1/marathon.json.mustache
+++ b/repo/packages/P/percona-mongo/1/marathon.json.mustache
@@ -1,0 +1,223 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./mongo-scheduler/bin/mongo ./mongo-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.secret_name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.secret_name}}"
+    }
+  },
+  {{/service.secret_name}}
+  "env": {
+    "PACKAGE_NAME": "percona-mongo",
+    "PACKAGE_VERSION": "0.2.0-3.4.13",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1522411894991",
+    "PACKAGE_BUILD_TIME_STR": "Fri Mar 30 2018 12:11:34 +0000",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "SLEEP_DURATION": "{{service.sleep}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+
+    "CONFIG_TEMPLATE_PATH": "mongo-scheduler",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "MONGODB_TOOLS_URI": "{{resource.assets.uris.mongodb-tools-zip}}",
+
+    "MONGODB_PORT": "{{mongodb.port}}",
+    "MONGODB_COUNT": "{{mongodb.count}}",
+    "MONGODB_CPUS": "{{mongodb.cpus}}",
+    "MONGODB_MEM": "{{mongodb.mem}}",
+    "MONGODB_DISK_SIZE": "{{mongodb.disk}}",
+    "MONGODB_DISK_TYPE": "{{mongodb.diskType}}",
+    "MONGODB_REPLSET": "{{mongodb.replicaSetName}}",
+    "MONGODB_USER_ADMIN_USER": "{{mongodb.userAdminUser}}",
+    "MONGODB_USER_ADMIN_PASSWORD": "{{mongodb.userAdminPassword}}",
+    "MONGODB_CLUSTER_ADMIN_USER": "{{mongodb.clusterAdminUser}}",
+    "MONGODB_CLUSTER_ADMIN_PASSWORD": "{{mongodb.clusterAdminPassword}}",
+    "MONGODB_BACKUP_USER": "{{mongodb.backupUser}}",
+    "MONGODB_BACKUP_PASSWORD": "{{mongodb.backupPassword}}",
+    "MONGODB_CLUSTER_MONITOR_USER": "{{mongodb.clusterMonitorUser}}",
+    "MONGODB_CLUSTER_MONITOR_PASSWORD": "{{mongodb.clusterMonitorPassword}}",
+    "MONGODB_KEY": "{{mongodb.key}}",
+    {{#mongodb.constraint}}
+        "MONGODB_CONSTRAINT": "{{mongodb.constraint}}",
+    {{/mongodb.constraint}}
+    "MONGODB_VERSION": "{{mongodb.version}}",
+    "MONGODB_STORAGE_ENGINE": "{{mongodb.storageEngine}}",
+
+    "MONGODB_NOFILE_LIMIT": "{{mongodb-advanced.openFileLimit}}",
+    "MONGODB_NPROC_LIMIT": "{{mongodb-advanced.processLimit}}",
+    
+    "MONGODB_SECURITY_JAVASCRIPT_ENABLED": "{{mongodb-advanced.securityJavascriptEnabled}}",
+    "MONGODB_SECURITY_REDACT_CLIENT_LOG_DATA": "{{mongodb-advanced.securityRedactClientLogData}}",
+
+    "MONGODB_STORAGE_INDEX_BUILD_RETRY": "{{mongodb-advanced.storageIndexBuildRetry}}",
+    "MONGODB_STORAGE_JOURNAL_COMMIT_INTERVAL_MS": "{{mongodb-advanced.storageJournalCommitIntervalMs}}",
+    "MONGODB_STORAGE_DIRECTORY_PER_DB": "{{mongodb-advanced.storageDirectoryPerDB}}",
+    "MONGODB_STORAGE_SYNC_PERIOD_SECS": "{{mongodb-advanced.storageSyncPeriodSecs}}",
+
+    "MONGODB_STORAGE_MMAPV1_PREALLOC_DATA_FILES": "{{mongodb-advanced.storageMMAPv1PreallocDataFiles}}",
+    "MONGODB_STORAGE_MMAPV1_NS_SIZE": "{{mongodb-advanced.storageMMAPv1NsSize}}",
+    "MONGODB_STORAGE_MMAPV1_QUOTA_ENFORCED": "{{mongodb-advanced.storageMMAPv1QuotaEnforced}}",
+    "MONGODB_STORAGE_MMAPV1_MAX_FILES_PER_DB": "{{mongodb-advanced.storageMMAPv1QuotaMaxFilesPerDB}}",
+    "MONGODB_STORAGE_MMAPV1_SMALLFILES": "{{mongodb-advanced.storageMMAPv1SmallFiles}}",
+
+    "MONGODB_STORAGE_WIREDTIGER_ENGINE_CONFIG_CACHE_SIZE_GB": "{{mongodb-advanced.storageWiredTigerEngineConfigCacheSizeGB}}",
+    "MONGODB_STORAGE_WIREDTIGER_ENGINE_CONFIG_JOURNAL_COMPRESSOR": "{{mongodb-advanced.storageWiredTigerEngineConfigJournalCompressor}}",
+    "MONGODB_STORAGE_WIREDTIGER_ENGINE_CONFIG_DIRECTORY_FOR_INDEXES": "{{mongodb-advanced.storageWiredTigerEngineConfigDirectoryForIndexes}}",
+    "MONGODB_STORAGE_WIREDTIGER_COLLECTION_CONFIG_BLOCK_COMPRESSOR": "{{mongodb-advanced.storageWiredTigerCollectionConfigBlockCompressor}}",
+    "MONGODB_STORAGE_WIREDTIGER_INDEX_CONFIG_PREFIX_COMPRESSION": "{{mongodb-advanced.storageWiredTigerIndexConfigPrefixCompression}}",
+
+    "MONGODB_STORAGE_ROCKSDB_CACHE_SIZE_GB": "{{mongodb-advanced.storageRocksDBCacheSizeGB}}",
+    "MONGODB_STORAGE_ROCKSDB_COMPRESSION": "{{mongodb-advanced.storageRocksDBCompression}}",
+    "MONGODB_STORAGE_ROCKSDB_WRITE_MB_PER_SEC": "{{mongodb-advanced.storageRocksDBMaxWriteMBPerSec}}",
+    "MONGODB_STORAGE_ROCKSDB_CRASH_SAFE_COUNTERS": "{{mongodb-advanced.storageRocksDBCrashSafeCounters}}",
+
+    "MONGODB_SET_PARAMETER_AUDIT_AUTHORIZATION_SUCCESS": "{{mongodb-auditlog.auditAuthorizationSuccess}}",
+    "MONGODB_SET_PARAMETER_FAIL_INDEX_KEY_TOO_LONG": "{{mongodb-advanced.setParameterFailIndexKeyTooLong}}",
+    "MONGODB_SET_PARAMETER_NO_TABLE_SCAN": "{{mongodb-advanced.setParameterNoTableScan}}",
+    "MONGODB_SET_PARAMETER_DISABLE_JAVASCRIPT_JIT": "{{mongodb-advanced.setParameterDisableJavaScriptJIT}}",
+    "MONGODB_SET_PARAMETER_MAX_INDEX_BUILD_MEMORY_USAGE_MB": "{{mongodb-advanced.setParameterMaxIndexBuildMemoryUsageMB}}",
+    "MONGODB_SET_PARAMETER_LOG_USER_IDS": "{{mongodb-advanced.setParameterLogUserIds}}",
+    "MONGODB_SET_PARAMETER_REPL_WRITER_THREAD_COUNT": "{{mongodb-advanced.setParameterReplWriterThreadCount}}",
+    "MONGODB_SET_PARAMETER_TTL_MONITOR_ENABLED": "{{mongodb-advanced.setParameterTTLMonitorEnabled}}",
+    "MONGODB_SET_PARAMETER_TTL_MONITOR_SLEEP_SECS": "{{mongodb-advanced.setParameterTTLMonitorSleepSecs}}",
+    "MONGODB_SET_PARAMETER_ROCKSDB_CONCURRENT_READ_TRANSACTIONS": "{{mongodb-advanced.setParameterRocksDBConcurrentReadTransactions}}",
+    "MONGODB_SET_PARAMETER_ROCKSDB_CONCURRENT_WRITE_TRANSACTIONS": "{{mongodb-advanced.setParameterRocksDBConcurrentWriteTransactions}}",
+    "MONGODB_SET_PARAMETER_WIREDTIGER_CONCURRENT_READ_TRANSACTIONS": "{{mongodb-advanced.setParameterWiredTigerConcurrentReadTransactions}}",
+    "MONGODB_SET_PARAMETER_WIREDTIGER_CONCURRENT_WRITE_TRANSACTIONS": "{{mongodb-advanced.setParameterWiredTigerConcurrentWriteTransactions}}",
+
+    "MONGODB_NET_MAX_INCOMING_CONNECTIONS": "{{mongodb-advanced.netMaxIncomingConnections}}",
+
+    "MONGODB_OPERATION_PROFILING_MODE": "{{mongodb-advanced.operationProfilingMode}}",
+    "MONGODB_OPERATION_PROFILING_SLOWOP_THRESHOLD_MS": "{{mongodb-advanced.operationProfilingSlowOpThresholdMs}}",
+    "MONGODB_OPERATION_PROFILING_RATE_LIMIT": "{{mongodb-advanced.operationProfilingRateLimit}}",
+
+    "MONGODB_REPLICATION_SECONDARY_INDEX_PREFETCH": "{{mongodb-advanced.replicationSecondaryIndexPrefetch}}",
+    "MONGODB_REPLICATION_ENABLE_MAJORITY_READ_CONCERN": "{{mongodb-advanced.replicationEnableMajorityReadConcern}}",
+
+    "MONGODB_AUDIT_LOG_ENABLED": "{{mongodb-auditlog.enabled}}",
+    "MONGODB_AUDIT_LOG_FILTER": "{{mongodb-auditlog.filter}}",
+
+    "MONGODB_SYSTEM_LOG_VERBOSITY": "{{mongodb-advanced.systemLogVerbosity}}",
+    "MONGODB_SYSTEM_LOG_TRACE_ALL_EXCEPTIONS": "{{mongodb-advanced.systemTraceAllExceptions}}",
+    "MONGODB_SYSTEM_LOG_TIMESTAMP_FORMAT": "{{mongodb-advanced.systemLogTimestampFormat}}",
+
+    {{#service.virtual_networks}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{node.virtual_network}}",
+    "CNI_PLUGIN_LABELS": "{{node.cni_plugin_labels}}",
+    {{/service.virtual_networks}}
+
+    "INIT_CPUS": "{{init.cpus}}",
+    "INIT_MEM": "{{init.mem}}",
+    "INIT_INITIATE_DELAY": "{{init.initiateDelay}}",
+    "INIT_MAX_CONNECT_TRIES": "{{init.maxConnectTries}}",
+    "INIT_MAX_INIT_REPLSET_TRIES": "{{init.maxInitReplsetTries}}",
+    "INIT_MAX_ADD_USERS_TRIES": "{{init.maxAddUsersTries}}",
+    "INIT_RETRY_SLEEP": "{{init.retrySleep}}",
+
+    "WATCHDOG_CPUS": "{{watchdog.cpus}}",
+    "WATCHDOG_MEM": "{{watchdog.mem}}",
+    "WATCHDOG_API_TIMEOUT": "{{watchdog.apiTimeout}}",
+    "WATCHDOG_API_POLL": "{{watchdog.apiPoll}}",
+    "WATCHDOG_REPLSET_TIMEOUT": "{{watchdog.replsetTimeout}}",
+    "WATCHDOG_REPLSET_POLL": "{{watchdog.replsetPoll}}",
+    "WATCHDOG_REPLSET_CONF_UPDATE_POLL": "{{watchdog.replsetConfUpdatePoll}}",
+    "WATCHDOG_DELAY_WATCHER_START": "{{watchdog.delayWatcherStart}}",
+
+    "BACKUP_ENABLED": "{{backup.enabled}}",
+    {{#backup.enabled}}
+    "BACKUP_HIDDEN_SECONDARY_ENABLED": "{{backup.hiddenSecondaryEnabled}}",
+    "BACKUP_HIDDEN_SECONDARY_CPUS": "{{backup.hiddenSecondaryCpus}}",
+    "BACKUP_HIDDEN_SECONDARY_MEM": "{{backup.hiddenSecondaryMem}}",
+    "BACKUP_CPUS": "{{backup.backupCpus}}",
+    "BACKUP_MEM": "{{backup.backupMem}}",
+    "BACKUP_VERSION": "{{backup.backupVersion}}",
+    "BACKUP_VERBOSE": "{{backup.verbose}}",
+    "BACKUP_ARCHIVE_METHOD": "{{backup.archiveMethod}}",
+    "BACKUP_UPLOAD_THREADS": "{{backup.uploadThreads}}",
+    "BACKUP_UPLOAD_RETRIES": "{{backup.uploadRetries}}",
+    "BACKUP_UPLOAD_S3_REGION": "{{backup.uploadS3Region}}",
+    "BACKUP_UPLOAD_S3_ACCESS_KEY": "{{backup.uploadS3AccessKey}}",
+    "BACKUP_UPLOAD_S3_SECRET_KEY": "{{backup.uploadS3SecretKey}}",
+    "BACKUP_UPLOAD_S3_BUCKET_NAME": "{{backup.uploadS3BucketName}}",
+    "BACKUP_UPLOAD_S3_BUCKET_PREFIX": "{{backup.uploadS3BucketPrefix}}",
+    "BACKUP_UPLOAD_S3_OBJECT_ACL": "{{backup.uploadS3ObjectACL}}",
+    "BACKUP_UPLOAD_S3_CHUNK_SIZE_MB": "{{backup.uploadS3UploadChunkSizeMb}}",
+    {{/backup.enabled}}
+
+    "PMM_ENABLED": "{{percona-pmm.enabled}}",
+    {{#percona-pmm.enabled}}
+    "PMM_ENABLE_QUERY_ANALYTICS": "{{percona-pmm.enableQueryAnalytics}}",
+    "PMM_CLIENT_VERSION": "{{percona-pmm.clientVersion}}",
+    "PMM_SERVER_ADDRESS": "{{percona-pmm.serverAddress}}",
+    "PMM_SERVER_USE_SSL": "{{percona-pmm.serverUseSSL}}",
+    "PMM_SERVER_USE_INSECURE_SSL": "{{percona-pmm.serverUseInsecureSSL}}",
+    "PMM_SERVER_USER": "{{percona-pmm.serverUser}}",
+    "PMM_SERVER_PASSWORD": "{{percona-pmm.serverPassword}}",
+    "PMM_LINUX_METRICS_EXPORTER_PORT": "{{percona-pmm.linuxMetricsExporterPort}}",
+    "PMM_MONGODB_METRICS_EXPORTER_PORT": "{{percona-pmm.mongodbMetricsExporterPort}}",
+    {{/percona-pmm.enabled}}
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    {{#service.secret_name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.secret_name}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.mongodb-tools-zip}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/percona-mongo/1/package.json
+++ b/repo/packages/P/percona-mongo/1/package.json
@@ -19,7 +19,7 @@
         "percona",
         "nosql"
     ],
-    "postInstallNotes": "DC/OS Mongo is being installed!\n\n\tDocumentation: https://www.percona.com/software/mongo-database/documentation and https://docs.mongodb.com/manual\n\tMongoDB Release Notes: https://docs.mongodb.com/manual/release-notes",
+    "postInstallNotes": "The DC/OS Mongo service is being installed. \n\n\tDocumentation: https://docs.mesosphere.com/service-docs/percona-mongo/\n\tIssues: mesosphere@percona.com",
     "postUninstallNotes": "DC/OS Mongo is being uninstalled.",
-    "preInstallNotes": "Community packages are unverified and unreviewed content for the community but we are tracking to make it a certified framework.\n\nDefault configuration requires 3 agent nodes each with: 1.0 CPU | 1024 MB MEM\n\nSupported Percona Server for MongoDB versions: 3.4.10. Use other versions at your own risk!\n\nNote: MongoDB replica sets with less than 3 nodes are unsupported and untested!\n\nFramework Documentation: https://github.com/dcos/examples/tree/master/percona-mongo"
+    "preInstallNotes": "Default configuration requires 3 agent nodes each with: 1.0 CPU | 1024 MB MEM | 1 1000 MB Disk"
 }

--- a/repo/packages/P/percona-mongo/1/package.json
+++ b/repo/packages/P/percona-mongo/1/package.json
@@ -1,0 +1,25 @@
+{
+    "packagingVersion": "4.0",
+    "upgradesFrom": [
+        "*"
+    ],
+    "downgradesTo": [
+        "*"
+    ],
+    "minDcosReleaseVersion": "1.10",
+    "name": "percona-mongo",
+    "version": "0.2.0-3.4.13",
+    "maintainer": "mesosphere@percona.com",
+    "description": "Percona Server for MongoDB Replica Set on Mesosphere DC/OS",
+    "selected": false,
+    "framework": true,
+    "tags": [
+        "mongo",
+        "mongodb",
+        "percona",
+        "nosql"
+    ],
+    "postInstallNotes": "DC/OS Mongo is being installed!\n\n\tDocumentation: https://www.percona.com/software/mongo-database/documentation and https://docs.mongodb.com/manual\n\tMongoDB Release Notes: https://docs.mongodb.com/manual/release-notes",
+    "postUninstallNotes": "DC/OS Mongo is being uninstalled.",
+    "preInstallNotes": "Community packages are unverified and unreviewed content for the community but we are tracking to make it a certified framework.\n\nDefault configuration requires 3 agent nodes each with: 1.0 CPU | 1024 MB MEM\n\nSupported Percona Server for MongoDB versions: 3.4.10. Use other versions at your own risk!\n\nNote: MongoDB replica sets with less than 3 nodes are unsupported and untested!\n\nFramework Documentation: https://github.com/dcos/examples/tree/master/percona-mongo"
+}

--- a/repo/packages/P/percona-mongo/1/resource.json
+++ b/repo/packages/P/percona-mongo/1/resource.json
@@ -1,0 +1,57 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
+      "scheduler-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/mongo-scheduler.zip",
+      "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.30.3/executor.zip",
+      "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.30.3/bootstrap.zip",
+      "mongodb-tools-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/mongodb-tools.zip"
+    }
+  },
+  "images": {
+    "icon-small": "https://www.percona.com/sites/default/files/PSfMDB-48.png",
+    "icon-medium": "https://www.percona.com/sites/default/files/PSfMDB-96.png",
+    "icon-large": "https://www.percona.com/sites/default/files/PSfMDB-256.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "dc1748bd88b423ea2632c034555024a5e579208f5766c345c04f555e7b5ba817"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "d17c2418988dabf056595e7280b754342064fbceb880d363121115c6524c614a"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "d2aeddbd3e11c4c2fbba8cb538427a52eaf5b036ae638af928e8268ff9aa77b3"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release percona-mongo 0.2.0-3.4.13 (automated commit)

Description:
dc/os percona mongo service release 0.2.0

Source URL: https://percona-dcos-mongo.s3.amazonaws.com/autodelete7d/percona-mongo/20180330-121114-ZXw6o3fVwThrWM9P/stub-universe-percona-mongo.json

Changes since revision 0:
0 files added: []
0 files removed: []
4 files changed:

```
--- 0/config.json
+++ 1/config.json
@@ -80,6 +80,15 @@
           "type": "integer",
           "default": 1000
         },
+        "diskType": {
+          "description": "MongoDB server node disk type, see DCOS documentation regarding Disk Resources for more info",
+          "type": "string",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
         "count": {
           "description": "Number of MongoDB replica set members/nodes to run. 1, 3, 5 or 7 node count is possible",
           "type": "integer",
@@ -105,7 +114,11 @@
         "version": {
           "description": "Percona MongoDB server version. See Pre-Install Notes for supported versions, use other versions at your own risk!",
           "type": "string",
-          "default": "3.4.10"
+          "enum": [
+            "3.4.10",
+            "3.4.13"
+          ],
+          "default": "3.4.13"
         },
         "constraint": {
           "description": "Marathon-style constraint for MongoDB server nodes (use empty string to override the default hostname UNIQUE behavior)",
@@ -620,12 +633,229 @@
           "description": "MongoDB replica set timeout, should be less than replsetPoll frequency, must end in 's' for seconds, 'm' for minutes, etc",
           "type": "string",
           "default": "3s"
+        },
+        "replsetConfUpdatePoll": {
+          "description": "MongoDB replica set config update frequency, must end in 's' for seconds, 'm' for minutes, etc",
+          "type": "string",
+          "default": "10s"
         }
       },
       "required": [
         "cpus",
         "mem"
       ]
+    },
+    "backup": {
+      "description": "Percona-Lab/mongodb_consistent_backup Backup configuration properties. Only mongodump-based backup and AWS S3 (for backup storage) is supported currently",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable backups",
+          "description": "Enable backups",
+          "type": "boolean",
+          "default": false
+        },
+        "hiddenSecondaryEnabled": {
+          "title": "Add dedicated MongoDB backup node",
+          "description": "Add a hidden-secondary MongoDB node dedicated to backup operations. This node cannot become primary and is invible to MongoDB drivers. The node will inherit any config options passed to the other mongod nodes",
+          "type": "boolean",
+          "default": true
+        },
+        "hiddenSecondaryCpus": {
+          "title": "Dedicated MongoDB backup node cpus",
+          "description": "MongoDB backup hidden-secondary node cpu requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "hiddenSecondaryMem": {
+          "title": "Dedicated MongoDB backup node mem",
+          "description": "MongoDB backup hidden-secondary node mem requirements, in megabytes",
+          "type": "integer",
+          "default": 1024
+        },
+        "backupCpus": {
+          "title": "Backup node cpus",
+          "description": "mongodb_consistent_backup node cpu requirements",
+          "type": "number",
+          "default": 2.0
+        },
+        "backupMem": {
+          "title": "Backup node mem",
+          "description": "mongodb_consistent_backup node mem requirements, in megabytes",
+          "type": "integer",
+          "default": 1024
+        },
+        "backupVersion": {
+          "title": "mongodb_consistent_backup version",
+          "description": "mongodb_consistent_backup version Dockerhub tag, see perconalab/mongodb_consistent_backup Dockerhub page for available versions. Version must be 1.3.0 or greater!",
+          "type": "string",
+          "default": "1.3.0"
+        },
+        "archiveMethod": {
+          "title": "archive.method",
+          "description": "mongodb_consistent_backup archive method (none or tar)",
+          "enum": [
+            "none",
+            "tar"
+          ],
+          "type": "string",
+          "default": "none"
+        },
+        "uploadThreads": {
+          "title": "upload.threads",
+          "description": "mongodb_consistent_backup upload thread count",
+          "type": "integer",
+          "default": 4
+        },
+        "uploadRetries": {
+          "title": "upload.retries",
+          "description": "mongodb_consistent_backup upload retry count",
+          "type": "integer",
+          "default": 5
+        },
+        "uploadS3Region": {
+          "title": "upload.s3.region",
+          "description": "mongodb_consistent_backup upload s3 region for upload",
+          "type": "string",
+          "default": "us-east-1"
+        },
+        "uploadS3AccessKey": {
+          "title": "upload.s3.access_key",
+          "description": "mongodb_consistent_backup upload s3 access key",
+          "type": "string",
+          "default": ""
+        },
+        "uploadS3SecretKey": {
+          "title": "upload.s3.secret_key",
+          "description": "mongodb_consistent_backup upload s3 secret key",
+          "type": "string",
+          "default": ""
+        },
+        "uploadS3BucketName": {
+          "title": "upload.s3.bucket_name",
+          "description": "mongodb_consistent_backup upload s3 bucket name",
+          "type": "string",
+          "default": ""
+        },
+        "uploadS3BucketPrefix": {
+          "title": "upload.s3.bucket_prefix",
+          "description": "mongodb_consistent_backup upload s3 bucket key prefix",
+          "type": "string",
+          "default": "/"
+        },
+        "uploadS3ObjectACL": {
+          "title": "upload.s3.object_acl",
+          "description": "mongodb_consistent_backup upload s3 object acl",
+          "type": "string",
+          "default": ""
+        },
+        "uploadS3UploadChunkSizeMb": {
+          "title": "upload.s3.chunk_size_mb",
+          "description": "mongodb_consistent_backup upload s3 chunk size in megabytes",
+          "type": "integer",
+          "default": 50
+        },
+        "verbose": {
+          "description": "Enable mongodb_consistent_backup verbose logging",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "required": [
+        "enabled",
+        "hiddenSecondaryEnabled",
+        "hiddenSecondaryCpus",
+        "hiddenSecondaryMem",
+        "backupCpus",
+        "backupMem",
+        "backupVersion",
+        "archiveMethod",
+        "uploadThreads",
+        "uploadRetries",
+        "uploadS3Region",
+        "uploadS3BucketPrefix",
+        "uploadS3UploadChunkSizeMb",
+        "verbose"
+      ]
+    },
+    "percona-pmm": {
+      "description": "Percona PMM monitoring configuration properties. This section assumes you have setup a PMM server beforehand, ie: it does NOT create a PMM server!",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable Percona PMM monitoring",
+          "description": "Enable Percona Monitoring & Management (PMM) monitoring of MongoDB and Linux",
+          "type": "boolean",
+          "default": false
+        },
+        "enableQueryAnalytics": {
+          "title": "Enable PMM Query Analytics (QAN) for MongoDB",
+          "description": "Enable Percona PMM Query Analytics (QAN) for MongoDB. This feature uses query profiles to analyse MongoDB queries and commands",
+          "type": "boolean",
+          "default": true
+        },
+        "clientVersion": {
+          "title": "Percona PMM client version",
+          "description": "Percona PMM client version, currently only the versions displayed are supported!",
+          "type": "string",
+          "enum": [
+            "1.8.1"
+          ],
+          "default": "1.8.1"
+        },
+        "serverAddress": {
+          "title": "Percona PMM server address",
+          "description": "Percona PMM server address. Include a port number after a colon for non-standard ports, ie: 'pmm.my-domain.com:8080'",
+          "type": "string",
+          "default": "pmm-server.marathon.l4lb.thisdcos.directory:80"
+        },
+        "serverUseSSL": {
+          "title": "Use SSL connections",
+          "description": "Use SSL for communication with the PMM server",
+          "type": "boolean",
+          "default": false
+        },
+        "serverUseInsecureSSL": {
+          "title": "Use Insecure SSL connections",
+          "description": "Use SSL without validation for communication with the PMM server",
+          "type": "boolean",
+          "default": false
+        },
+        "serverUser": {
+          "title": "PMM Server username",
+          "description": "Username to be used for connections to the PMM Server. Automatically enables authentication",
+          "type": "string",
+          "default": ""
+        },
+        "serverPassword": {
+          "title": "PMM Server password",
+          "description": "Password to be used for connections to the PMM Server. A PMM Server username is required",
+          "type": "string",
+          "default": ""
+        },
+        "linuxMetricsExporterPort": {
+          "title": "PMM Client Linux metrics port",
+          "description": "Port to run the Linux operating system metrics exporter on, default of '0' will use a random, available port (recommended)",
+          "type": "integer",
+          "default": 0
+        },
+        "mongodbMetricsExporterPort": {
+          "title": "PMM Client MongoDB metrics port",
+          "description": "Port to run the MongoDB database metrics exporter on, default of '0' will use a random, available port (recommended)",
+          "type": "integer",
+          "default": 0
+        }
+      },
+      "required": [
+        "enabled",
+        "enableQueryAnalytics",
+        "clientVersion",
+        "serverAddress",
+        "serverUseSSL",
+        "serverUseInsecureSSL",
+        "linuxMetricsExporterPort",
+        "mongodbMetricsExporterPort"
+      ]
     }
   }
 }
--- 0/marathon.json.mustache
+++ 1/marathon.json.mustache
@@ -22,9 +22,9 @@
   {{/service.secret_name}}
   "env": {
     "PACKAGE_NAME": "percona-mongo",
-    "PACKAGE_VERSION": "0.1.0-3.4.10",
-    "PACKAGE_BUILD_TIME_EPOCH_MS": "1516650166499",
-    "PACKAGE_BUILD_TIME_STR": "Mon Jan 22 2018 19:42:46 +0000",
+    "PACKAGE_VERSION": "0.2.0-3.4.13",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1522411894991",
+    "PACKAGE_BUILD_TIME_STR": "Fri Mar 30 2018 12:11:34 +0000",
     "FRAMEWORK_NAME": "{{service.name}}",
     "SLEEP_DURATION": "{{service.sleep}}",
     "FRAMEWORK_USER": "{{service.user}}",
@@ -40,6 +40,7 @@
     "MONGODB_CPUS": "{{mongodb.cpus}}",
     "MONGODB_MEM": "{{mongodb.mem}}",
     "MONGODB_DISK_SIZE": "{{mongodb.disk}}",
+    "MONGODB_DISK_TYPE": "{{mongodb.diskType}}",
     "MONGODB_REPLSET": "{{mongodb.replicaSetName}}",
     "MONGODB_USER_ADMIN_USER": "{{mongodb.userAdminUser}}",
     "MONGODB_USER_ADMIN_PASSWORD": "{{mongodb.userAdminPassword}}",
@@ -134,7 +135,42 @@
     "WATCHDOG_API_POLL": "{{watchdog.apiPoll}}",
     "WATCHDOG_REPLSET_TIMEOUT": "{{watchdog.replsetTimeout}}",
     "WATCHDOG_REPLSET_POLL": "{{watchdog.replsetPoll}}",
+    "WATCHDOG_REPLSET_CONF_UPDATE_POLL": "{{watchdog.replsetConfUpdatePoll}}",
     "WATCHDOG_DELAY_WATCHER_START": "{{watchdog.delayWatcherStart}}",
+
+    "BACKUP_ENABLED": "{{backup.enabled}}",
+    {{#backup.enabled}}
+    "BACKUP_HIDDEN_SECONDARY_ENABLED": "{{backup.hiddenSecondaryEnabled}}",
+    "BACKUP_HIDDEN_SECONDARY_CPUS": "{{backup.hiddenSecondaryCpus}}",
+    "BACKUP_HIDDEN_SECONDARY_MEM": "{{backup.hiddenSecondaryMem}}",
+    "BACKUP_CPUS": "{{backup.backupCpus}}",
+    "BACKUP_MEM": "{{backup.backupMem}}",
+    "BACKUP_VERSION": "{{backup.backupVersion}}",
+    "BACKUP_VERBOSE": "{{backup.verbose}}",
+    "BACKUP_ARCHIVE_METHOD": "{{backup.archiveMethod}}",
+    "BACKUP_UPLOAD_THREADS": "{{backup.uploadThreads}}",
+    "BACKUP_UPLOAD_RETRIES": "{{backup.uploadRetries}}",
+    "BACKUP_UPLOAD_S3_REGION": "{{backup.uploadS3Region}}",
+    "BACKUP_UPLOAD_S3_ACCESS_KEY": "{{backup.uploadS3AccessKey}}",
+    "BACKUP_UPLOAD_S3_SECRET_KEY": "{{backup.uploadS3SecretKey}}",
+    "BACKUP_UPLOAD_S3_BUCKET_NAME": "{{backup.uploadS3BucketName}}",
+    "BACKUP_UPLOAD_S3_BUCKET_PREFIX": "{{backup.uploadS3BucketPrefix}}",
+    "BACKUP_UPLOAD_S3_OBJECT_ACL": "{{backup.uploadS3ObjectACL}}",
+    "BACKUP_UPLOAD_S3_CHUNK_SIZE_MB": "{{backup.uploadS3UploadChunkSizeMb}}",
+    {{/backup.enabled}}
+
+    "PMM_ENABLED": "{{percona-pmm.enabled}}",
+    {{#percona-pmm.enabled}}
+    "PMM_ENABLE_QUERY_ANALYTICS": "{{percona-pmm.enableQueryAnalytics}}",
+    "PMM_CLIENT_VERSION": "{{percona-pmm.clientVersion}}",
+    "PMM_SERVER_ADDRESS": "{{percona-pmm.serverAddress}}",
+    "PMM_SERVER_USE_SSL": "{{percona-pmm.serverUseSSL}}",
+    "PMM_SERVER_USE_INSECURE_SSL": "{{percona-pmm.serverUseInsecureSSL}}",
+    "PMM_SERVER_USER": "{{percona-pmm.serverUser}}",
+    "PMM_SERVER_PASSWORD": "{{percona-pmm.serverPassword}}",
+    "PMM_LINUX_METRICS_EXPORTER_PORT": "{{percona-pmm.linuxMetricsExporterPort}}",
+    "PMM_MONGODB_METRICS_EXPORTER_PORT": "{{percona-pmm.mongodbMetricsExporterPort}}",
+    {{/percona-pmm.enabled}}
 
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
--- 0/package.json
+++ 1/package.json
@@ -8,7 +8,7 @@
     ],
     "minDcosReleaseVersion": "1.10",
     "name": "percona-mongo",
-    "version": "0.1.0-3.4.10",
+    "version": "0.2.0-3.4.13",
     "maintainer": "mesosphere@percona.com",
     "description": "Percona Server for MongoDB Replica Set on Mesosphere DC/OS",
     "selected": false,
--- 0/resource.json
+++ 1/resource.json
@@ -3,10 +3,10 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
-      "scheduler-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.1.0-3.4.10/mongo-scheduler.zip",
+      "scheduler-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/mongo-scheduler.zip",
       "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.30.3/executor.zip",
       "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.30.3/bootstrap.zip",
-      "mongodb-tools-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.1.0-3.4.10/mongodb-tools.zip"
+      "mongodb-tools-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/mongodb-tools.zip"
     }
   },
   "images": {
@@ -21,11 +21,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "20ae7f3477b9873d67085cbe7b162a24bb4edf5eab7afba6eb65804a6faa94d3"
+              "value": "dc1748bd88b423ea2632c034555024a5e579208f5766c345c04f555e7b5ba817"
             }
           ],
           "kind": "executable",
-          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.1.0-3.4.10/dcos-service-cli-darwin"
+          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -33,11 +33,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "e2848b345f24ef875a272f0554ae2fea58f82fe7aaaee46b0213e540357eb88c"
+              "value": "d17c2418988dabf056595e7280b754342064fbceb880d363121115c6524c614a"
             }
           ],
           "kind": "executable",
-          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.1.0-3.4.10/dcos-service-cli-linux"
+          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -45,11 +45,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "977f74aad2b35fdbc8fd020f5c7d1ddf87325f70be69c801107cf74e94f5874c"
+              "value": "d2aeddbd3e11c4c2fbba8cb538427a52eaf5b036ae638af928e8268ff9aa77b3"
             }
           ],
           "kind": "executable",
-          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.1.0-3.4.10/dcos-service-cli.exe"
+          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/dcos-service-cli.exe"
         }
       }
     }
```
