### PR TITLE
Justinrlee fix crdb

### DIFF
--- a/repo/packages/C/cockroachdb/3/marathon.json.mustache
+++ b/repo/packages/C/cockroachdb/3/marathon.json.mustache
@@ -26,7 +26,7 @@
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
-    "COCKROACH_URI": "{{resource.assets.uris.cockroach-binary}}/cockroach-v{{service.version}}.linux-amd64.tgz",
+    "COCKROACH_URI": "{{resource.assets.uris.cockroach-tgz}}",
     "COCKROACH_VERSION": "cockroach-v{{service.version}}.linux-amd64",
     "COCKROACH_CACHE_SIZE": "{{service.cache_size}}",
     "COCKROACH_MAX_SQL_MEMORY": "{{service.max_sql_memory}}",

--- a/repo/packages/C/cockroachdb/3/resource.json
+++ b/repo/packages/C/cockroachdb/3/resource.json
@@ -6,7 +6,7 @@
       "scheduler-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.0-2.0.0/cockroachdb-scheduler.zip",
       "executor-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.0-2.0.0/executor.zip",
       "bootstrap-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.0-2.0.0/bootstrap.zip",
-      "cockroach-binary": "https://binaries.cockroachdb.com"
+      "cockroach-binary": "https://binaries.cockroachdb.com/cockroach-v2.0.0.linux-amd64.tgz"
     }
   },
   "images": {

--- a/repo/packages/C/cockroachdb/3/resource.json
+++ b/repo/packages/C/cockroachdb/3/resource.json
@@ -6,7 +6,7 @@
       "scheduler-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.0-2.0.0/cockroachdb-scheduler.zip",
       "executor-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.0-2.0.0/executor.zip",
       "bootstrap-zip": "https://dcos-cockroachdb.s3.amazonaws.com/dcos/release/2.0.0-2.0.0/bootstrap.zip",
-      "cockroach-binary": "https://binaries.cockroachdb.com/cockroach-v2.0.0.linux-amd64.tgz"
+      "cockroach-tgz": "https://binaries.cockroachdb.com/cockroach-v2.0.0.linux-amd64.tgz"
     }
   },
   "images": {


### PR DESCRIPTION
I'm pretty sure items in the resource.json should be absolute links, not relative paths, cause we use to build local universe (i.e., we try to actually download everything referenced in the resource.json)