### PR TITLE
Fix Cerebro version

### DIFF
--- a/repo/packages/C/cerebro/2/marathon.json.mustache
+++ b/repo/packages/C/cerebro/2/marathon.json.mustache
@@ -24,7 +24,7 @@
     "CEREBRO_LDAP_BASE": "{{authentication.ldap.base}}",
     "CEREBRO_LDAP_METHOD": "{{authentication.ldap.method}}",
     "CEREBRO_LDAP_DOMAIN": "{{authentication.ldap.domain}}",
-    "CEREBRO_VERSION": "0.7.1",
+    "CEREBRO_VERSION": "0.7.2",
     "ES_1": "{{elastic.cluster_1}}",
     "ES_2": "{{elastic.cluster_2}}",
     "ES_3": "{{elastic.cluster_3}}",


### PR DESCRIPTION
Fix typo in latest release, incorrect version breaks command to run the service.