### PR TITLE
Support DC/OS 1.13 and Improve user facing error messages of universe converter

### DIFF
--- a/converter/Dockerfile
+++ b/converter/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a base image
-FROM python:3
+FROM python:3.7
 
 # Set the working directory to the /converter directory
 WORKDIR /converter

--- a/converter/README.md
+++ b/converter/README.md
@@ -13,7 +13,12 @@ docker push "<your_org>/universe-converter:dev"
 ```
 
 2. The docker build should have generated a `target/marathon.json`
-3. Use the above marathon app defintion to launch a marathon app in any cluster.
+3. Use the above marathon app defintion to launch a marathon app in any cluster. If testing from outside the cluster, these labels need to be added :
+```
+     "DCOS_SERVICE_NAME": "transform",
+     "DCOS_SERVICE_SCHEME": "http",
+     "DCOS_SERVICE_PORT_INDEX": "0"
+```
 4. Once the app is healthy, we can ssh to one of the nodes and execute bunch of curl calls. Here is a sample : 
 
 ```bash

--- a/converter/README.md
+++ b/converter/README.md
@@ -1,0 +1,32 @@
+# Universe Converter
+
+Wiki : https://wiki.mesosphere.com/display/OPS/Universe+Converter+Service
+
+
+### Testing
+
+1. Build a docker image for the converter locally with something like : 
+
+```bash
+DOCKER_IMAGE="<your_org>/universe-converter"  DOCKER_TAG="dev" ./converter/build.bash
+docker push "<your_org>/universe-converter:dev"
+```
+
+2. The docker build should have generated a `target/marathon.json`
+3. Use the above marathon app defintion to launch a marathon app in any cluster.
+4. Once the app is healthy, we can ssh to one of the nodes and execute bunch of curl calls. Here is a sample : 
+
+```bash
+# Export a stub url you want to test.
+STUB_UNIVERSE_URL=<Any_stub_url>
+
+# Test all the happy paths.
+for i in v5,1.13 v5,1.12 v4,1.13 v4,1.12 v4,1.11 v4,1.10 v3,1.9; do
+    IFS=',' read packaging_version dcos_version <<< "${i}"
+    echo "Testing ${packaging_version} for ${dcos_version}"
+    curl -f -X GET "http://transform.marathon.mesos:8086/transform?url=${STUB_UNIVERSE_URL}" \
+         -H "Accept: application/vnd.dcos.universe.repo+json;charset=utf-8;version=${packaging_version}" \
+         -H "User-Agent: cosmos/0.6.0 dcos/${dcos_version}" \
+         -o /dev/null
+done
+```

--- a/converter/marathon.json
+++ b/converter/marathon.json
@@ -10,20 +10,20 @@
       "image": "mesosphere/universe-converter:dev"
     }
   },
-  "env" : {
-    "MAX_REPO_SIZE" : "20",
-    "LOGLEVEL" : "INFO"
+  "env": {
+    "MAX_REPO_SIZE": "20",
+    "LOGLEVEL": "INFO"
   },
-  "networks" : [
+  "networks": [
     {
       "mode": "HOST"
     }
   ],
   "portDefinitions": [
     {
-      "name" : "universeconverter",
-      "port" : 8086,
-      "protocol" : "tcp"
+      "name": "universeconverter",
+      "port": 8086,
+      "protocol": "tcp"
     }
   ],
   "labels": {

--- a/converter/service/converter.py
+++ b/converter/service/converter.py
@@ -37,7 +37,7 @@ transform_url_path = '/transform'
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
-    level=os.environ.get('LOGLEVEL', 'INFO'),
+    level=os.environ.get('LOGLEVEL', 'DEBUG'),
     format='[%(asctime)s|%(threadName)s|%(levelname)s]: %(message)s'
 )
 
@@ -203,6 +203,7 @@ def render_json(packages, dcos_version, repo_version):
         dcos_version
     )
     packages_dict = {json_key_packages: processed_packages}
+    logger.info('validation for {}'.format(repo_version))
     errors = gen_universe.validate_repo_with_schema(
         packages_dict,
         repo_version

--- a/converter/service/converter.py
+++ b/converter/service/converter.py
@@ -112,9 +112,7 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         self.send_response(HTTPStatus.OK)
-        content_header = gen_universe.format_universe_repo_content_type(
-            _get_repo_version(accept))
-        self.send_header(header_content_type, content_header)
+        self.send_header(header_content_type, accept)
         self.send_header(header_content_length, len(json_response))
         self.end_headers()
         self.wfile.write(json_response.encode())

--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -783,9 +783,6 @@ def _load_jsonschema(repo_version):
     :return: the schema dictionary
     :rtype: dict
     """
-    print("schema_dir : {}".format(schema_dir))
-    print("repo_version : {}".format(repo_version))
-    print('{}/{}-repo-schema.json'.format(schema_dir, repo_version))
     with open(
         '{}/{}-repo-schema.json'.format(schema_dir, repo_version),
         encoding='utf-8'

--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -783,7 +783,9 @@ def _load_jsonschema(repo_version):
     :return: the schema dictionary
     :rtype: dict
     """
-
+    print("schema_dir : {}".format(schema_dir))
+    print("repo_version : {}".format(repo_version))
+    print('{}/{}-repo-schema.json'.format(schema_dir, repo_version))
     with open(
         '{}/{}-repo-schema.json'.format(schema_dir, repo_version),
         encoding='utf-8'


### PR DESCRIPTION
- Make the universe converter service multithreaded with better logging to address [INFINITY-3577](https://jira.mesosphere.com/browse/INFINITY-3577)
- Bump converter to get the latest tooling (`gen_universe.py` can now understand `1.13`). [DCOS-42285](https://jira.mesosphere.com/browse/DCOS-42285)