### PR TITLE
Release portworx-zookeeper 1.1-3.4.11-eee2a45 (automated commit)

### DIFF
--- a/repo/packages/P/portworx-zookeeper/1/config.json
+++ b/repo/packages/P/portworx-zookeeper/1/config.json
@@ -1,0 +1,269 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS Zookeeper service configuration properties",
+      "properties": {
+        "name": {
+          "title": "Service name",
+          "description": "The name of the Zookeeper service instance",
+          "type": "string",
+          "default": "portworx-zookeeper"
+        },
+        "user": {
+          "title": "User",
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "service_account_secret": {
+          "title": "Credential secret name (optional)",
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        }
+      },
+      "required": [
+        "name",
+        "user"
+      ]
+    },
+    "node": {
+      "description": "DC/OS Zookeeper node configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of Zookeeper nodes in the cluster",
+          "type": "integer",
+          "default": 3,
+          "minimum": 3
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for nodes. Example: 'hostname:UNIQUE'",
+          "type": "string",
+          "default": ""
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Number of cpu shares allocated to the Zookeeper process",
+          "type": "number",
+          "default": 0.5
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "The amount of memory allocated to the Zookeeper process (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "The amount of disk space allocated to Zookeeper (in MB)",
+          "type": "integer",
+          "default": 2048
+        },
+        "portworx_volume_name": {
+          "title": "Portworx volume name",
+          "description": "Name of the volume used with Portworx driver",
+          "type": "string",
+          "default": "ZookeeperVolume"
+        },
+        "portworx_volume_options": {
+          "title": "Portworx volume options",
+          "description": "Comma separated key=value pairs of options passed to Portworx driver",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "portworx_volume_name"
+      ]
+    },
+    "zookeeper": {
+      "description": "Zookeeper configuration properties",
+      "type": "object",
+      "properties": {
+        "client_port": {
+          "title": "Client port",
+          "description": "Port used by clients to connect to Zookeeper",
+          "type": "integer",
+          "default": 2182
+        },
+        "tick_time": {
+          "title": "Tick time",
+          "description": "The length of a single tick, which is the basic time unit used by ZooKeeper (in milliseconds)",
+          "type": "integer",
+          "default": 2000
+        },
+        "global_outstanding_limit": {
+          "title": "Global outstanding limit",
+          "description": "To prevent ZooKeeper from running out of memory due to queued requests, ZooKeeper will throttle clients so that there is no more than globalOutstandingLimit outstanding requests in the system",
+          "type": "integer",
+          "default": 1000
+        },
+        "pre_alloc_size": {
+          "title": "PreAlloc size",
+          "description": "To avoid seeks ZooKeeper allocates space in the transaction log file in blocks of preAllocSize kilobytes",
+          "type": "integer",
+          "default": 65536
+        },
+        "snap_count": {
+          "title": "Snap count",
+          "description": "After Snap count transactions are written to a log file a snapshot is started and a new transaction log file is started",
+          "type": "integer",
+          "default": 100000
+        },
+        "max_client_connections": {
+          "title": "Max client connections",
+          "description": "Limits the number of concurrent connections (at the socket level) that a single client, identified by IP address, may make to a single member of the ZooKeeper ensemble",
+          "type": "integer",
+          "default": 60
+        },
+        "client_port_address": {
+          "title": "Client port address",
+          "description": "The address (ipv4, ipv6 or hostname) to listen for client connections",
+          "type": "string",
+          "default": ""
+        },
+        "min_session_timeout": {
+          "title": "Min session timeout",
+          "description": "Minimum session timeout that the server will allow the client to negotiate (in milliseconds)",
+          "type": "integer",
+          "default": 4000
+        },
+        "max_session_timeout": {
+          "title": "Max session timeout",
+          "description": "Maximum session timeout that the server will allow the client to negotiate (in milliseconds)",
+          "type": "integer",
+          "default": 40000
+        },
+        "fsync_warning_threshold": {
+          "title": "Fsync warning threshold",
+          "description": "A warning message will be output to the log whenever an fsync in the Transactional Log (WAL) takes longer than this value (in milliseconds)",
+          "type": "integer",
+          "default": 1000
+        },
+        "autopurge_snap_retain_count": {
+          "title": "Snapshot retain count",
+          "description": "When enabled, ZooKeeper auto purge feature retains these many most recent snapshots and the corresponding transaction logs",
+          "type": "integer",
+          "default": 3
+        },
+        "autopurge_interval": {
+          "title": "Purge interval",
+          "description": "The time interval (in hours) for which the purge task has to be triggered. Set to a positive integer (1 and above) to enable the auto purging",
+          "type": "integer",
+          "default": 0
+        },
+        "sync_enabled": {
+          "title": "Sync enabled",
+          "description": "The observers now log transaction and write snapshot to disk by default like the participants. This reduces the recovery time of the observers on restart",
+          "type": "string",
+          "default": "true"
+        },
+        "election_algorithm": {
+          "title": "Election algorithm",
+          "description": "Election implementation to use. A value of '0' corresponds to the original UDP-based version, '1' corresponds to the non-authenticated UDP-based version of fast leader election, '2' corresponds to the authenticated UDP-based version of fast leader election, and '3' corresponds to TCP-based version of fast leader election",
+          "type": "integer",
+          "default": 3
+        },
+        "init_limit": {
+          "title": "Init time",
+          "description": "Amount of time, in ticks, to allow followers to connect and sync to a leader",
+          "type": "integer",
+          "default": 10
+        },
+        "leader_serves": {
+          "title": "Leader serves",
+          "description": "Whether a leader accepts client connections or not",
+          "type": "string",
+          "default": "yes"
+        },
+        "leader_port": {
+          "title": "Leader port",
+          "description": "Port used to connect to a leader",
+          "type": "integer",
+          "default": 2889
+        },
+        "leader_election_port": {
+          "title": "Leader election port",
+          "description": "Port used to conduct the leader election",
+          "type": "integer",
+          "default": 3889
+        },
+        "connection_timeout": {
+          "title": "Election connection timeout",
+          "description": "Sets the timeout value (in seconds) for opening connections for leader election notifications. Only applicable if you are using electionAlg 3",
+          "type": "integer",
+          "default": 5
+        },
+        "sync_limit": {
+          "title": "Sync limit",
+          "description": "Amount of time, in ticks, to allow followers to sync with ZooKeeper",
+          "type": "integer",
+          "default": 5
+        },
+        "ip_reachable_timeout": {
+          "title": "IP reachable timeout",
+          "description": "Timeout value for IP addresses reachable checking when hostname is resolved (in milliseconds)",
+          "type": "integer"
+        },
+        "tcp_keep_alive": {
+          "title": "TCP Keep alive",
+          "description": "Setting this to true sets the TCP keepAlive flag on the sockets used by quorum members to perform elections",
+          "type": "string",
+          "default": "false"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "client_port",
+        "tick_time",
+        "leader_port",
+        "leader_election_port"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/portworx-zookeeper/1/marathon.json.mustache
+++ b/repo/packages/P/portworx-zookeeper/1/marathon.json.mustache
@@ -1,0 +1,121 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./zookeeper-scheduler/bin/zookeeper ./zookeeper-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+
+    "ZOOKEEPER_VERSION": "3.4.11",
+
+    "NODE_COUNT": "{{node.count}}",
+    "NODE_PLACEMENT": "{{node.placement_constraint}}",
+
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+
+    "ZOOKEEPER_CPUS": "{{node.cpus}}",
+    "ZOOKEEPER_MEM_MB": "{{node.mem}}",
+    "ZOOKEEPER_DISK_MB": "{{node.disk}}",
+    "ZOOKEEPER_DOCKER_VOLUME_NAME": "{{{node.portworx_volume_name}}}",
+    "ZOOKEEPER_DOCKER_VOLUME_OPTIONS": "{{{node.portworx_volume_options}}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.service_account_secret}}
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "SCHEDULER_URI": "{{resource.assets.uris.scheduler-zip}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "ZOOKEEPER_URI": "{{resource.assets.uris.zookeeper-tar-gz}}",
+
+    "CONFIG_TEMPLATE_PATH": "zookeeper-scheduler",
+
+    "TASKCFG_ALL_ZOOKEEPER_CLIENT_PORT": "{{zookeeper.client_port}}",
+    "TASKCFG_ALL_TICK_TIME": "{{zookeeper.tick_time}}",
+    "TASKCFG_ALL_GLOBAL_OUTSTANDING_LIMIT": "{{zookeeper.global_outstanding_limit}}",
+    "TASKCFG_ALL_PRE_ALLOC_SIZE": "{{zookeeper.pre_alloc_size}}",
+    "TASKCFG_ALL_SNAP_COUNT": "{{zookeeper.snap_count}}",
+    "TASKCFG_ALL_MAX_CLIENT_CONNECTIONS": "{{zookeeper.max_client_connections}}",
+    "TASKCFG_ALL_CLIENT_PORT_ADDRESS": "{{zookeeper.client_port_address}}",
+    "TASKCFG_ALL_MIN_SESSION_TIMEOUT": "{{zookeeper.min_session_timeout}}",
+    "TASKCFG_ALL_MAX_SESSION_TIMEOUT": "{{zookeeper.max_session_timeout}}",
+    "TASKCFG_ALL_FSYNC_WARNING_THRESHOLD": "{{zookeeper.fsync_warning_threshold}}",
+    "TASKCFG_ALL_SNAP_RETAIN_COUNT": "{{zookeeper.autopurge_snap_retain_count}}",
+    "TASKCFG_ALL_PURGE_INTERVAL": "{{zookeeper.autopurge_interval}}",
+    "TASKCFG_ALL_SYNC_ENABLED": "{{zookeeper.sync_enabled}}",
+    "TASKCFG_ALL_ELECTION_ALGORITHM": "{{zookeeper.election_algorithm}}",
+    "TASKCFG_ALL_INIT_LIMIT": "{{zookeeper.init_limit}}",
+    "TASKCFG_ALL_LEADER_SERVES": "{{zookeeper.leader_serves}}",
+    "TASKCFG_ALL_LEADER_PORT": "{{zookeeper.leader_port}}",
+    "TASKCFG_ALL_LEADER_ELECTION_PORT": "{{zookeeper.leader_election_port}}",
+    "TASKCFG_ALL_CONNECTION_TIMEOUT": "{{zookeeper.connection_timeout}}",
+    "TASKCFG_ALL_SYNC_LIMIT": "{{zookeeper.sync_limit}}",
+    "TASKCFG_ALL_IP_REACHABLE_TIMEOUT": "{{zookeeper.ip_reachable_timeout}}",
+    "TASKCFG_ALL_TCP_KEEP_ALIVE": "{{zookeeper.tcp_keep_alive}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx-zookeeper/1/package.json
+++ b/repo/packages/P/portworx-zookeeper/1/package.json
@@ -1,0 +1,17 @@
+{
+  "description": "Apache Zookeeper backed by Portworx volumes",
+  "framework": true,
+  "maintainer": "support@portworx.com",
+  "minDcosReleaseVersion": "1.9",
+  "name": "portworx-zookeeper",
+  "packagingVersion": "4.0",
+  "postInstallNotes": "DC/OS portworx-zookeeper is being installed!\n\n\tDocumentation: https://docs.portworx.com/scheduler/mesosphere-dcos/frameworks.html",
+  "postUninstallNotes": "DC/OS portworx-zookeeper has been uninstalled.\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required.",
+  "preInstallNotes": "Default configuration requires 3 agent nodes each with: 0.5 CPU | 1024 MB MEM\n\nPortworx should be installed on the Private Agents to be able to provision volumes.\n\nCommunity packages are unverified and unreviewed content from the community.",
+  "selected": false,
+  "tags": [
+    "zookeeper",
+    "portworx"
+  ],
+  "version": "1.1-3.4.11-eee2a45"
+}

--- a/repo/packages/P/portworx-zookeeper/1/resource.json
+++ b/repo/packages/P/portworx-zookeeper/1/resource.json
@@ -1,0 +1,57 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
+      "zookeeper-tar-gz": "https://s3-us-west-1.amazonaws.com/px-dcos/zookeeper/zookeeper-3.4.11.tar.gz",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-eee2a45/bootstrap.zip",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-eee2a45/zookeeper-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-eee2a45/executor.zip"
+    }
+  },
+  "images": {
+    "icon-small": "https://s3-us-west-1.amazonaws.com/px-dcos/portworx-zookeeper/img/zk-small.png",
+    "icon-medium": "https://s3-us-west-1.amazonaws.com/px-dcos/portworx-zookeeper/img/zk-medium.png",
+    "icon-large": "https://s3-us-west-1.amazonaws.com/px-dcos/portworx-zookeeper/img/zk-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "1354709564d05aad0c205addc692f6ad632bf9f4caf1d9df150a46a319a1a03d"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-eee2a45/dcos-portworx-zookeeper-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "a8857d8c365dae7c71774393df6510fa63c3d29791b2e4c31bd51f28d79106b5"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-eee2a45/dcos-portworx-zookeeper-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "b19d530d708bdbbf09ac2bb7179fbf7c5440f0134270c60337af53cfcf0546bb"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-eee2a45/dcos-portworx-zookeeper.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Changes since revision 0:
0 files added: []
0 files removed: []
3 files changed:

```
--- 0/marathon.json.mustache
+++ 1/marathon.json.mustache
@@ -43,11 +43,11 @@
     "ZOOKEEPER_DOCKER_VOLUME_NAME": "{{{node.portworx_volume_name}}}",
     "ZOOKEEPER_DOCKER_VOLUME_OPTIONS": "{{{node.portworx_volume_options}}}",

-    {{#service.secret_name}}
+    {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
     "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
-    {{/service.secret_name}}
+    {{/service.service_account_secret}}

     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
--- 0/package.json
+++ 1/package.json
@@ -13,5 +13,5 @@
     "zookeeper",
     "portworx"
   ],
-  "version": "1.1-3.4.11-56b7afa"
+  "version": "1.1-3.4.11-eee2a45"
 }
--- 0/resource.json
+++ 1/resource.json
@@ -3,10 +3,10 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u131-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
-      "zookeeper-tar-gz": "http://apache.claz.org/zookeeper/zookeeper-3.4.11/zookeeper-3.4.11.tar.gz",
-      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-56b7afa/bootstrap.zip",
-      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-56b7afa/zookeeper-scheduler.zip",
-      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-56b7afa/executor.zip"
+      "zookeeper-tar-gz": "https://s3-us-west-1.amazonaws.com/px-dcos/zookeeper/zookeeper-3.4.11.tar.gz",
+      "bootstrap-zip": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-eee2a45/bootstrap.zip",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-eee2a45/zookeeper-scheduler.zip",
+      "executor-zip": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-eee2a45/executor.zip"
     }
   },
   "images": {
@@ -25,7 +25,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-56b7afa/dcos-portworx-zookeeper-darwin"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-eee2a45/dcos-portworx-zookeeper-darwin"
         }
       },
       "linux": {
@@ -37,7 +37,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-56b7afa/dcos-portworx-zookeeper-linux"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-eee2a45/dcos-portworx-zookeeper-linux"
         }
       },
       "windows": {
@@ -49,7 +49,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-56b7afa/dcos-portworx-zookeeper.exe"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-zookeeper/assets/1.1-3.4.11-eee2a45/dcos-portworx-zookeeper.exe"
         }
       }
     }
```