### PR TITLE
Update to Traefik 1.6.2

### DIFF
--- a/repo/packages/T/traefik/2/config.json
+++ b/repo/packages/T/traefik/2/config.json
@@ -1,0 +1,417 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "service": {
+      "properties": {
+        "name": {
+          "default": "traefik",
+          "description": "Name of the Traefik instance",
+          "type": "string"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each Traefik instance.",
+          "minimum": 0.5,
+          "type": "number"
+        },
+        "mem": {
+          "default": 128.0,
+          "description": "Memory (MB) to allocate to each Traefik task.",
+          "minimum": 64.0,
+          "type": "number"
+        },
+        "instances": {
+          "default": 2,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "user": {
+          "description": "The user that runs the Traefik service and owns the Mesos sandbox.",
+          "type": "string",
+          "default": "root"
+        },
+        "role": {
+          "default": "slave_public",
+          "description": "Deploy Traefik only on nodes with this role.",
+          "type": "string"
+        },
+        "minimumHealthCapacity": {
+          "default": 0.5,
+          "description": "Minimum health capacity.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "maximumOverCapacity": {
+          "default": 0.2,
+          "description": "Maximum over capacity.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "disk": {
+          "default": 100,
+          "description": "Disk space (in MB) to allocate for each instance.",
+          "minimum": 20,
+          "type": "integer"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    },
+    "entrypoint": {
+      "description": "Traefik entrypoints",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "http-address": {
+          "default": "",
+          "description": "Leave empty for listening on all interfaces.",
+          "type": "string"
+        },
+        "http-port": {
+          "default": 80,
+          "description": "HTTP port.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "http-compression": {
+          "default": true,
+          "description": "Enable compression.",
+          "type": "boolean"
+        },
+        "https-enable": {
+          "default": true,
+          "description": "Enable HTTPS entrypoint.",
+          "type": "boolean"
+        },
+        "https-address": {
+          "default": "",
+          "description": "Leave empty for listening on all interfaces.",
+          "type": "string"
+        },
+        "https-port": {
+          "default": 443,
+          "description": "HTTPS port.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "https-compression": {
+          "default": true,
+          "description": "Enable compression.",
+          "type": "boolean"
+        },
+        "api-enable": {
+          "default": true,
+          "description": "Enable API entrypoint.",
+          "type": "boolean"
+        },
+        "enable-dashboard": {
+          "default": true,
+          "description": "Enable Admin Dashboard.",
+          "type": "boolean"
+        },
+        "api-address": {
+          "description": "Leave empty for listening on all interfaces.",
+          "type": "string"
+        },
+        "api-port": {
+          "default": 8080,
+          "description": "API (admin) port, if not defined $PORT1 will be used",
+          "type": "integer"
+        }
+      }
+    },
+    "traefik": {
+      "description": "Traefik configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "secret-name": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "log-level": {
+          "description": "Traefik log level.",
+          "type": "string",
+          "default": "INFO"
+        },
+        "grace-timeout": {
+          "description": "Duration to give active requests a chance to finish before Traefik stops",
+          "type": "string",
+          "default": "30s"
+        },
+        "healthcheck-interval": {
+          "description": "Default health check interval",
+          "type": "string",
+          "default": "30s"
+        },
+        "read-timeout": {
+          "description": "The maximum duration for reading the entire request, including the body",
+          "type": "string",
+          "default": "0s"
+        },
+        "write-timeout": {
+          "description": "The maximum duration before timing out writes of the response",
+          "type": "string",
+          "default": "0s"
+        },
+        "idle-timeout": {
+          "description": "The maximum duration an idle (keep-alive) connection will remain idle before closing itself.",
+          "type": "string",
+          "default": "180s"
+        },
+        "retry": {
+          "description": "Number of attempts to reach backend service",
+          "type": "string"
+        },
+        "config-file": {
+          "description": "Path to additional Traefik config file in TOML format.",
+          "type": "string"
+        },
+        "watch-config-file": {
+          "description": "Watch config file for changes.",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "marathon": {
+      "description": "Marathon configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "default": true,
+          "description": "Enable Marathon provider.",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "default": "http://marathon.mesos:8080",
+          "description": "Marathon endpoint, multiple instances separate by comma.",
+          "type": "string"
+        },
+        "watch": {
+          "default": true,
+          "description": "Watch changes in Marathon.",
+          "type": "boolean"
+        },
+        "domain": {
+          "default": "marathon.localhost",
+          "description": "Default domain. Can be overridden by setting the 'traefik.domain' label on an application.",
+          "type": "string"
+        },
+        "marathonlb-compatibility": {
+          "default": false,
+          "description": "Enable compatibility with marathon-lb labels.",
+          "type": "boolean"
+        },
+        "expose": {
+          "default": false,
+          "description": "Expose Marathon apps by default in Traefik.",
+          "type": "boolean"
+        },
+        "respect-readiness-checks": {
+          "default": true,
+          "description": "During deployment Traefik will respect readiness checks if defined in Marathon.",
+          "type": "boolean"
+        },
+        "groups-as-subdomains": {
+          "default": false,
+          "description": "Convert Marathon groups to subdomains.",
+          "type": "boolean"
+        },
+        "dialer-timeout": {
+          "default": "60s",
+          "description": "Amount of time to allow the Marathon provider to wait to open a TCP connection to a Marathon master.",
+          "type": "string"
+        },
+        "keep-alive": {
+          "default": "10s",
+          "description": "Set the TCP Keep Alive interval for the Marathon HTTP Client.",
+          "type": "string"
+        },
+        "force-task-hostname": {
+          "default": false,
+          "description": "By default, a task's IP address (as returned by the Marathon API) is used as backend server if an IP-per-task configuration can be found; otherwise, the name of the host running the task is used. The latter behavior can be enforced by enabling this switch.",
+          "type": "boolean"
+        }
+      }
+    },
+    "mesos": {
+      "description": "Allows directly exposing Mesos applications",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "default": false,
+          "description": "Enable Mesos provider.",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "default": "http://leader.mesos:5050",
+          "description": "Mesos endpoint, multiple instances separate by comma.",
+          "type": "string"
+        },
+        "watch": {
+          "default": true,
+          "description": "Watch changes in Marathon.",
+          "type": "boolean"
+        },
+        "domain": {
+          "default": "mesos.localhost",
+          "description": "Default domain. Can be overridden by setting the 'traefik.domain' label on an application.",
+          "type": "string"
+        },
+        "expose": {
+          "default": false,
+          "description": "Expose Mesos apps by default in Traefik.",
+          "type": "boolean"
+        },
+        "groups-as-subdomains": {
+          "default": false,
+          "description": "Convert Marathon groups to subdomains.",
+          "type": "boolean"
+        },
+        "timeout": {
+          "default": 30,
+          "description": "Mesos HTTP API timeout",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "zk-timeout": {
+          "default": 30,
+          "description": "ZooKeeper timeout",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "refresh": {
+          "default": 30,
+          "description": "Polling interval",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ip-sources": {
+          "default": "host",
+          "description": "IP sources (e.g. host, docker, mesos, netinfo).",
+          "type": "string"
+        }
+      }
+    },
+    "kubernetess": {
+      "description": "Allows access to Kubernetess applications",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "default": false,
+          "description": "Enable Kubernetess provider.",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "description": "Kubernetes server endpoint",
+          "type": "string"
+        },
+        "token": {
+          "description": "Bearer token used for the Kubernetes client configuration",
+          "type": "string"
+        },
+        "ca": {
+          "description": "Path to the certificate authority file",
+          "type": "string"
+        },
+        "namespaces": {
+          "description": "Comma-separated namespaces to watch",
+          "type": "string"
+        },
+        "filename": {
+          "description": "Override default configuration template",
+          "type": "string"
+        },
+        "ingress-class": {
+          "description": "Value of `kubernetes.io/ingress.class` annotation that identifies Ingress objects to be processed",
+          "type": "string"
+        },
+        "disable-pass-host-headers": {
+          "default": false,
+          "description": "Disable PassHost Headers",
+          "type": "boolean"
+        },
+        "enable-pass-tls-cert": {
+          "default": false,
+          "description": "Disable PassHost Headers",
+          "type": "boolean"
+        }
+      }
+    },
+    "metrics": {
+      "description": "Metrics configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "recent-errors": {
+          "default": 10,
+          "description": "Number of logged recent errors",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "prometheus-entrypoint": {
+          "default": "",
+          "description": "Traefik entrypoint for Prometheus (e.g. api)",
+          "type": "string"
+        },
+        "prometheus-buckets": {
+          "default": "0.1,0.3,1.2,5.0",
+          "type": "string"
+        },
+        "datadog-address": {
+          "default": "",
+          "description": "DataDog endpoint",
+          "type": "string"
+        },
+        "datadog-pushinterval": {
+          "default": "10s",
+          "type": "string"
+        },
+        "influxdb-address": {
+          "default": "",
+          "description": "InfluxDB endpoint",
+          "type": "string"
+        },
+        "influxdb-pushinterval": {
+          "default": "10s",
+          "type": "string"
+        },
+        "statsd-address": {
+          "default": "",
+          "description": "StatsD endpoint",
+          "type": "string"
+        },
+        "statsd-pushinterval": {
+          "default": "10s",
+          "type": "string"
+        }
+      }
+    },
+    "logging": {
+      "description": "Logging configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "access-logs": {
+          "default": false,
+          "description": "Enable Access Logs",
+          "type": "boolean"
+        },
+        "access-logs-format": {
+          "description": "Default is text",
+          "type": "string"
+        },
+        "access-logs-path": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/T/traefik/2/marathon.json.mustache
+++ b/repo/packages/T/traefik/2/marathon.json.mustache
@@ -1,0 +1,142 @@
+{
+  "id": "{{service.name}}",
+  "instances": {{service.instances}},
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "disk": {{service.disk}},
+  "user": "{{service.user}}",
+  "cmd": "mv dcos-traefik-1.1.0/* $(pwd)/ && bash bootstrap.sh && ./traefik_linux-amd64 -c traefik.toml",
+  "uris": [
+    "{{resource.assets.uris.traefik-bin}}",
+    "{{resource.assets.uris.confd-bin}}",
+    "{{resource.assets.uris.bootstrap}}"
+  ],
+  {{#service.role}}
+  "acceptedResourceRoles": [
+    "{{service.role}}"
+  ],
+  {{/service.role}}
+  "healthChecks": [
+    {
+      "path": "/ping",
+      "portIndex": 0,
+      "protocol": "MESOS_HTTP",
+      "gracePeriodSeconds": 20,
+      "intervalSeconds": 5,
+      "timeoutSeconds": 2,
+      "maxConsecutiveFailures": 2,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": {{service.minimumHealthCapacity}},
+    "maximumOverCapacity": {{service.maximumOverCapacity}}
+  },
+  "requirePorts":true,
+  "env": {
+    "TRAEFIK_LOG_LEVEL": "{{traefik.log-level}}",
+    "TRAEFIK_GRACE_TIMEOUT": "{{traefik.grace-timeout}}",
+    "TRAEFIK_HEALTHCHECK_INTERVAL": "{{traefik.healthcheck-interval}}",
+    "TRAEFIK_READ_TIMEOUT": "{{traefik.read-timeout}}",
+    "TRAEFIK_WRITE_TIMEOUT": "{{traefik.write-timeout}}",
+    "TRAEFIK_IDLE_TIMEOUT": "{{traefik.idle-timeout}}",
+    {{#traefik.retry}}
+    "TRAEFIK_RETRY": "{{traefik.retry}}",
+    {{/traefik.retry}}
+    "TRAEFIK_HTTP_ADDRESS": "{{entrypoint.http-address}}",
+    "TRAEFIK_HTTP_PORT": "{{entrypoint.http-port}}",
+    "TRAEFIK_HTTPS_ENABLE": "{{entrypoint.https-enable}}",
+    "TRAEFIK_HTTPS_PORT": "{{entrypoint.https-port}}",
+    "TRAEFIK_HTTPS_ADDRESS": "{{entrypoint.https-address}}",
+    "TRAEFIK_HTTPS_COMPRESSION": "{{entrypoint.https-compression}}",
+    "TRAEFIK_PING_ENABLE": "true",
+    "TRAEFIK_API_ENABLE": "{{entrypoint.api-enable}}",
+    "TRAEFIK_API_PORT": "{{entrypoint.api-port}}",
+    "TRAEFIK_API_ADDRESS": "{{entrypoint.api-address}}",
+    "TRAEFIK_API_DASHBOARD": "{{entrypoint.enable-dashboard}}",
+    "TRAEFIK_FILE_NAME": "{{traefik.config-file}}",
+    "TRAEFIK_FILE_WATCH": "{{traefik.watch-config-file}}",
+    "TRAEFIK_MARATHON_ENABLE": "{{marathon.enable}}",
+    "TRAEFIK_MARATHON_ENDPOINT": "{{marathon.endpoint}}",
+    "TRAEFIK_MARATHON_WATCH": "{{marathon.watch}}",
+    "TRAEFIK_MARATHON_EXPOSE": "{{marathon.expose}}",
+    "TRAEFIK_MARATHON_DOMAIN": "{{marathon.domain}}",
+    "TRAEFIK_MARATHON_LB_COMPATIBILITY": "{{marathon.marathonlb-compatibility}}",
+    "TRAEFIK_MARATHON_GROUPS_AS_SUBDOMAINS": "{{marathon.groups-as-subdomains}}",
+    "TRAEFIK_MARATHON_DIALER_TIMEOUT": "{{marathon.dialer-timeout}}",
+    "TRAEFIK_MARATHON_KEEP_ALIVE": "{{marathon.keep-alive}}",
+    "TRAEFIK_MARATHON_FORCE_TASK_HOSTNAME": "{{marathon.force-task-hostname}}",
+    "TRAEFIK_MARATHON_RESPECT_READINESS_CHECKS": "{{marathon.respect-readiness-checks}}",
+    "TRAEFIK_MESOS_ENABLE": "{{mesos.enable}}",
+    "TRAEFIK_MESOS_ENDPOINT": "{{mesos.endpoint}}",
+    "TRAEFIK_MESOS_WATCH": "{{mesos.watch}}",
+    "TRAEFIK_MESOS_EXPOSE": "{{mesos.expose}}",
+    "TRAEFIK_MESOS_DOMAIN": "{{mesos.domain}}",
+    "TRAEFIK_MESOS_GROUPS_AS_SUBDOMAINS": "{{mesos.groups-as-subdomains}}",
+    "TRAEFIK_MESOS_ZK_TIMEOUT": "{{mesos.zk-timeout}}",
+    "TRAEFIK_MESOS_TIMEOUT": "{{mesos.timeout}}",
+    "TRAEFIK_MESOS_REFRESH": "{{mesos.refresh}}",
+    "TRAEFIK_MESOS_IP_SOURCES": "{{mesos.ip-sources}}",
+    "TRAEFIK_K8S_ENABLE": "{{kubernetess.enable}}",
+    "TRAEFIK_K8S_ENDPOINT": "{{kubernetess.endpoint}}",
+    "TRAEFIK_K8S_TOKEN": "{{kubernetess.token}}",
+    "TRAEFIK_K8S_CA": "{{kubernetess.ca}}",
+    "TRAEFIK_K8S_NAMESPACES": "{{kubernetess.namespaces}}",
+    "TRAEFIK_K8S_FILENAME": "{{kubernetess.filename}}",
+    "TRAEFIK_K8S_INGRESS_CLASS": "{{kubernetess.ingress-class}}",
+    "TRAEFIK_K8S_DISABLE_PASS_HOST_HEADERS": "{{kubernetess.disable-pass-host-headers}}",
+    "TRAEFIK_K8S_ENABLE_PASS_TLS_CERT": "{{kubernetess.enable-pass-tls-cert}}",
+    "TRAEFIK_STATISTICS_RECENT_ERRORS": "{{metrics.recent-errors}}",
+    "TRAEFIK_ACCESS_LOG": "{{logging.access-logs}}",
+    "TRAEFIK_ACCESS_FORMAT": "{{logging.access-logs-format}}",
+    "TRAEFIK_ACCESS_PATH": "{{logging.access-logs-path}}",
+    {{#metrics.datadog-address}}
+    "TRAEFIK_DATADOG_ADDRESS": "{{metrics.datadog-address}}",
+    "TRAEFIK_DATADOG_PUSHINTERVAL": "{{metrics.datadog-pushinterval}}",
+    {{/metrics.datadog-address}}
+    {{#metrics.influxdb-address}}
+    "TRAEFIK_INFLUXDB_ADDRESS": "{{metrics.influxdb-address}}",
+    "TRAEFIK_INFLUXDB_PUSHINTERVAL": "{{metrics.influxdb-pushinterval}}",
+    {{/metrics.influxdb-address}}
+    {{#metrics.statsd-address}}
+    "TRAEFIK_STATSD_ADDRESS": "{{metrics.statsd-address}}",
+    "TRAEFIK_STATSD_PUSHINTERVAL": "{{metrics.statsd-pushinterval}}",
+    {{/metrics.statsd-address}}
+    {{#metrics.prometheus-entrypoint}}
+    "TRAEFIK_PROMETHEUS_ENTRYPOINT": "{{metrics.prometheus-entrypoint}}",
+    "TRAEFIK_PROMETHEUS_BUCKETS": "{{metrics.prometheus-buckets}}",
+    {{/metrics.prometheus-entrypoint}}
+    {{#traefik.secret-name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    {{/traefik.secret-name}}
+    "TRAEFIK_MARATHON_EXPOSE": "{{marathon.expose}}"
+  },
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_PACKAGE_VERSION": "{{package.version}}",
+    {{#entrypoint.api-enable}}
+      {{#entrypoint.enable-dashboard}}
+    "DCOS_SERVICE_PORT_INDEX": "1",
+      {{/entrypoint.enable-dashboard}}
+    {{/entrypoint.api-enable}}
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  },
+  {{#traefik.secret-name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{traefik.secret-name}}"
+    }
+  },
+  {{/traefik.secret-name}}
+  "ports": [
+    0
+    {{#entrypoint.api-enable}}
+    ,{{entrypoint.api-port}}
+    {{/entrypoint.api-enable}}
+    ,{{entrypoint.http-port}}
+    {{#entrypoint.https-enable}}
+    ,{{entrypoint.https-port}}
+    {{/entrypoint.https-enable}}
+  ]
+}

--- a/repo/packages/T/traefik/2/package.json
+++ b/repo/packages/T/traefik/2/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "4.0",
+  "name": "traefik",
+  "version": "1.1.0-1.6.2",
+  "minDcosReleaseVersion": "1.9",
+  "scm": "https://github.com/containous/traefik",
+  "description": "Traefik is a modern HTTP reverse proxy and load balancer written in go. It supports several backends (Docker, Swarm mode, Kubernetes, Marathon, Consul, Etcd, Rancher, Amazon ECS, and a lot more) to manage its configuration automatically and dynamically. \n\nSee https://docs.traefik.io for more information.",
+  "maintainer": "https://github.com/deric/dcos-traefik",
+  "tags": ["loadbalancer", "service-discovery", "reverse-proxy", "proxy", "traffic", "ingress"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production!\n\n",
+  "postInstallNotes": "Traefik DC/OS Service has been successfully installed!\nSee https://docs.traefik.io for documentation.",
+  "postUninstallNotes": "Traefik DC/OS Service has been uninstalled and will no longer run.",
+  "licenses": [
+    {
+      "name": "MIT",
+      "url": "https://github.com/containous/traefik/blob/master/LICENSE.md"
+    }
+  ]
+}

--- a/repo/packages/T/traefik/2/resource.json
+++ b/repo/packages/T/traefik/2/resource.json
@@ -1,8 +1,9 @@
 {
   "assets": {
     "uris": {
-      "traefik-bin": "https://github.com/containous/traefik/releases/download/v1.4.4/traefik_linux-amd64",
-      "bootstrap-sh": "https://raw.githubusercontent.com/deric/dcos-traefik/v1.0.0/bootstrap.sh"
+      "traefik-bin": "https://github.com/containous/traefik/releases/download/v1.6.2/traefik_linux-amd64",
+      "confd-bin": "https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64",
+      "bootstrap": "https://github.com/deric/dcos-traefik/archive/v1.1.0.tar.gz"
     }
   },
   "images": {


### PR DESCRIPTION
Updated Traefik to latest release. There are several Mesos/Marathon changes regarding labels, see [changelog](https://github.com/containous/traefik/blob/master/CHANGELOG.md), but Marathon 1.5 API is still not fully supported.

* simplified monitoring (Prometheus, InfluxDB, StatsD, DataDog)
* configuration file generated by `confd`
* added many configuration variables
* easier integration with providers (Marathon, Mesos, Kubernetess)

```
diff --git a/repo/packages/T/traefik/1/config.json b/repo/packages/T/traefik/2/config.json
index d7e33f2e..a137309b 100644
--- a/repo/packages/T/traefik/1/config.json
+++ b/repo/packages/T/traefik/2/config.json
@@ -11,7 +11,7 @@
         "cpus": {
           "default": 1,
           "description": "CPU shares to allocate to each Traefik instance.",
-          "minimum": 1,
+          "minimum": 0.5,
           "type": "number"
         },
         "mem": {
@@ -21,7 +21,7 @@
           "type": "number"
         },
         "instances": {
-          "default": 1,
+          "default": 2,
           "description": "Number of instances to run.",
           "minimum": 1,
           "type": "integer"
@@ -37,7 +37,7 @@
           "type": "string"
         },
         "minimumHealthCapacity": {
-          "default": 0.0,
+          "default": 0.5,
           "description": "Minimum health capacity.",
           "minimum": 0,
           "type": "number"
@@ -47,13 +47,19 @@
           "description": "Maximum over capacity.",
           "minimum": 0,
           "type": "number"
+        },
+        "disk": {
+          "default": 100,
+          "description": "Disk space (in MB) to allocate for each instance.",
+          "minimum": 20,
+          "type": "integer"
         }
       },
       "required": ["cpus", "mem", "instances", "name"],
       "type": "object"
     },
-    "traefik": {
-      "description": "Traefik configuration",
+    "entrypoint": {
+      "description": "Traefik entrypoints",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -68,9 +74,14 @@
           "minimum": 1,
           "type": "number"
         },
+        "http-compression": {
+          "default": true,
+          "description": "Enable compression.",
+          "type": "boolean"
+        },
         "https-enable": {
           "default": true,
-          "description": "Enable HTTPS endpoint.",
+          "description": "Enable HTTPS entrypoint.",
           "type": "boolean"
         },
         "https-address": {
@@ -84,31 +95,79 @@
           "minimum": 1,
           "type": "number"
         },
-        "admin-enable": {
+        "https-compression": {
           "default": true,
-          "description": "Enable admin (web UI) endpoint.",
+          "description": "Enable compression.",
           "type": "boolean"
         },
-        "admin-address": {
-          "default": "",
+        "api-enable": {
+          "default": true,
+          "description": "Enable API entrypoint.",
+          "type": "boolean"
+        },
+        "enable-dashboard": {
+          "default": true,
+          "description": "Enable Admin Dashboard.",
+          "type": "boolean"
+        },
+        "api-address": {
           "description": "Leave empty for listening on all interfaces.",
           "type": "string"
         },
-        "admin-port": {
+        "api-port": {
           "default": 8080,
-          "description": "Web admin port.",
-          "minimum": 1,
-          "type": "number"
-        },
+          "description": "API (admin) port, if not defined $PORT1 will be used",
+          "type": "integer"
+        }
+      }
+    },
+    "traefik": {
+      "description": "Traefik configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
         "secret-name": {
           "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
           "type": "string",
           "default": ""
         },
-        "config-file": {
-          "description": "Path to additional Traefik config file. Directive will be ignored if file doesn't exist upon service start.",
+        "log-level": {
+          "description": "Traefik log level.",
+          "type": "string",
+          "default": "INFO"
+        },
+        "grace-timeout": {
+          "description": "Duration to give active requests a chance to finish before Traefik stops",
+          "type": "string",
+          "default": "30s"
+        },
+        "healthcheck-interval": {
+          "description": "Default health check interval",
+          "type": "string",
+          "default": "30s"
+        },
+        "read-timeout": {
+          "description": "The maximum duration for reading the entire request, including the body",
+          "type": "string",
+          "default": "0s"
+        },
+        "write-timeout": {
+          "description": "The maximum duration before timing out writes of the response",
+          "type": "string",
+          "default": "0s"
+        },
+        "idle-timeout": {
+          "description": "The maximum duration an idle (keep-alive) connection will remain idle before closing itself.",
           "type": "string",
-          "default": "/etc/traefik/rules.toml"
+          "default": "180s"
+        },
+        "retry": {
+          "description": "Number of attempts to reach backend service",
+          "type": "string"
+        },
+        "config-file": {
+          "description": "Path to additional Traefik config file in TOML format.",
+          "type": "string"
         },
         "watch-config-file": {
           "description": "Watch config file for changes.",
@@ -124,7 +183,7 @@
       "properties": {
         "enable": {
           "default": true,
-          "description": "Use Marathon endpoint.",
+          "description": "Enable Marathon provider.",
           "type": "boolean"
         },
         "endpoint": {
@@ -178,6 +237,180 @@
           "type": "boolean"
         }
       }
+    },
+    "mesos": {
+      "description": "Allows directly exposing Mesos applications",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "default": false,
+          "description": "Enable Mesos provider.",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "default": "http://leader.mesos:5050",
+          "description": "Mesos endpoint, multiple instances separate by comma.",
+          "type": "string"
+        },
+        "watch": {
+          "default": true,
+          "description": "Watch changes in Marathon.",
+          "type": "boolean"
+        },
+        "domain": {
+          "default": "mesos.localhost",
+          "description": "Default domain. Can be overridden by setting the 'traefik.domain' label on an application.",
+          "type": "string"
+        },
+        "expose": {
+          "default": false,
+          "description": "Expose Mesos apps by default in Traefik.",
+          "type": "boolean"
+        },
+        "groups-as-subdomains": {
+          "default": false,
+          "description": "Convert Marathon groups to subdomains.",
+          "type": "boolean"
+        },
+        "timeout": {
+          "default": 30,
+          "description": "Mesos HTTP API timeout",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "zk-timeout": {
+          "default": 30,
+          "description": "ZooKeeper timeout",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "refresh": {
+          "default": 30,
+          "description": "Polling interval",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ip-sources": {
+          "default": "host",
+          "description": "IP sources (e.g. host, docker, mesos, netinfo).",
+          "type": "string"
+        }
+      }
+    },
+    "kubernetess": {
+      "description": "Allows access to Kubernetess applications",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "default": false,
+          "description": "Enable Kubernetess provider.",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "description": "Kubernetes server endpoint",
+          "type": "string"
+        },
+        "token": {
+          "description": "Bearer token used for the Kubernetes client configuration",
+          "type": "string"
+        },
+        "ca": {
+          "description": "Path to the certificate authority file",
+          "type": "string"
+        },
+        "namespaces": {
+          "description": "Comma-separated namespaces to watch",
+          "type": "string"
+        },
+        "filename": {
+          "description": "Override default configuration template",
+          "type": "string"
+        },
+        "ingress-class": {
+          "description": "Value of `kubernetes.io/ingress.class` annotation that identifies Ingress objects to be processed",
+          "type": "string"
+        },
+        "disable-pass-host-headers": {
+          "default": false,
+          "description": "Disable PassHost Headers",
+          "type": "boolean"
+        },
+        "enable-pass-tls-cert": {
+          "default": false,
+          "description": "Disable PassHost Headers",
+          "type": "boolean"
+        }
+      }
+    },
+    "metrics": {
+      "description": "Metrics configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "recent-errors": {
+          "default": 10,
+          "description": "Number of logged recent errors",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "prometheus-entrypoint": {
+          "default": "",
+          "description": "Traefik entrypoint for Prometheus (e.g. api)",
+          "type": "string"
+        },
+        "prometheus-buckets": {
+          "default": "0.1,0.3,1.2,5.0",
+          "type": "string"
+        },
+        "datadog-address": {
+          "default": "",
+          "description": "DataDog endpoint",
+          "type": "string"
+        },
+        "datadog-pushinterval": {
+          "default": "10s",
+          "type": "string"
+        },
+        "influxdb-address": {
+          "default": "",
+          "description": "InfluxDB endpoint",
+          "type": "string"
+        },
+        "influxdb-pushinterval": {
+          "default": "10s",
+          "type": "string"
+        },
+        "statsd-address": {
+          "default": "",
+          "description": "StatsD endpoint",
+          "type": "string"
+        },
+        "statsd-pushinterval": {
+          "default": "10s",
+          "type": "string"
+        }
+      }
+    },
+    "logging": {
+      "description": "Logging configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "access-logs": {
+          "default": false,
+          "description": "Enable Access Logs",
+          "type": "boolean"
+        },
+        "access-logs-format": {
+          "description": "Default is text",
+          "type": "string"
+        },
+        "access-logs-path": {
+          "type": "string"
+        }
+      }
     }
   },
   "type": "object"
diff --git a/repo/packages/T/traefik/1/marathon.json.mustache b/repo/packages/T/traefik/2/marathon.json.mustache
index 1a9dbadf..8e1d828a 100644
--- a/repo/packages/T/traefik/1/marathon.json.mustache
+++ b/repo/packages/T/traefik/2/marathon.json.mustache
@@ -3,11 +3,13 @@
   "instances": {{service.instances}},
   "cpus": {{service.cpus}},
   "mem": {{service.mem}},
+  "disk": {{service.disk}},
   "user": "{{service.user}}",
-  "cmd": "bash bootstrap.sh && ./traefik_linux-amd64 -c traefik.toml",
+  "cmd": "mv dcos-traefik-1.1.0/* $(pwd)/ && bash bootstrap.sh && ./traefik_linux-amd64 -c traefik.toml",
   "uris": [
     "{{resource.assets.uris.traefik-bin}}",
-    "{{resource.assets.uris.bootstrap-sh}}"
+    "{{resource.assets.uris.confd-bin}}",
+    "{{resource.assets.uris.bootstrap}}"
   ],
   {{#service.role}}
   "acceptedResourceRoles": [
@@ -15,10 +17,9 @@
   ],
   {{/service.role}}
   "healthChecks": [
-    {{#traefik.admin-enable}}
     {
-      "path": "/health",
-      "portIndex": 1,
+      "path": "/ping",
+      "portIndex": 0,
       "protocol": "MESOS_HTTP",
       "gracePeriodSeconds": 20,
       "intervalSeconds": 5,
@@ -26,7 +27,6 @@
       "maxConsecutiveFailures": 2,
       "ignoreHttp1xx": false
     }
-    {{/traefik.admin-enable}}
   ],
   "upgradeStrategy": {
     "minimumHealthCapacity": {{service.minimumHealthCapacity}},
@@ -34,26 +34,78 @@
   },
   "requirePorts":true,
   "env": {
-    "TRAEFIK_HTTP_ADDRESS": "{{traefik.http-address}}",
-    "TRAEFIK_HTTP_PORT": "{{traefik.http-port}}",
-    "TRAEFIK_HTTPS_ENABLE": "{{traefik.https-enable}}",
-    "TRAEFIK_HTTPS_PORT": "{{traefik.https-port}}",
-    "TRAEFIK_HTTPS_ADDRESS": "{{traefik.https-address}}",
-    "TRAEFIK_ADMIN_ENABLE": "{{traefik.admin-enable}}",
-    "TRAEFIK_ADMIN_PORT": "{{traefik.admin-port}}",
-    "TRAEFIK_ADMIN_ADDRESS": "{{traefik.admin-address}}",
+    "TRAEFIK_LOG_LEVEL": "{{traefik.log-level}}",
+    "TRAEFIK_GRACE_TIMEOUT": "{{traefik.grace-timeout}}",
+    "TRAEFIK_HEALTHCHECK_INTERVAL": "{{traefik.healthcheck-interval}}",
+    "TRAEFIK_READ_TIMEOUT": "{{traefik.read-timeout}}",
+    "TRAEFIK_WRITE_TIMEOUT": "{{traefik.write-timeout}}",
+    "TRAEFIK_IDLE_TIMEOUT": "{{traefik.idle-timeout}}",
+    {{#traefik.retry}}
+    "TRAEFIK_RETRY": "{{traefik.retry}}",
+    {{/traefik.retry}}
+    "TRAEFIK_HTTP_ADDRESS": "{{entrypoint.http-address}}",
+    "TRAEFIK_HTTP_PORT": "{{entrypoint.http-port}}",
+    "TRAEFIK_HTTPS_ENABLE": "{{entrypoint.https-enable}}",
+    "TRAEFIK_HTTPS_PORT": "{{entrypoint.https-port}}",
+    "TRAEFIK_HTTPS_ADDRESS": "{{entrypoint.https-address}}",
+    "TRAEFIK_HTTPS_COMPRESSION": "{{entrypoint.https-compression}}",
+    "TRAEFIK_PING_ENABLE": "true",
+    "TRAEFIK_API_ENABLE": "{{entrypoint.api-enable}}",
+    "TRAEFIK_API_PORT": "{{entrypoint.api-port}}",
+    "TRAEFIK_API_ADDRESS": "{{entrypoint.api-address}}",
+    "TRAEFIK_API_DASHBOARD": "{{entrypoint.enable-dashboard}}",
     "TRAEFIK_FILE_NAME": "{{traefik.config-file}}",
     "TRAEFIK_FILE_WATCH": "{{traefik.watch-config-file}}",
     "TRAEFIK_MARATHON_ENABLE": "{{marathon.enable}}",
     "TRAEFIK_MARATHON_ENDPOINT": "{{marathon.endpoint}}",
     "TRAEFIK_MARATHON_WATCH": "{{marathon.watch}}",
+    "TRAEFIK_MARATHON_EXPOSE": "{{marathon.expose}}",
     "TRAEFIK_MARATHON_DOMAIN": "{{marathon.domain}}",
-    "TRAEFIK_MARATHONLB_COMPATIBILITY": "{{marathon.marathonlb-compatibility}}",
+    "TRAEFIK_MARATHON_LB_COMPATIBILITY": "{{marathon.marathonlb-compatibility}}",
     "TRAEFIK_MARATHON_GROUPS_AS_SUBDOMAINS": "{{marathon.groups-as-subdomains}}",
     "TRAEFIK_MARATHON_DIALER_TIMEOUT": "{{marathon.dialer-timeout}}",
     "TRAEFIK_MARATHON_KEEP_ALIVE": "{{marathon.keep-alive}}",
     "TRAEFIK_MARATHON_FORCE_TASK_HOSTNAME": "{{marathon.force-task-hostname}}",
     "TRAEFIK_MARATHON_RESPECT_READINESS_CHECKS": "{{marathon.respect-readiness-checks}}",
+    "TRAEFIK_MESOS_ENABLE": "{{mesos.enable}}",
+    "TRAEFIK_MESOS_ENDPOINT": "{{mesos.endpoint}}",
+    "TRAEFIK_MESOS_WATCH": "{{mesos.watch}}",
+    "TRAEFIK_MESOS_EXPOSE": "{{mesos.expose}}",
+    "TRAEFIK_MESOS_DOMAIN": "{{mesos.domain}}",
+    "TRAEFIK_MESOS_GROUPS_AS_SUBDOMAINS": "{{mesos.groups-as-subdomains}}",
+    "TRAEFIK_MESOS_ZK_TIMEOUT": "{{mesos.zk-timeout}}",
+    "TRAEFIK_MESOS_TIMEOUT": "{{mesos.timeout}}",
+    "TRAEFIK_MESOS_REFRESH": "{{mesos.refresh}}",
+    "TRAEFIK_MESOS_IP_SOURCES": "{{mesos.ip-sources}}",
+    "TRAEFIK_K8S_ENABLE": "{{kubernetess.enable}}",
+    "TRAEFIK_K8S_ENDPOINT": "{{kubernetess.endpoint}}",
+    "TRAEFIK_K8S_TOKEN": "{{kubernetess.token}}",
+    "TRAEFIK_K8S_CA": "{{kubernetess.ca}}",
+    "TRAEFIK_K8S_NAMESPACES": "{{kubernetess.namespaces}}",
+    "TRAEFIK_K8S_FILENAME": "{{kubernetess.filename}}",
+    "TRAEFIK_K8S_INGRESS_CLASS": "{{kubernetess.ingress-class}}",
+    "TRAEFIK_K8S_DISABLE_PASS_HOST_HEADERS": "{{kubernetess.disable-pass-host-headers}}",
+    "TRAEFIK_K8S_ENABLE_PASS_TLS_CERT": "{{kubernetess.enable-pass-tls-cert}}",
+    "TRAEFIK_STATISTICS_RECENT_ERRORS": "{{metrics.recent-errors}}",
+    "TRAEFIK_ACCESS_LOG": "{{logging.access-logs}}",
+    "TRAEFIK_ACCESS_FORMAT": "{{logging.access-logs-format}}",
+    "TRAEFIK_ACCESS_PATH": "{{logging.access-logs-path}}",
+    {{#metrics.datadog-address}}
+    "TRAEFIK_DATADOG_ADDRESS": "{{metrics.datadog-address}}",
+    "TRAEFIK_DATADOG_PUSHINTERVAL": "{{metrics.datadog-pushinterval}}",
+    {{/metrics.datadog-address}}
+    {{#metrics.influxdb-address}}
+    "TRAEFIK_INFLUXDB_ADDRESS": "{{metrics.influxdb-address}}",
+    "TRAEFIK_INFLUXDB_PUSHINTERVAL": "{{metrics.influxdb-pushinterval}}",
+    {{/metrics.influxdb-address}}
+    {{#metrics.statsd-address}}
+    "TRAEFIK_STATSD_ADDRESS": "{{metrics.statsd-address}}",
+    "TRAEFIK_STATSD_PUSHINTERVAL": "{{metrics.statsd-pushinterval}}",
+    {{/metrics.statsd-address}}
+    {{#metrics.prometheus-entrypoint}}
+    "TRAEFIK_PROMETHEUS_ENTRYPOINT": "{{metrics.prometheus-entrypoint}}",
+    "TRAEFIK_PROMETHEUS_BUCKETS": "{{metrics.prometheus-buckets}}",
+    {{/metrics.prometheus-entrypoint}}
     {{#traefik.secret-name}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
     {{/traefik.secret-name}}
@@ -63,9 +115,11 @@
     "DCOS_SERVICE_NAME": "{{service.name}}",
     "DCOS_SERVICE_SCHEME": "http",
     "DCOS_PACKAGE_VERSION": "{{package.version}}",
-    {{#traefik.admin-enable}}
+    {{#entrypoint.api-enable}}
+      {{#entrypoint.enable-dashboard}}
     "DCOS_SERVICE_PORT_INDEX": "1",
-    {{/traefik.admin-enable}}
+      {{/entrypoint.enable-dashboard}}
+    {{/entrypoint.api-enable}}
     "DCOS_PACKAGE_IS_FRAMEWORK": "false"
   },
   {{#traefik.secret-name}}
@@ -76,12 +130,13 @@
   },
   {{/traefik.secret-name}}
   "ports": [
-    {{traefik.http-port}}
-    {{#traefik.admin-enable}}
-    ,{{traefik.admin-port}}
-    {{/traefik.admin-enable}}
-    {{#traefik.https-enable}}
-    ,{{traefik.https-port}}
-    {{/traefik.https-enable}}
+    0
+    {{#entrypoint.api-enable}}
+    ,{{entrypoint.api-port}}
+    {{/entrypoint.api-enable}}
+    ,{{entrypoint.http-port}}
+    {{#entrypoint.https-enable}}
+    ,{{entrypoint.https-port}}
+    {{/entrypoint.https-enable}}
   ]
 }
diff --git a/repo/packages/T/traefik/1/package.json b/repo/packages/T/traefik/2/package.json
index d8d5310f..6a2e48bf 100644
--- a/repo/packages/T/traefik/1/package.json
+++ b/repo/packages/T/traefik/2/package.json
@@ -1,12 +1,12 @@
 {
   "packagingVersion": "4.0",
   "name": "traefik",
-  "version": "1.0.1-1.5.3",
+  "version": "1.1.0-1.6.2",
   "minDcosReleaseVersion": "1.9",
   "scm": "https://github.com/containous/traefik",
   "description": "Traefik is a modern HTTP reverse proxy and load balancer written in go. It supports several backends (Docker, Swarm mode, Kubernetes, Marathon, Consul, Etcd, Rancher, Amazon ECS, and a lot more) to manage its configuration automatically and dynamically. \n\nSee https://docs.traefik.io for more information.",
   "maintainer": "https://github.com/deric/dcos-traefik",
-  "tags": ["loadbalancer", "service-discovery", "reverse-proxy", "proxy", "traffic"],
+  "tags": ["loadbalancer", "service-discovery", "reverse-proxy", "proxy", "traffic", "ingress"],
   "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production!\n\n",
   "postInstallNotes": "Traefik DC/OS Service has been successfully installed!\nSee https://docs.traefik.io for documentation.",
   "postUninstallNotes": "Traefik DC/OS Service has been uninstalled and will no longer run.",
diff --git a/repo/packages/T/traefik/1/resource.json b/repo/packages/T/traefik/2/resource.json
index c27dc8a0..79008cdb 100644
--- a/repo/packages/T/traefik/1/resource.json
+++ b/repo/packages/T/traefik/2/resource.json
@@ -1,8 +1,9 @@
 {
   "assets": {
     "uris": {
-      "traefik-bin": "https://github.com/containous/traefik/releases/download/v1.5.3/traefik_linux-amd64",
-      "bootstrap-sh": "https://raw.githubusercontent.com/deric/dcos-traefik/v1.0.0/bootstrap.sh"
+      "traefik-bin": "https://github.com/containous/traefik/releases/download/v1.6.2/traefik_linux-amd64",
+      "confd-bin": "https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64",
+      "bootstrap": "https://github.com/deric/dcos-traefik/archive/v1.1.0.tar.gz"
     }
   },
   "images": {
```