### PR TITLE
Add single package repo files for DC/OS >= 1.8

### DIFF
--- a/docker/server/build.bash
+++ b/docker/server/build.bash
@@ -19,7 +19,7 @@ function clean {
 
 }
 
-function prepare {
+function prepare {(
 
   local universeBuildTarget="${DOCKER_SERVER_DIR}/../../target"
 
@@ -29,12 +29,14 @@ function prepare {
     cp -r ${DOCKER_SERVER_DIR}/../../target/repo-*.json ${DOCKER_SERVER_DIR}/target
     # copy over the build zip repos (only 1.6.1 and 1.7)
     cp -r ${DOCKER_SERVER_DIR}/../../target/repo-*.zip ${DOCKER_SERVER_DIR}/target
+    # copy over the packages files
+    (cd ${DOCKER_SERVER_DIR}/../../target; rsync -R */package/* ${DOCKER_SERVER_DIR}/target)
   else
     err "Please run scripts/build.sh before trying to build universe server"
   fi
 
 
-}
+)}
 
 function gzipJsonFiles {(
 

--- a/docker/server/marathon.json
+++ b/docker/server/marathon.json
@@ -9,6 +9,7 @@
     "docker": {
       "network": "BRIDGE",
       "image": "mesosphere/universe-server:$tag",
+      "forcePullImage": true,
       "portMappings": [
         {
           "containerPort": 80,

--- a/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
+++ b/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
@@ -62,6 +62,11 @@ server {
     rewrite ^/repo-1.7$ /repo-up-to-1.7.zip break;
   }
 
+  location /package {
+    # This is supported from 1.8 and above. Results in 404 for older versions.
+    rewrite ^ /$universe_version/$dcos_release_version$uri.json;
+  }
+
   location = /repo {
     types {
       application/zip zip;
@@ -78,20 +83,22 @@ server {
     rewrite ^/repo$ /repo-up-to-$dcos_release_version.zip break;
   }
 
-  location = /v3 {
+  location /v3 {
     internal;
     types {
       "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3" json;
     }
     rewrite ^/v3$ /repo-up-to-$dcos_release_version.json break;
+    rewrite ^/v3(.*)$ $1 break;
   }
 
-  location = /v4 {
+  location /v4 {
     internal;
     types {
       "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v4" json;
     }
     rewrite ^/v4$ /repo-up-to-$dcos_release_version.json break;
+    rewrite ^/v4(.*)$ $1 break;
   }
 
 }

--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -712,10 +712,10 @@ def validate_repo_with_schema(repo_json_data, repo_version):
 def _populate_dcos_version_json_to_folder(dcos_version, outdir):
     """Populate the repo-up-to-<dcos-version>.json file to a folder.
     The folder structure would be :
-        <dcos-version>
-            -package
-                -<name-of-package1>.json
-                -<name-of-package2>.json
+        <dcos-version>/
+            package/
+                <name-of-package1>.json
+                <name-of-package2>.json
 
     :param dcos_version: The version of DC/OS file to process.
     :type dcos_version: str

--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import os
 from distutils.version import LooseVersion
 import argparse
 import base64
@@ -67,10 +67,14 @@ def main():
     ct_empty_path = args.outdir / 'repo-empty-v3.content_type'
     create_content_type_file(ct_empty_path, "v3")
 
+    zip_file_dcos_versions = ["1.6.1", "1.7"]
+    json_file_dcos_versions = ["1.8", "1.9", "1.10", "1.11", "1.12"]
     # create universe-by-version files for `dcos_versions`
-    dcos_versions = ["1.6.1", "1.7", "1.8", "1.9", "1.10", "1.11", "1.12"]
+    dcos_versions = zip_file_dcos_versions + json_file_dcos_versions
     [render_universe_by_version(
         args.outdir, copy.deepcopy(packages), version) for version in dcos_versions]
+    for dcos_version in json_file_dcos_versions:
+        _populate_dcos_version_json_to_folder(dcos_version, args.outdir)
 
 
 def render_universe_by_version(outdir, packages, version):
@@ -207,7 +211,7 @@ def filter_and_downgrade_packages_by_version(packages, version):
         # Prior to 1.10, Cosmos had a rendering bug that required
         # stringified JSON to be doubly escaped. This was corrected
         # in 1.10, but it means that packages with stringified JSON parameters
-        # that need to bridge versions must be accomodated.
+        # that need to bridge versions must be accommodated.
         #
         # < 1.9 style escaping:
         # \\\"field\\\": \\\"value\\\"
@@ -703,6 +707,39 @@ def validate_repo_with_schema(repo_json_data, repo_version):
         for suberror in sorted(error.context, key=lambda e: e.schema_path):
             errors.append('{}: {}'.format(list(suberror.schema_path), suberror.message))
     return errors
+
+
+def _populate_dcos_version_json_to_folder(dcos_version, outdir):
+    """Populate the repo-up-to-<dcos-version>.json file to a folder.
+    The folder structure would be :
+        <dcos-version>
+            -package
+                -<name-of-package1>.json
+                -<name-of-package2>.json
+
+    :param dcos_version: The version of DC/OS file to process.
+    :type dcos_version: str
+    :param outdir: Path to the directory to use to store all universe objects
+    :type outdir: str
+    :return: None
+    """
+    repo_dir = outdir / dcos_version / 'package'
+    pathlib.Path(repo_dir).mkdir(parents=True)
+    repo_file = pathlib.Path(outdir / 'repo-up-to-{}.json'.format(dcos_version))
+    with repo_file.open('r',  encoding='utf-8') as f:
+        data = json.loads(f.read())
+        packages_dict = {}
+
+        for package in data.get('packages'):
+            package_name = package.get('name')
+            package_list = packages_dict.get(package_name, [])
+            package_list.append(package)
+            packages_dict[package_name] = package_list
+
+        for package_name, package_list in packages_dict.items():
+            with pathlib.Path(repo_dir / '{}.json'.format(package_name))\
+                        .open('w', encoding='utf-8') as f:
+                json.dump({'packages': package_list}, f)
 
 
 def _validate_repo(file_path, version):


### PR DESCRIPTION
Address [DCOS-37596](https://jira.mesosphere.com/browse/DCOS-37596)

- I have implemented this for DC/OS 1.8 and above.
- An example url would be `http://.../package/cassandra`. It should be straightforward to append `?version=<a.b.c>` in future if needed.
- Tested this by making sure i can add two repos with urls <domain-name>/repo and <domain-name>/package/cassandra to `Package Repositories`.

TODO 
- Need to coordinate with @lloesche once this is merged for the deployment of universe server.