### PR TITLE
Remove support@mesosphere.io as maintainer for packages not supported by Mesosphere

### DIFF
--- a/repo/packages/C/ceph/0/package.json
+++ b/repo/packages/C/ceph/0/package.json
@@ -3,7 +3,7 @@
   "name": "ceph",
   "version": "0.2.9-0.1",
   "scm": "https://github.com/ceph",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "https://www.ceph.org",
   "description": "Ceph, a free-software storage platform, implements object storage on a single distributed computer cluster, and provides interfaces for object-, block- and file-level storage. Ceph aims primarily for completely distributed operation without a single point of failure, scalable to the exabyte level, and freely available.\n\nCeph replicates data and makes it fault-tolerant, using commodity hardware and requiring no specific hardware support. As a result of its design, the system is both self-healing and self-managing, aiming to minimize administration time and other costs.",
   "tags": [

--- a/repo/packages/E/etcd/0/package.json
+++ b/repo/packages/E/etcd/0/package.json
@@ -3,7 +3,7 @@
   "name": "etcd",
   "version": "0.0.2",
   "scm": "https://github.com/mesosphere/etcd-mesos",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "description": "A distributed consistent key-value store for shared configuration and service discovery.",
   "framework": true,
   "tags": ["mesosphere", "framework", "consensus"],

--- a/repo/packages/F/flink/0/package.json
+++ b/repo/packages/F/flink/0/package.json
@@ -18,7 +18,7 @@
         }
     ],
 
-    "maintainer": "support@mesosphere.io",
+    "maintainer": "https://dcos.io/community/",
 
     "selected": false,
     "minDcosReleaseVersion": "1.8",

--- a/repo/packages/M/mongodb-admin/0/package.json
+++ b/repo/packages/M/mongodb-admin/0/package.json
@@ -4,7 +4,7 @@
   "name": "mongodb-admin",
   "version": "0.0.20-0.1",
   "scm": "https://github.com/mrvautin/adminMongo",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "https://github.com/mrvautin/adminMongo",
   "description": "A Web user interface to administer MongoDB databases built using Express.",
   "tags": ["admin", "database", "mongoclient", "mongo", "mongodb", "nosql"],

--- a/repo/packages/M/mongodb/0/package.json
+++ b/repo/packages/M/mongodb/0/package.json
@@ -4,7 +4,7 @@
   "name": "mongodb",
   "version": "3.2-0.1",
   "scm": "https://github.com/tutumcloud/tutum-docker-mongodb",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "https://www.mongodb.com",
   "description": "MongoDB is an open-source, document database designed for ease of development and scaling.",
   "tags": ["database", "mongo", "mongodb", "nosql"],

--- a/repo/packages/M/mysql-admin/0/package.json
+++ b/repo/packages/M/mysql-admin/0/package.json
@@ -3,7 +3,7 @@
   "name": "mysql-admin",
   "version": "0.1",
   "scm": "https://github.com/phpmyadmin/docker",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "https://www.phpmyadmin.net/",
   "description": "phpMyAdmin is a free software tool written in PHP, intended to handle the administration of MySQL over the Web. phpMyAdmin supports a wide range of operations on MySQL and MariaDB.\n\nThis DC/OS package is ready to be used alongside the DC/OS `mysql` package. Other MySQL servers may work, but haven't been tested.",
   "tags": [

--- a/repo/packages/M/mysql/0/package.json
+++ b/repo/packages/M/mysql/0/package.json
@@ -3,7 +3,7 @@
   "name": "mysql",
   "version": "5.7.12",
   "scm": "https://github.com/mysql/mysql-server.git",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "https://mysql-ci.org",
   "description": "MySQL is the world's most popular open source database. With its proven performance, reliability and ease-of-use, MySQL has become the leading database choice for web-based applications, covering the entire range from personal projects and websites, via e-commerce and information services, all the way to high profile web properties including Facebook, Twitter, YouTube, Yahoo! and many more.",
   "tags": ["database", "mysql", "sql"],

--- a/repo/packages/M/mysql/1/package.json
+++ b/repo/packages/M/mysql/1/package.json
@@ -3,7 +3,7 @@
   "name": "mysql",
   "version": "5.7.12",
   "scm": "https://github.com/mysql/mysql-server.git",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "https://mysql-ci.org",
   "description": "MySQL is the world's most popular open source database. With its proven performance, reliability and ease-of-use, MySQL has become the leading database choice for web-based applications, covering the entire range from personal projects and websites, via e-commerce and information services, all the way to high profile web properties including Facebook, Twitter, YouTube, Yahoo! and many more.",
   "tags": ["database", "mysql", "sql"],

--- a/repo/packages/M/mysql/2/package.json
+++ b/repo/packages/M/mysql/2/package.json
@@ -3,7 +3,7 @@
   "name": "mysql",
   "version": "5.7.12",
   "scm": "https://github.com/mysql/mysql-server.git",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "https://mysql-ci.org",
   "description": "MySQL is the world's most popular open source database. With its proven performance, reliability and ease-of-use, MySQL has become the leading database choice for web-based applications, covering the entire range from personal projects and websites, via e-commerce and information services, all the way to high profile web properties including Facebook, Twitter, YouTube, Yahoo! and many more.",
   "tags": ["database", "mysql", "sql"],

--- a/repo/packages/M/mysql/3/package.json
+++ b/repo/packages/M/mysql/3/package.json
@@ -3,7 +3,7 @@
   "name": "mysql",
   "version": "5.7.12",
   "scm": "https://github.com/mysql/mysql-server.git",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "https://mysql-ci.org",
   "description": "MySQL is the world's most popular open source database. With its proven performance, reliability and ease-of-use, MySQL has become the leading database choice for web-based applications, covering the entire range from personal projects and websites, via e-commerce and information services, all the way to high profile web properties including Facebook, Twitter, YouTube, Yahoo! and many more.",
   "tags": ["database", "mysql", "sql"],

--- a/repo/packages/M/mysql/4/package.json
+++ b/repo/packages/M/mysql/4/package.json
@@ -4,7 +4,7 @@
   "name": "mysql",
   "version": "0.2",
   "scm": "https://github.com/mysql/mysql-server.git",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "https://mysql-ci.org",
   "description": "MySQL is the world's most popular open source database. With its proven performance, reliability and ease-of-use, MySQL has become the leading database choice for web-based applications, covering the entire range from personal projects and websites, via e-commerce and information services, all the way to high profile web properties including Facebook, Twitter, YouTube, Yahoo! and many more.",
   "tags": ["database", "mysql", "sql"],

--- a/repo/packages/O/openldap-admin/0/package.json
+++ b/repo/packages/O/openldap-admin/0/package.json
@@ -3,7 +3,7 @@
   "name": "openldap-admin",
   "version": "0.1",
   "scm": "https://github.com/dinkel/docker-phpldapadmin",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "http://phpldapadmin.sourceforge.net/wiki/index.php/Main_Page",
   "description": "phpLDAPadmin is a web-based LDAP client. It provides easy, anywhere-accessible, multi-language administration for your LDAP server.",
   "tags": [

--- a/repo/packages/O/openldap-admin/1/package.json
+++ b/repo/packages/O/openldap-admin/1/package.json
@@ -3,7 +3,7 @@
   "name": "openldap-admin",
   "version": "0.2",
   "scm": "https://github.com/dinkel/docker-phpldapadmin",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "http://phpldapadmin.sourceforge.net/wiki/index.php/Main_Page",
   "description": "phpLDAPadmin is a web-based LDAP client. It provides easy, anywhere-accessible, multi-language administration for your LDAP server.\n\nThis DC/OS package is ready to be used alongside the DC/OS `openldap` package. Other LDAP servers may work, but haven't been tested.",
   "tags": [

--- a/repo/packages/O/openldap-admin/2/package.json
+++ b/repo/packages/O/openldap-admin/2/package.json
@@ -3,7 +3,7 @@
   "name": "openldap-admin",
   "version": "0.3",
   "scm": "https://github.com/dinkel/docker-phpldapadmin",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "http://phpldapadmin.sourceforge.net/wiki/index.php/Main_Page",
   "description": "phpLDAPadmin is a web-based LDAP client. It provides easy, anywhere-accessible, multi-language administration for your LDAP server.\n\nThis DC/OS package is ready to be used alongside the DC/OS `openldap` package. Other LDAP servers may work, but haven't been tested.",
   "tags": [

--- a/repo/packages/O/openldap/0/package.json
+++ b/repo/packages/O/openldap/0/package.json
@@ -3,7 +3,7 @@
   "name": "openldap",
   "version": "0.1",
   "scm": "https://github.com/dinkel/docker-openldap",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "http://www.openldap.org/",
   "description": "OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.",
   "framework": true,

--- a/repo/packages/O/openldap/1/package.json
+++ b/repo/packages/O/openldap/1/package.json
@@ -3,7 +3,7 @@
   "name": "openldap",
   "version": "0.2",
   "scm": "https://github.com/dinkel/docker-openldap",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "http://www.openldap.org/",
   "description": "OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.",
   "framework": true,

--- a/repo/packages/O/openldap/2/package.json
+++ b/repo/packages/O/openldap/2/package.json
@@ -4,7 +4,7 @@
   "name": "openldap",
   "version": "0.3",
   "scm": "https://github.com/dinkel/docker-openldap",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "http://www.openldap.org/",
   "description": "OpenLDAP Software is an open source implementation of the Lightweight Directory Access Protocol.",
   "framework": true,

--- a/repo/packages/P/postgresql-admin/0/package.json
+++ b/repo/packages/P/postgresql-admin/0/package.json
@@ -3,7 +3,7 @@
   "name": "postgresql-admin",
   "version": "0.1",
   "scm": "https://github.com/jacksoncage/dockerfiles/tree/master/phppgadmin",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "http://phppgadmin.sourceforge.net/doku.php",
   "description": "PhpPgAdmin is a web-based administration tool for PostgreSQL. It is perfect for PostgreSQL DBAs, newbies, and hosting services.\n\nThis DC/OS package is ready to be used alongside the DC/OS `postgresql` package. Other PostgreSQL servers may work, but haven't been tested.",
   "tags": [

--- a/repo/packages/P/postgresql/0/package.json
+++ b/repo/packages/P/postgresql/0/package.json
@@ -4,7 +4,7 @@
   "name": "postgresql",
   "version": "0.1",
   "scm": "https://github.com/docker-library/official-images/pulls?q=label%3Alibrary%2Fpostgres",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "website": "http://www.postgresql.org/",
   "description": "PostgreSQL is an object-relational database management system (ORDBMS) with an emphasis on extensibility and standards-compliance.",
   "framework": true,

--- a/repo/packages/Z/zeppelin/0/package.json
+++ b/repo/packages/Z/zeppelin/0/package.json
@@ -3,7 +3,7 @@
   "name": "zeppelin",
   "version": "0.5.6",
   "scm": "https://github.com/apache/incubator-zeppelin",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "description": "Zeppelin is a web-based notebook that enables interactive data analytics",
   "framework": true,
   "tags": ["nflabs", "framework", "bigdata", "spark", "notebook", "interactive"],

--- a/repo/packages/Z/zeppelin/1/package.json
+++ b/repo/packages/Z/zeppelin/1/package.json
@@ -3,7 +3,7 @@
   "name": "zeppelin",
   "version": "0.5.6",
   "scm": "https://github.com/apache/incubator-zeppelin",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "description": "Zeppelin is a web-based notebook that enables interactive data analytics",
   "framework": true,
   "tags": ["nflabs", "bigdata", "spark", "notebook", "interactive"],

--- a/repo/packages/Z/zeppelin/2/package.json
+++ b/repo/packages/Z/zeppelin/2/package.json
@@ -3,7 +3,7 @@
   "name": "zeppelin",
   "version": "0.6.0",
   "scm": "https://github.com/apache/incubator-zeppelin",
-  "maintainer": "support@mesosphere.io",
+  "maintainer": "https://dcos.io/community/",
   "description": "Zeppelin is a web-based notebook that enables interactive data analytics",
   "framework": true,
   "tags": ["nflabs", "bigdata", "spark", "notebook", "interactive"],


### PR DESCRIPTION
I was just going through the universe repo to check any packages that claim to be supported by Mesopshere but are not actually supported/ never were supported.
I found a few. Thankfully they are older versions of a bunch community packages. This PR updates package.json for all such old packages