### PR TITLE
Update Traefik to 1.6.5

### DIFF
--- a/repo/packages/T/traefik/3/config.json
+++ b/repo/packages/T/traefik/3/config.json
@@ -1,0 +1,417 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "properties": {
+    "service": {
+      "properties": {
+        "name": {
+          "default": "traefik",
+          "description": "Name of the Traefik instance",
+          "type": "string"
+        },
+        "cpus": {
+          "default": 1,
+          "description": "CPU shares to allocate to each Traefik instance.",
+          "minimum": 0.5,
+          "type": "number"
+        },
+        "mem": {
+          "default": 128.0,
+          "description": "Memory (MB) to allocate to each Traefik task.",
+          "minimum": 64.0,
+          "type": "number"
+        },
+        "instances": {
+          "default": 2,
+          "description": "Number of instances to run.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "user": {
+          "description": "The user that runs the Traefik service and owns the Mesos sandbox.",
+          "type": "string",
+          "default": "root"
+        },
+        "role": {
+          "default": "slave_public",
+          "description": "Deploy Traefik only on nodes with this role.",
+          "type": "string"
+        },
+        "minimumHealthCapacity": {
+          "default": 0.5,
+          "description": "Minimum health capacity.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "maximumOverCapacity": {
+          "default": 0.2,
+          "description": "Maximum over capacity.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "disk": {
+          "default": 100,
+          "description": "Disk space (in MB) to allocate for each instance.",
+          "minimum": 20,
+          "type": "integer"
+        }
+      },
+      "required": ["cpus", "mem", "instances", "name"],
+      "type": "object"
+    },
+    "entrypoint": {
+      "description": "Traefik entrypoints",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "http-address": {
+          "default": "",
+          "description": "Leave empty for listening on all interfaces.",
+          "type": "string"
+        },
+        "http-port": {
+          "default": 80,
+          "description": "HTTP port.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "http-compression": {
+          "default": true,
+          "description": "Enable compression.",
+          "type": "boolean"
+        },
+        "https-enable": {
+          "default": true,
+          "description": "Enable HTTPS entrypoint.",
+          "type": "boolean"
+        },
+        "https-address": {
+          "default": "",
+          "description": "Leave empty for listening on all interfaces.",
+          "type": "string"
+        },
+        "https-port": {
+          "default": 443,
+          "description": "HTTPS port.",
+          "minimum": 1,
+          "type": "number"
+        },
+        "https-compression": {
+          "default": true,
+          "description": "Enable compression.",
+          "type": "boolean"
+        },
+        "api-enable": {
+          "default": true,
+          "description": "Enable API entrypoint.",
+          "type": "boolean"
+        },
+        "enable-dashboard": {
+          "default": true,
+          "description": "Enable Admin Dashboard.",
+          "type": "boolean"
+        },
+        "api-address": {
+          "description": "Leave empty for listening on all interfaces.",
+          "type": "string"
+        },
+        "api-port": {
+          "default": 8080,
+          "description": "API (admin) port, if not defined $PORT1 will be used",
+          "type": "integer"
+        }
+      }
+    },
+    "traefik": {
+      "description": "Traefik configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "secret-name": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "log-level": {
+          "description": "Traefik log level.",
+          "type": "string",
+          "default": "INFO"
+        },
+        "grace-timeout": {
+          "description": "Duration to give active requests a chance to finish before Traefik stops",
+          "type": "string",
+          "default": "30s"
+        },
+        "healthcheck-interval": {
+          "description": "Default health check interval",
+          "type": "string",
+          "default": "30s"
+        },
+        "read-timeout": {
+          "description": "The maximum duration for reading the entire request, including the body",
+          "type": "string",
+          "default": "0s"
+        },
+        "write-timeout": {
+          "description": "The maximum duration before timing out writes of the response",
+          "type": "string",
+          "default": "0s"
+        },
+        "idle-timeout": {
+          "description": "The maximum duration an idle (keep-alive) connection will remain idle before closing itself.",
+          "type": "string",
+          "default": "180s"
+        },
+        "retry": {
+          "description": "Number of attempts to reach backend service",
+          "type": "string"
+        },
+        "config-file": {
+          "description": "Path to additional Traefik config file in TOML format.",
+          "type": "string"
+        },
+        "watch-config-file": {
+          "description": "Watch config file for changes.",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "marathon": {
+      "description": "Marathon configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "default": true,
+          "description": "Enable Marathon provider.",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "default": "http://marathon.mesos:8080",
+          "description": "Marathon endpoint, multiple instances separate by comma.",
+          "type": "string"
+        },
+        "watch": {
+          "default": true,
+          "description": "Watch changes in Marathon.",
+          "type": "boolean"
+        },
+        "domain": {
+          "default": "marathon.localhost",
+          "description": "Default domain. Can be overridden by setting the 'traefik.domain' label on an application.",
+          "type": "string"
+        },
+        "marathonlb-compatibility": {
+          "default": false,
+          "description": "Enable compatibility with marathon-lb labels.",
+          "type": "boolean"
+        },
+        "expose": {
+          "default": false,
+          "description": "Expose Marathon apps by default in Traefik.",
+          "type": "boolean"
+        },
+        "respect-readiness-checks": {
+          "default": true,
+          "description": "During deployment Traefik will respect readiness checks if defined in Marathon.",
+          "type": "boolean"
+        },
+        "groups-as-subdomains": {
+          "default": false,
+          "description": "Convert Marathon groups to subdomains.",
+          "type": "boolean"
+        },
+        "dialer-timeout": {
+          "default": "60s",
+          "description": "Amount of time to allow the Marathon provider to wait to open a TCP connection to a Marathon master.",
+          "type": "string"
+        },
+        "keep-alive": {
+          "default": "10s",
+          "description": "Set the TCP Keep Alive interval for the Marathon HTTP Client.",
+          "type": "string"
+        },
+        "force-task-hostname": {
+          "default": false,
+          "description": "By default, a task's IP address (as returned by the Marathon API) is used as backend server if an IP-per-task configuration can be found; otherwise, the name of the host running the task is used. The latter behavior can be enforced by enabling this switch.",
+          "type": "boolean"
+        }
+      }
+    },
+    "mesos": {
+      "description": "Allows directly exposing Mesos applications",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "default": false,
+          "description": "Enable Mesos provider.",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "default": "http://leader.mesos:5050",
+          "description": "Mesos endpoint, multiple instances separate by comma.",
+          "type": "string"
+        },
+        "watch": {
+          "default": true,
+          "description": "Watch changes in Marathon.",
+          "type": "boolean"
+        },
+        "domain": {
+          "default": "mesos.localhost",
+          "description": "Default domain. Can be overridden by setting the 'traefik.domain' label on an application.",
+          "type": "string"
+        },
+        "expose": {
+          "default": false,
+          "description": "Expose Mesos apps by default in Traefik.",
+          "type": "boolean"
+        },
+        "groups-as-subdomains": {
+          "default": false,
+          "description": "Convert Marathon groups to subdomains.",
+          "type": "boolean"
+        },
+        "timeout": {
+          "default": 30,
+          "description": "Mesos HTTP API timeout",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "zk-timeout": {
+          "default": 30,
+          "description": "ZooKeeper timeout",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "refresh": {
+          "default": 30,
+          "description": "Polling interval",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ip-sources": {
+          "default": "host",
+          "description": "IP sources (e.g. host, docker, mesos, netinfo).",
+          "type": "string"
+        }
+      }
+    },
+    "kubernetess": {
+      "description": "Allows access to Kubernetess applications",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enable": {
+          "default": false,
+          "description": "Enable Kubernetess provider.",
+          "type": "boolean"
+        },
+        "endpoint": {
+          "description": "Kubernetes server endpoint",
+          "type": "string"
+        },
+        "token": {
+          "description": "Bearer token used for the Kubernetes client configuration",
+          "type": "string"
+        },
+        "ca": {
+          "description": "Path to the certificate authority file",
+          "type": "string"
+        },
+        "namespaces": {
+          "description": "Comma-separated namespaces to watch",
+          "type": "string"
+        },
+        "filename": {
+          "description": "Override default configuration template",
+          "type": "string"
+        },
+        "ingress-class": {
+          "description": "Value of `kubernetes.io/ingress.class` annotation that identifies Ingress objects to be processed",
+          "type": "string"
+        },
+        "disable-pass-host-headers": {
+          "default": false,
+          "description": "Disable PassHost Headers",
+          "type": "boolean"
+        },
+        "enable-pass-tls-cert": {
+          "default": false,
+          "description": "Disable PassHost Headers",
+          "type": "boolean"
+        }
+      }
+    },
+    "metrics": {
+      "description": "Metrics configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "recent-errors": {
+          "default": 10,
+          "description": "Number of logged recent errors",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "prometheus-entrypoint": {
+          "default": "",
+          "description": "Traefik entrypoint for Prometheus (e.g. api)",
+          "type": "string"
+        },
+        "prometheus-buckets": {
+          "default": "0.1,0.3,1.2,5.0",
+          "type": "string"
+        },
+        "datadog-address": {
+          "default": "",
+          "description": "DataDog endpoint",
+          "type": "string"
+        },
+        "datadog-pushinterval": {
+          "default": "10s",
+          "type": "string"
+        },
+        "influxdb-address": {
+          "default": "",
+          "description": "InfluxDB endpoint",
+          "type": "string"
+        },
+        "influxdb-pushinterval": {
+          "default": "10s",
+          "type": "string"
+        },
+        "statsd-address": {
+          "default": "",
+          "description": "StatsD endpoint",
+          "type": "string"
+        },
+        "statsd-pushinterval": {
+          "default": "10s",
+          "type": "string"
+        }
+      }
+    },
+    "logging": {
+      "description": "Logging configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "access-logs": {
+          "default": false,
+          "description": "Enable Access Logs",
+          "type": "boolean"
+        },
+        "access-logs-format": {
+          "description": "Default is text",
+          "type": "string"
+        },
+        "access-logs-path": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/T/traefik/3/marathon.json.mustache
+++ b/repo/packages/T/traefik/3/marathon.json.mustache
@@ -1,0 +1,142 @@
+{
+  "id": "{{service.name}}",
+  "instances": {{service.instances}},
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "disk": {{service.disk}},
+  "user": "{{service.user}}",
+  "cmd": "mv dcos-traefik-1.1.1/* $(pwd)/ && bash bootstrap.sh && ./traefik_linux-amd64 -c traefik.toml",
+  "uris": [
+    "{{resource.assets.uris.traefik-bin}}",
+    "{{resource.assets.uris.confd-bin}}",
+    "{{resource.assets.uris.bootstrap}}"
+  ],
+  {{#service.role}}
+  "acceptedResourceRoles": [
+    "{{service.role}}"
+  ],
+  {{/service.role}}
+  "healthChecks": [
+    {
+      "path": "/ping",
+      "portIndex": 0,
+      "protocol": "MESOS_HTTP",
+      "gracePeriodSeconds": 20,
+      "intervalSeconds": 5,
+      "timeoutSeconds": 2,
+      "maxConsecutiveFailures": 2,
+      "ignoreHttp1xx": false
+    }
+  ],
+  "upgradeStrategy": {
+    "minimumHealthCapacity": {{service.minimumHealthCapacity}},
+    "maximumOverCapacity": {{service.maximumOverCapacity}}
+  },
+  "requirePorts":true,
+  "env": {
+    "TRAEFIK_LOG_LEVEL": "{{traefik.log-level}}",
+    "TRAEFIK_GRACE_TIMEOUT": "{{traefik.grace-timeout}}",
+    "TRAEFIK_HEALTHCHECK_INTERVAL": "{{traefik.healthcheck-interval}}",
+    "TRAEFIK_READ_TIMEOUT": "{{traefik.read-timeout}}",
+    "TRAEFIK_WRITE_TIMEOUT": "{{traefik.write-timeout}}",
+    "TRAEFIK_IDLE_TIMEOUT": "{{traefik.idle-timeout}}",
+    {{#traefik.retry}}
+    "TRAEFIK_RETRY": "{{traefik.retry}}",
+    {{/traefik.retry}}
+    "TRAEFIK_HTTP_ADDRESS": "{{entrypoint.http-address}}",
+    "TRAEFIK_HTTP_PORT": "{{entrypoint.http-port}}",
+    "TRAEFIK_HTTPS_ENABLE": "{{entrypoint.https-enable}}",
+    "TRAEFIK_HTTPS_PORT": "{{entrypoint.https-port}}",
+    "TRAEFIK_HTTPS_ADDRESS": "{{entrypoint.https-address}}",
+    "TRAEFIK_HTTPS_COMPRESSION": "{{entrypoint.https-compression}}",
+    "TRAEFIK_PING_ENABLE": "true",
+    "TRAEFIK_API_ENABLE": "{{entrypoint.api-enable}}",
+    "TRAEFIK_API_PORT": "{{entrypoint.api-port}}",
+    "TRAEFIK_API_ADDRESS": "{{entrypoint.api-address}}",
+    "TRAEFIK_API_DASHBOARD": "{{entrypoint.enable-dashboard}}",
+    "TRAEFIK_FILE_NAME": "{{traefik.config-file}}",
+    "TRAEFIK_FILE_WATCH": "{{traefik.watch-config-file}}",
+    "TRAEFIK_MARATHON_ENABLE": "{{marathon.enable}}",
+    "TRAEFIK_MARATHON_ENDPOINT": "{{marathon.endpoint}}",
+    "TRAEFIK_MARATHON_WATCH": "{{marathon.watch}}",
+    "TRAEFIK_MARATHON_EXPOSE": "{{marathon.expose}}",
+    "TRAEFIK_MARATHON_DOMAIN": "{{marathon.domain}}",
+    "TRAEFIK_MARATHON_LB_COMPATIBILITY": "{{marathon.marathonlb-compatibility}}",
+    "TRAEFIK_MARATHON_GROUPS_AS_SUBDOMAINS": "{{marathon.groups-as-subdomains}}",
+    "TRAEFIK_MARATHON_DIALER_TIMEOUT": "{{marathon.dialer-timeout}}",
+    "TRAEFIK_MARATHON_KEEP_ALIVE": "{{marathon.keep-alive}}",
+    "TRAEFIK_MARATHON_FORCE_TASK_HOSTNAME": "{{marathon.force-task-hostname}}",
+    "TRAEFIK_MARATHON_RESPECT_READINESS_CHECKS": "{{marathon.respect-readiness-checks}}",
+    "TRAEFIK_MESOS_ENABLE": "{{mesos.enable}}",
+    "TRAEFIK_MESOS_ENDPOINT": "{{mesos.endpoint}}",
+    "TRAEFIK_MESOS_WATCH": "{{mesos.watch}}",
+    "TRAEFIK_MESOS_EXPOSE": "{{mesos.expose}}",
+    "TRAEFIK_MESOS_DOMAIN": "{{mesos.domain}}",
+    "TRAEFIK_MESOS_GROUPS_AS_SUBDOMAINS": "{{mesos.groups-as-subdomains}}",
+    "TRAEFIK_MESOS_ZK_TIMEOUT": "{{mesos.zk-timeout}}",
+    "TRAEFIK_MESOS_TIMEOUT": "{{mesos.timeout}}",
+    "TRAEFIK_MESOS_REFRESH": "{{mesos.refresh}}",
+    "TRAEFIK_MESOS_IP_SOURCES": "{{mesos.ip-sources}}",
+    "TRAEFIK_K8S_ENABLE": "{{kubernetess.enable}}",
+    "TRAEFIK_K8S_ENDPOINT": "{{kubernetess.endpoint}}",
+    "TRAEFIK_K8S_TOKEN": "{{kubernetess.token}}",
+    "TRAEFIK_K8S_CA": "{{kubernetess.ca}}",
+    "TRAEFIK_K8S_NAMESPACES": "{{kubernetess.namespaces}}",
+    "TRAEFIK_K8S_FILENAME": "{{kubernetess.filename}}",
+    "TRAEFIK_K8S_INGRESS_CLASS": "{{kubernetess.ingress-class}}",
+    "TRAEFIK_K8S_DISABLE_PASS_HOST_HEADERS": "{{kubernetess.disable-pass-host-headers}}",
+    "TRAEFIK_K8S_ENABLE_PASS_TLS_CERT": "{{kubernetess.enable-pass-tls-cert}}",
+    "TRAEFIK_STATISTICS_RECENT_ERRORS": "{{metrics.recent-errors}}",
+    "TRAEFIK_ACCESS_LOG": "{{logging.access-logs}}",
+    "TRAEFIK_ACCESS_FORMAT": "{{logging.access-logs-format}}",
+    "TRAEFIK_ACCESS_PATH": "{{logging.access-logs-path}}",
+    {{#metrics.datadog-address}}
+    "TRAEFIK_DATADOG_ADDRESS": "{{metrics.datadog-address}}",
+    "TRAEFIK_DATADOG_PUSHINTERVAL": "{{metrics.datadog-pushinterval}}",
+    {{/metrics.datadog-address}}
+    {{#metrics.influxdb-address}}
+    "TRAEFIK_INFLUXDB_ADDRESS": "{{metrics.influxdb-address}}",
+    "TRAEFIK_INFLUXDB_PUSHINTERVAL": "{{metrics.influxdb-pushinterval}}",
+    {{/metrics.influxdb-address}}
+    {{#metrics.statsd-address}}
+    "TRAEFIK_STATSD_ADDRESS": "{{metrics.statsd-address}}",
+    "TRAEFIK_STATSD_PUSHINTERVAL": "{{metrics.statsd-pushinterval}}",
+    {{/metrics.statsd-address}}
+    {{#metrics.prometheus-entrypoint}}
+    "TRAEFIK_PROMETHEUS_ENTRYPOINT": "{{metrics.prometheus-entrypoint}}",
+    "TRAEFIK_PROMETHEUS_BUCKETS": "{{metrics.prometheus-buckets}}",
+    {{/metrics.prometheus-entrypoint}}
+    {{#traefik.secret-name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    {{/traefik.secret-name}}
+    "TRAEFIK_MARATHON_EXPOSE": "{{marathon.expose}}"
+  },
+  "labels": {
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_PACKAGE_VERSION": "{{package.version}}",
+    {{#entrypoint.api-enable}}
+      {{#entrypoint.enable-dashboard}}
+    "DCOS_SERVICE_PORT_INDEX": "1",
+      {{/entrypoint.enable-dashboard}}
+    {{/entrypoint.api-enable}}
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  },
+  {{#traefik.secret-name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{traefik.secret-name}}"
+    }
+  },
+  {{/traefik.secret-name}}
+  "ports": [
+    0
+    {{#entrypoint.api-enable}}
+    ,{{entrypoint.api-port}}
+    {{/entrypoint.api-enable}}
+    ,{{entrypoint.http-port}}
+    {{#entrypoint.https-enable}}
+    ,{{entrypoint.https-port}}
+    {{/entrypoint.https-enable}}
+  ]
+}

--- a/repo/packages/T/traefik/3/package.json
+++ b/repo/packages/T/traefik/3/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "4.0",
+  "name": "traefik",
+  "version": "1.1.1-1.6.5",
+  "minDcosReleaseVersion": "1.9",
+  "scm": "https://github.com/containous/traefik",
+  "description": "Traefik is a modern HTTP reverse proxy and load balancer written in go. It supports several backends (Docker, Swarm mode, Kubernetes, Marathon, Consul, Etcd, Rancher, Amazon ECS, and a lot more) to manage its configuration automatically and dynamically. \n\nSee https://docs.traefik.io for more information.",
+  "maintainer": "https://github.com/deric/dcos-traefik",
+  "tags": ["loadbalancer", "service-discovery", "reverse-proxy", "proxy", "traffic", "ingress"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production!\n\n",
+  "postInstallNotes": "Traefik DC/OS Service has been successfully installed!\nSee https://docs.traefik.io for documentation.",
+  "postUninstallNotes": "Traefik DC/OS Service has been uninstalled and will no longer run.",
+  "licenses": [
+    {
+      "name": "MIT",
+      "url": "https://github.com/containous/traefik/blob/master/LICENSE.md"
+    }
+  ]
+}

--- a/repo/packages/T/traefik/3/resource.json
+++ b/repo/packages/T/traefik/3/resource.json
@@ -1,0 +1,14 @@
+{
+  "assets": {
+    "uris": {
+      "traefik-bin": "https://github.com/containous/traefik/releases/download/v1.6.5/traefik_linux-amd64",
+      "confd-bin": "https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64",
+      "bootstrap": "https://github.com/deric/dcos-traefik/archive/v1.1.1.tar.gz"
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/traefik-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/traefik-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/traefik-icon-large.png"
+  }
+}


### PR DESCRIPTION
* Updated Traefik
* Fixed passing `stateTimeoutSecond` for Mesos backend (deric/dcos-traefik#1)
```
diff --git a/repo/packages/T/traefik/2/marathon.json.mustache b/repo/packages/T/traefik/3/marathon.json.mustache
index 8e1d828a..b65e2c28 100644
--- a/repo/packages/T/traefik/2/marathon.json.mustache
+++ b/repo/packages/T/traefik/3/marathon.json.mustache
@@ -5,7 +5,7 @@
   "mem": {{service.mem}},
   "disk": {{service.disk}},
   "user": "{{service.user}}",
-  "cmd": "mv dcos-traefik-1.1.0/* $(pwd)/ && bash bootstrap.sh && ./traefik_linux-amd64 -c traefik.toml",
+  "cmd": "mv dcos-traefik-1.1.1/* $(pwd)/ && bash bootstrap.sh && ./traefik_linux-amd64 -c traefik.toml",
   "uris": [
     "{{resource.assets.uris.traefik-bin}}",
     "{{resource.assets.uris.confd-bin}}",
diff --git a/repo/packages/T/traefik/2/package.json b/repo/packages/T/traefik/3/package.json
index 6a2e48bf..a747d3db 100644
--- a/repo/packages/T/traefik/2/package.json
+++ b/repo/packages/T/traefik/3/package.json
@@ -1,7 +1,7 @@
 {
   "packagingVersion": "4.0",
   "name": "traefik",
-  "version": "1.1.0-1.6.2",
+  "version": "1.1.1-1.6.5",
   "minDcosReleaseVersion": "1.9",
   "scm": "https://github.com/containous/traefik",
   "description": "Traefik is a modern HTTP reverse proxy and load balancer written in go. It supports several backends (Docker, Swarm mode, Kubernetes, Marathon, Consul, Etcd, Rancher, Amazon ECS, and a lot more) to manage its configuration automatically and dynamically. \n\nSee https://docs.traefik.io for more information.",
diff --git a/repo/packages/T/traefik/2/resource.json b/repo/packages/T/traefik/3/resource.json
index 79008cdb..df81cbdb 100644
--- a/repo/packages/T/traefik/2/resource.json
+++ b/repo/packages/T/traefik/3/resource.json
@@ -1,9 +1,9 @@
 {
   "assets": {
     "uris": {
-      "traefik-bin": "https://github.com/containous/traefik/releases/download/v1.6.2/traefik_linux-amd64",
+      "traefik-bin": "https://github.com/containous/traefik/releases/download/v1.6.5/traefik_linux-amd64",
       "confd-bin": "https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64",
-      "bootstrap": "https://github.com/deric/dcos-traefik/archive/v1.1.0.tar.gz"
+      "bootstrap": "https://github.com/deric/dcos-traefik/archive/v1.1.1.tar.gz"
     }
   },
   "images": {
```