### PR TITLE
Release percona-pxc-mysql 0.1.0-5.7.21-29.26 (automated commit)



### DIFF
--- a/repo/packages/P/percona-pxc-mysql/0/config.json
+++ b/repo/packages/P/percona-pxc-mysql/0/config.json
@@ -1,0 +1,207 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "percona-pxc-mysql",
+          "title": "Service name"
+        },
+        "cluster_name": {
+          "description": "Specifies the name of the cluster and should be identical on all nodes.",
+          "type": "string",
+          "default": "cluster1"
+        },
+        "mysql_root_password": {
+          "description": "Specifies the password for mysql cluster",
+          "type": "string",
+          "default": "root"
+        },
+        "user": {
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root",
+          "title": "User"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": "",
+          "title": "Credential secret name (optional)"
+        },
+        "ssl_enabled": {
+          "description": "Enables SSL support for Percona XtraDB Cluster",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "enum": [
+            "V0",
+            "V1"
+          ],
+          "default": "V1"
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        }
+      },
+      "required": [
+        "name",
+        "user"
+      ]
+    },
+    "pxc": {
+      "description": "Template pod configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of Template pods to run",
+          "type": "integer",
+          "default": 3
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Placement constraints for nodes. Example: [[\"hostname\", \"UNIQUE\"]]",
+          "type": "string",
+          "default": "[[\"hostname\", \"UNIQUE\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Template pod CPU requirements",
+          "type": "number",
+          "default": 0.1
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Template pod mem requirements (in MB)",
+          "type": "integer",
+          "default": 252
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Template pod persistent disk requirements (in MB)",
+          "type": "integer",
+          "default": 25
+        },
+        "disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "port": {
+          "description": "Port for broker to listen on",
+          "type": "integer",
+          "default": 3306
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "disk_type"
+      ]
+    },
+    "proxysql": {
+      "description": "Template pod configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Proxysql Node count",
+          "description": "Number of Template pods to run",
+          "type": "integer",
+          "default": 1
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Placement constraints for nodes. Example: [[\"hostname\", \"UNIQUE\"]]",
+          "type": "string",
+          "default": "[[\"hostname\", \"UNIQUE\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Template pod CPU requirements",
+          "type": "number",
+          "default": 0.1
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Template pod mem requirements (in MB)",
+          "type": "integer",
+          "default": 252
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Template pod persistent disk requirements (in MB)",
+          "type": "integer",
+          "default": 25
+        },
+        "disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "disk_type"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/percona-pxc-mysql/0/marathon.json.mustache
+++ b/repo/packages/P/percona-pxc-mysql/0/marathon.json.mustache
@@ -1,0 +1,114 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "user": "{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./percona-pxc-mysql-scheduler/bin/percona-pxc-mysql ./percona-pxc-mysql-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "PACKAGE_NAME": "percona-pxc-mysql",
+    "PACKAGE_VERSION": "0.1.0-5.7.21-29.26",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1532963653379",
+    "PACKAGE_BUILD_TIME_STR": "Mon Jul 30 2018 15:14:13 +0000",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    
+    "CLUSTER_NAME": "{{service.cluster_name}}",
+    "MYSQL_ROOT_PASSWORD": "{{service.mysql_root_password}}",
+
+    "PXC_COUNT": "{{pxc.count}}",
+    "PXC_PLACEMENT": "{{{pxc.placement_constraint}}}",
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+    "PXC_CPUS": "{{pxc.cpus}}",
+    "PXC_MEM": "{{pxc.mem}}",
+    "PXC_DISK": "{{pxc.disk}}",
+    "PXC_DISK_TYPE": "{{pxc.disk_type}}",
+    "PXC_PORT": "{{pxc.port}}",
+
+    "PROXYSQL_COUNT": "{{proxysql.count}}",
+    "PROXYSQL_PLACEMENT": "{{{proxysql.placement_constraint}}}",
+    "PROXYSQL_CPUS": "{{proxysql.cpus}}",
+    "PROXYSQL_MEM": "{{proxysql.mem}}",
+    "PROXYSQL_DISK": "{{proxysql.disk}}",
+    "PROXYSQL_DISK_TYPE": "{{proxysql.disk_type}}",
+
+    {{#service.ssl_enabled}}
+    "PXC_NET_SSL_ENABLED": "{{service.ssl_enabled}}",
+    {{/service.ssl_enabled}}
+
+    "PXC_DOCKER_IMAGE": "{{resource.assets.container.docker.percona-xtradb-cluster}}",
+    "PROXYSQL_DOCKER_IMAGE": "{{resource.assets.container.docker.proxysql}}",
+    "MYSQL_DOCKER_IMAGE": "{{resource.assets.container.docker.mysqlcli}}",
+
+    "ZK_SERVER": "zookeeper-0-server.kafka-zookeeper.autoip.dcos.thisdcos.directory:1140,zookeeper-1-server.kafka-zookeeper.autoip.dcos.thisdcos.directory:1140,zookeeper-2-server.kafka-zookeeper.autoip.dcos.thisdcos.directory:1140",
+    "SYNC_STATE": "Not-Synced",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "PIP_URI": "{{resource.assets.uris.pip-uri}}",
+    "ZK_URI": "{{resource.assets.uris.zk-uri}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.service_account_secret}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+ 
+  },
+  "uris": [
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "{{resource.assets.uris.pip-uri}}",
+    "{{resource.assets.uris.zk-uri}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/percona-pxc-mysql/0/package.json
+++ b/repo/packages/P/percona-pxc-mysql/0/package.json
@@ -1,0 +1,23 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "*"
+  ],
+  "downgradesTo": [
+    "*"
+  ],
+  "minDcosReleaseVersion": "1.9",
+  "name": "percona-pxc-mysql",
+  "version": "0.1.0-5.7.21-29.26",
+  "maintainer": "https://dcos.io/community",
+  "description": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production!",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "pxc",
+    "percona-pxc-mysql"
+  ],
+  "preInstallNotes": "Default configuration requires 3 agent nodes each with: 0.1 CPU | 252 MB MEM | 1 25 MB Disk.",
+  "postInstallNotes": "DC/OS Percona XtraDB CLuster is being installed!\n\n\tDocumentation: https://github.com/dcos/examples\n\tIssues: https://dcos.io/community",
+  "postUninstallNotes": "DC/OS Percona XtraDB CLuster is being uninstalled."
+}

--- a/repo/packages/P/percona-pxc-mysql/0/resource.json
+++ b/repo/packages/P/percona-pxc-mysql/0/resource.json
@@ -1,0 +1,65 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz",
+      "bootstrap-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip",
+      "scheduler-zip": "https://pxc-bucket.s3.amazonaws.com/pxc/assets/0.1.0-5.7.21-29.26/percona-pxc-mysql-scheduler.zip",
+      "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip",
+      "pip-uri": "https://bootstrap.pypa.io/get-pip.py",
+      "zk-uri": "https://s3-ap-northeast-1.amazonaws.com/pxc-utils/zookeepercli-linux-amd64-binary.tar.gz"
+    },
+    "container": {
+      "docker": {
+        "percona-xtradb-cluster": "percona/percona-xtradb-cluster:5.7.21",
+        "proxysql": "percona/proxysql:1.4.9",
+        "mysqlcli": "mysql:5.7"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3.amazonaws.com/pxc-icons/pxc-icon-small.png",
+    "icon-medium": "https://s3.amazonaws.com/pxc-icons/pxc-icon-medium.png",
+    "icon-large": "https://s3.amazonaws.com/pxc-icons/pxc-icon-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "c459d2109b31fc0b423f8cacd49df855ef898e63609f7050957f4a0e044d5432"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "e580ee8b71c0c26b1a1a605ca09cbd3528a2c031a8de11519024ccbbce862339"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "9135f9456a40cd53e27e73e44fc94c1d4cbf27d9b59f2b47d82bad3ae0f8c714"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release percona-pxc-mysql 0.1.0-5.7.21-29.26 (automated commit)

Description:
dc/os percona-pxc-mysql alpha release 0.1.0

Source URL: https://pxc-bucket.s3.amazonaws.com/autodelete7d/percona-pxc-mysql/20180730-151412-yYMt6IvFwvLc5NCq/stub-universe-percona-pxc-mysql.json

Changes between revisions -1 => 0:
4 files added: [config.json, resource.json, package.json, marathon.json.mustache]
0 files removed: []
0 files changed:

```
```
