### PR TITLE
Release percona-mongo 0.3.0-3.6.5 (automated commit)



### DIFF
--- a/repo/packages/P/percona-mongo/100/config.json
+++ b/repo/packages/P/percona-mongo/100/config.json
@@ -1,0 +1,1123 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "title": "Service name",
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "percona-mongo"
+        },
+        "sleep": {
+          "description": "The sleep duration in seconds before tasks exit.",
+          "type": "integer",
+          "default": 1000
+        },
+        "user": {
+          "title": "User",
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root"
+        },
+        "principal": {
+          "title": "Custom principal (optional)",
+          "description": "The principal for the service instance, or empty to use the default.",
+          "type": "string",
+          "default": ""
+        },
+        "virtual_networks": {
+          "description": "Enable DC/OS Virtual Networking",
+          "type": "boolean",
+          "default": false
+        },
+        "secret_name": {
+          "title": "Credential secret name (optional)",
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": ""
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        },
+        "mesos_api_version": {
+          "description": "The Mesos API version to be used by the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "V0",
+            "V1"
+          ],
+          "default": "V1"
+        }
+      },
+      "required": [
+        "name",
+        "sleep",
+        "user",
+        "mesos_api_version"
+      ]
+    },
+    "mongodb": {
+      "description": "MongoDB server node configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "MongoDB server node cpu requirements. Example: 1 equals one CPU, 0.1 equals 10% of one CPU, etc",
+          "type": "number",
+          "default": 1,
+          "minimum": 0.1
+        },
+        "mem": {
+          "description": "MongoDB server node mem requirements, in megabytes",
+          "type": "integer",
+          "default": 1024,
+          "minimum": 1024
+        },
+        "disk": {
+          "description": "MongoDB server node disk requirements, in megabytes",
+          "type": "integer",
+          "default": 1000,
+          "minimum": 1
+        },
+        "diskType": {
+          "description": "MongoDB server node disk type, see DCOS documentation regarding Disk Resources for more info",
+          "type": "string",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "count": {
+          "description": "Number of MongoDB replica set members/nodes to run. 1, 3, 5 or 7 node count is possible",
+          "type": "integer",
+          "enum": [
+            1,
+            3,
+            5,
+            7
+          ],
+          "default": 3
+        },
+        "replicaSetName": {
+          "title": "replication.replicaSetName",
+          "description": "Name of the MongoDB ReplicaSet",
+          "type": "string",
+          "default": "rs"
+        },
+        "port": {
+          "description": "MongoDB server listening port. Must be a number between 1024 and 65535",
+          "type": "integer",
+          "default": 27017,
+          "minimum": 1025,
+          "maximum": 65535
+        },
+        "storageEngine": {
+          "title": "storage.engine",
+          "description": "Percona MongoDB storage engine (options: wiredTiger, mmapv1 or inMemory)",
+          "type": "string",
+          "enum": [
+            "wiredTiger",
+            "mmapv1",
+            "inMemory"
+          ],
+          "default": "wiredTiger"
+        },
+        "placement": {
+          "title": "MongoDB Node Placement",
+          "description": "MongoDB Node Placement configuration properties. By default all data-bearing MongoDB tasks run on unique DC/OS agent hosts for high-availability",
+          "type": "object",
+          "properties": {
+            "constraint": {
+              "description": "Marathon-style constraint for MongoDB server nodes (use empty string to override the default hostname UNIQUE behavior)",
+              "type": "string",
+              "default": "[[\"hostname\", \"UNIQUE\"]]",
+              "media": {
+                "type": "application/x-zone-constraints+json"
+              }
+            }
+          },
+          "required": [
+            "constraint"
+          ]
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "count",
+        "replicaSetName",
+        "port",
+        "placement",
+        "storageEngine"
+      ]
+    },
+    "mongodb-credentials": {
+      "title": "MongoDB Credentials",
+      "description": "MongoDB System Users and Key configuration properties. Note: for security, system passwords must be 10-characters or longer. The 'key' should be generated using the command 'openssl rand -base64 756'.",
+      "type": "object",
+      "properties": {
+        "backupUser": {
+          "description": "MongoDB backup user name",
+          "type": "string",
+          "default": "backup"
+        },
+        "backupPassword": {
+          "description": "MongoDB backup password, must be 10 characters or longer",
+          "type": "string",
+          "default": ""
+        },
+        "userAdminUser": {
+          "description": "MongoDB userAdmin user name",
+          "type": "string",
+          "default": "useradmin"
+        },
+        "userAdminPassword": {
+          "description": "MongoDB userAdmin password, must be 10 characters or longer",
+          "type": "string",
+          "default": ""
+        },
+        "clusterAdminUser": {
+          "description": "MongoDB clusterAdmin user name",
+          "type": "string",
+          "default": "clusteradmin"
+        },
+        "clusterAdminPassword": {
+          "description": "MongoDB clusterAdmin password, must be 10 characters or longer",
+          "type": "string",
+          "default": ""
+        },
+        "clusterMonitorUser": {
+          "description": "MongoDB clusterMonitor user name",
+          "type": "string",
+          "default": "clustermonitor"
+        },
+        "clusterMonitorPassword": {
+          "description": "MongoDB clusterMonitor password, must be 10 characters or longer",
+          "type": "string",
+          "default": ""
+        },
+        "key": {
+          "description": "The key to be used for intra-node replica set communication. The key must be 1024 characters long. We strongly recommend a new key is generated by running 'openssl rand -base64 756'",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "allOf": [
+        {
+          "properties": {
+            "backupPassword": {
+              "minLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "userAdminPassword": {
+              "minLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "clusterAdminPassword": {
+              "minLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "clusterMonitorPassword": {
+              "minLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "key": {
+              "minLength": 1023,
+              "maxLength": 1024
+            }
+          }
+        },
+        {
+          "required": [
+            "backupUser",
+            "backupPassword",
+            "userAdminUser",
+            "userAdminPassword",
+            "clusterAdminUser",
+            "clusterAdminPassword",
+            "clusterMonitorUser",
+            "clusterMonitorPassword",
+            "key"
+          ]
+        }
+      ]
+    },
+    "mongodb-advanced": {
+      "description": "MongoDB server advanced server configuration properties. Adjust with caution!",
+      "type": "object",
+      "properties": {
+        "container": {
+          "title": "Linux Container",
+          "description": "MongoDB Linux Container configuration properties",
+          "type": "object",
+          "properties": {
+            "openFileLimit": {
+              "title": "Open Files Limit (ulimit)",
+              "description": "Maximum number of open files inside the container ('NOFILE' ulimit setting)",
+              "type": "number",
+              "default": 64000,
+              "minimum": 1024
+            },
+            "processLimit": {
+              "title": "Max Processes Limit (ulimit)",
+              "description": "Maximum number of processes running inside the container ('NPROC' ulimit setting)",
+              "type": "number",
+              "default": 64000,
+              "minimum": 1024
+            }
+          },
+          "required": [
+            "openFileLimit",
+            "processLimit"
+          ]
+        },
+        "security": {
+          "description": "MongoDB security configuration properties",
+          "type": "object",
+          "properties": {
+            "redactClientLogData": {
+              "title": "security.redactClientLogData",
+              "description": "The Percona Log Redaction feature prevents writing of potentially sensitive data stored on the database to the diagnostic log",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "redactClientLogData"
+          ]
+        },
+        "storage": {
+          "description": "MongoDB storage-level configuration properties",
+          "type": "object",
+          "properties": {
+            "indexBuildRetry": {
+              "title": "storage.indexBuildRetry",
+              "description": "Specifies whether mongod rebuilds incomplete indexes on the next start up",
+              "type": "boolean",
+              "default": true
+            },
+            "directoryPerDB": {
+              "title": "storage.directoryPerDB",
+              "description": "When true, MongoDB uses a separate directory to store data for each database",
+              "type": "boolean",
+              "default": false
+            },
+            "syncPeriodSecs": {
+              "title": "storage.syncPeriodSecs",
+              "description": "The amount of time that can pass before MongoDB flushes data to the data files via an fsync operation",
+              "type": "integer",
+              "default": 60,
+              "minimum": 0
+            },
+            "journal": {
+              "title": "Journaling",
+              "description": "MongoDB Storage Journal configuration properties",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "title": "storage.journal.enabled",
+                  "description": "Enable or disable the durability journal to ensure data files remain valid and recoverable",
+                  "type": "boolean",
+                  "default": true
+                },
+                "commitIntervalMs": {
+                  "title": "storage.journal.commitIntervalMs",
+                  "description": "The maximum amount of time in milliseconds that the mongod process allows between journal operations",
+                  "type": "integer",
+                  "default": 100,
+                  "minimum": 1
+                }
+              },
+              "required": [
+                "enabled",
+                "commitIntervalMs"
+              ]
+            },
+            "mmapv1": {
+              "title": "MMAPv1 Storage Engine",
+              "description": "MongoDB MMAPv1 storage-engine configuration properties",
+              "type": "object",
+              "properties": {
+                "preallocDataFiles": {
+                  "title": "storage.mmapv1.preallocDataFiles",
+                  "description": "Enables or disables the preallocation of data files. By default, MongoDB does not preallocate data files",
+                  "type": "boolean",
+                  "default": true
+                },
+                "nsSize": {
+                  "title": "storage.mmapv1.nsSize",
+                  "description": "The default size for namespace files, which are files that end in .ns. Each collection and index counts as a namespace",
+                  "type": "integer",
+                  "default": 16,
+                  "minimum": 1
+                },
+                "quotaEnforced": {
+                  "title": "storage.mmapv1.quota.enforced",
+                  "description": "Enable or disable the enforcement of a maximum limit for the number data files each database can have",
+                  "type": "boolean",
+                  "default": false
+                },
+                "quotaMaxFilesPerDB": {
+                  "title": "storage.mmapv1.quota.maxFilesPerDB",
+                  "description": "The limit on the number of data files per database",
+                  "type": "integer",
+                  "default": 8,
+                  "minimum": 1
+                },
+                "smallFiles": {
+                  "title": "storage.mmapv1.smallFiles",
+                  "description": "When true, MongoDB uses a smaller default file size",
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "required": [
+                "preallocDataFiles",
+                "nsSize",
+                "quotaEnforced",
+                "quotaMaxFilesPerDB",
+                "smallFiles"
+              ]
+            },
+            "wiredTiger": {
+              "title": "WiredTiger Storage Engine",
+              "description": "MongoDB WiredTiger storage-engine configuration properties",
+              "type": "object",
+              "properties": {
+                "engineConfigJournalCompressor": {
+                  "title": "storage.wiredTiger.engineConfig.journalCompressor",
+                  "description": "The type of compression to use to compress WiredTiger journal data. Available compressors are: none, snappy, zlib",
+                  "type": "string",
+                  "enum": [
+                    "snappy",
+                    "none",
+                    "zlib"
+                  ],
+                  "default": "snappy"
+                },
+                "engineConfigDirectoryForIndexes": {
+                  "title": "storage.wiredTiger.engineConfig.directoryForIndexes",
+                  "description": "When true, mongod stores indexes and collections in separate subdirectories under the data (i.e. storage.dbPath) directory",
+                  "type": "boolean",
+                  "default": false
+                },
+                "collectionConfigBlockCompressor": {
+                  "title": "storage.wiredTiger.collectionConfig.blockCompressor",
+                  "description": "The default type of compression to use to compress collection data. You can override this on a per-collection basis when creating collections. Available compressors are: none, snappy, zlib",
+                  "type": "string",
+                  "enum": [
+                    "snappy",
+                    "none",
+                    "zlib"
+                  ],
+                  "default": "snappy"
+                },
+                "indexConfigPrefixCompression": {
+                  "title": "storage.wiredTiger.indexConfig.prefixCompression",
+                  "description": "Specify true to enable prefix compression for index data, or false to disable prefix compression for index data",
+                  "type": "boolean",
+                  "default": true
+                }
+              },
+              "required": [
+                "engineConfigJournalCompressor",
+                "engineConfigDirectoryForIndexes",
+                "collectionConfigBlockCompressor",
+                "indexConfigPrefixCompression"
+              ]
+            }
+          },
+          "required": [
+            "indexBuildRetry",
+            "directoryPerDB",
+            "syncPeriodSecs",
+            "journal",
+            "mmapv1",
+            "wiredTiger"
+          ]
+        },
+        "setParameter": {
+          "title": "Server Parameters",
+          "description": "MongoDB Server Parameter (setParameter) configuration properties",
+          "type": "object",
+          "properties": {
+            "failIndexKeyTooLong": {
+              "title": "setParameter: failIndexKeyTooLong",
+              "description": "Enable failing of updates and inserts that have indexed values longer than the Index Key Length Limit",
+              "type": "boolean",
+              "default": true
+            },
+            "maxIndexBuildMemoryUsageMB": {
+              "title": "setParameter: maxIndexBuildMemoryUsageMB",
+              "description": "Limits the amount of memory that simultaneous foreground index builds on one collection may consume for the duration of the builds",
+              "type": "integer",
+              "default": 500
+            },
+            "logUserIds": {
+              "title": "setParameter: logUserIds",
+              "description": "Enable logging of user IDs. 1 = true, 0 = false",
+              "enum": [
+                0,
+                1
+              ],
+              "type": "integer",
+              "default": 0
+            },
+            "ttlMonitorEnabled": {
+              "title": "setParameter: ttlMonitorEnabled",
+              "description": "Enable background thread that is responsible for deleting documents from collections with TTL indexes",
+              "type": "boolean",
+              "default": true
+            },
+            "ttlMonitorSleepSecs": {
+              "title": "setParameter: ttlMonitorSleepSecs",
+              "description": "Defines the number of seconds to wait between checking TTL Indexes for old documents and removing them",
+              "type": "integer",
+              "default": 60,
+              "minimum": 1
+            },
+            "wiredTigerConcurrentReadTransactions": {
+              "title": "setParameter: wiredTigerConcurrentReadTransactions",
+              "description": "Maximum number of concurrently running read transactions in the WiredTiger engine",
+              "type": "integer",
+              "default": 128,
+              "minimum": 1
+            },
+            "wiredTigerConcurrentWriteTransactions": {
+              "title": "setParameter: wiredTigerConcurrentWriteTransactions",
+              "description": "Maximum number of concurrently running write transactions in the WiredTiger engine",
+              "type": "integer",
+              "default": 128,
+              "minimum": 1
+            }
+          },
+          "required": [
+            "failIndexKeyTooLong",
+            "maxIndexBuildMemoryUsageMB",
+            "logUserIds",
+            "ttlMonitorEnabled",
+            "ttlMonitorSleepSecs",
+            "wiredTigerConcurrentReadTransactions",
+            "wiredTigerConcurrentWriteTransactions"
+          ]
+        },
+        "net": {
+          "title": "Network",
+          "description": "MongoDB Network configuration properties",
+          "type": "object",
+          "properties": {
+            "maxIncomingConnections": {
+              "title": "net.maxIncomingConnections",
+              "description": "Specify the maximum number of incoming connections",
+              "type": "number",
+              "default": 51200,
+              "minimum": 1
+            },
+            "transportLayer": {
+              "title": "net.transportLayer",
+              "description": "The networking implementation the mongos or mongod uses. To revert to the pre-version 3.6 implementation, change this option to 'legacy'",
+              "type": "string",
+              "enum": [
+                "asio",
+                "legacy"
+              ],
+              "default": "asio"
+            },
+            "serviceExecutor": {
+              "title": "net.serviceExecutor",
+              "description": "Determines the threading and execution model mongos or mongod uses to execute client requests.",
+              "type": "string",
+              "enum": [
+                "synchronous",
+                "adaptive"
+              ],
+              "default": "synchronous"
+            }
+          },
+          "required": [
+            "maxIncomingConnections",
+            "transportLayer",
+            "serviceExecutor"
+          ]
+        },
+        "operationProfiling": {
+          "title": "Operation Profiling",
+          "description": "MongoDB Operation Profiling configuration properties",
+          "type": "object",
+          "properties": {
+            "mode": {
+              "title": "operationProfiling.mode",
+              "description": "Percona MongoDB operation profiling mode (options: slowOp, all or off)",
+              "type": "string",
+              "enum": [
+                "slowOp",
+                "off",
+                "all"
+              ],
+              "default": "slowOp"
+            },
+            "slowOpThresholdMs": {
+              "title": "operationProfiling.slowOpThresholdMs",
+              "description": "Percona MongoDB operation profiling slowOp mode threshold in milliseconds",
+              "type": "integer",
+              "default": 100,
+              "minimum": 1
+            },
+            "rateLimit": {
+              "title": "operationProfiling.rateLimit",
+              "description": "Percona MongoDB operation profiling rate limiting value",
+              "type": "integer",
+              "default": 1
+            }
+          },
+          "required": [
+            "mode",
+            "slowOpThresholdMs",
+            "rateLimit"
+          ]
+        },
+        "replication": {
+          "description": "MongoDB Replication configuration properties",
+          "type": "object",
+          "properties": {
+            "secondaryIndexPrefetch": {
+              "title": "replication.secondaryIndexPrefetch",
+              "description": "The indexes that secondary members of a replica set load into memory before applying operations from the oplog",
+              "type": "string",
+              "enum": [
+                "none",
+                "_id_only",
+                "all"
+              ],
+              "default": "all"
+            }
+          },
+          "required": [
+            "secondaryIndexPrefetch"
+          ]
+        },
+        "auditLog": {
+          "title": "Percona AuditLog",
+          "description": "Percona Server for MongoDB AuditLog configuration properties. The audit log is written to the file 'auditLog.bson' in the MongoDB data path",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable PSMDB Audit Log",
+              "description": "Enables the Percona Server for MongoDB audit log feature",
+              "type": "boolean",
+              "default": false
+            },
+            "filter": {
+              "title": "auditLog.filter",
+              "description": "The filter document (in json style) to be used for filtering the Percona Server for MongoDB audit log",
+              "type": "string",
+              "default": "{}"
+            },
+            "auditAuthorizationSuccess": {
+              "title": "setParameter: auditAuthorizationSuccess",
+              "description": "Enables the logging of all read and write operations",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "enabled",
+            "filter",
+            "auditAuthorizationSuccess"
+          ]
+        },
+        "systemLog": {
+          "title": "System Log",
+          "description": "MongoDB System Log configuration properties",
+          "type": "object",
+          "properties": {
+            "verbosity": {
+              "title": "systemLog.verbosity",
+              "description": "The default log message verbosity level for components. The verbosity level determines the amount of Informational and Debug messages MongoDB outputs. The verbosity level can range from 0 to 5",
+              "type": "integer",
+              "enum": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5
+              ],
+              "default": 0
+            },
+            "traceAllExceptions": {
+              "title": "systemLog.traceAllExceptions",
+              "description": "Print verbose information for debugging. Use for additional logging for support-related troubleshooting",
+              "type": "boolean",
+              "default": false
+            },
+            "timestampFormat": {
+              "title": "systemLog.timestampFormat",
+              "description": "The time format for timestamps in log messages. Specify one of the following values: ctime, iso8601-utc, iso8601-local",
+              "type": "string",
+              "enum": [
+                "iso8601-local",
+                "ctime",
+                "iso8601-utc"
+              ],
+              "default": "iso8601-local"
+            }
+          },
+          "required": [
+            "verbosity",
+            "traceAllExceptions",
+            "timestampFormat"
+          ]
+        }
+      },
+      "required": [
+        "container",
+        "security",
+        "net",
+        "storage",
+        "setParameter",
+        "operationProfiling",
+        "replication",
+        "auditLog",
+        "systemLog"
+      ]
+    },
+    "mongodb-ssl": {
+      "title": "MongoDB SSL",
+      "description": "MongoDB SSL configuration properties. This section requires DC/OS Enterprise Edition!",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable MongoDB SSL Support",
+          "description": "Enables SSL support for Percona Server for MongoDB server",
+          "type": "boolean",
+          "default": false
+        },
+        "mode": {
+          "title": "MongoDB SSL Mode",
+          "description": "MongoDB SSL mode. See documentation for net.ssl.mode for more information",
+          "type": "string",
+          "enum": [
+            "allowSSL",
+            "preferSSL",
+            "requireSSL"
+          ],
+          "default": "preferSSL"
+        },
+        "name": {
+          "title": "DC/OS SSL Name",
+          "description": "Name of the SSL certificates that are auto-generated by DC/OS. Leave empty to auto-generate as 'SERVICENAME-REPLSETNAME'",
+          "type": "string",
+          "default": ""
+        },
+        "allowConnectionsWithoutCertificates": {
+          "title": "net.ssl.allowConnectionsWithoutCertificates",
+          "description": "Allow MongoDB to accept connections when the client does not present a certificate when establishing the connection",
+          "type": "boolean",
+          "default": false
+        },
+        "allowInvalidCertificates": {
+          "title": "net.ssl.allowInvalidCertificates",
+          "description": "Disable the validation checks for TLS/SSL certificates on other servers in the cluster and allow invalid certificates",
+          "type": "boolean",
+          "default": false
+        },
+        "allowInvalidHostnames": {
+          "title": "net.ssl.allowInvalidHostnames",
+          "description": "Disable the validation of the hostnames in TLS/SSL certificates, allowing mongod to connect to MongoDB instances if the hostname their certificates do not match the specified hostname",
+          "type": "boolean",
+          "default": false
+        },
+        "disabledProtocols": {
+          "title": "net.ssl.disabledProtocols",
+          "description": "Prevents server from accepting incoming connections that use a specific protocol or protocols. net.ssl.disabledProtocols recognizes the following protocols: TLS1_0, TLS1_1, and TLS1_2. Specifying an unrecognized protocol will prevent the server from starting. To specify multiple protocols, use a comma separated list of protocols",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "required": [
+        "enabled",
+        "mode",
+        "allowConnectionsWithoutCertificates",
+        "allowInvalidCertificates",
+        "allowInvalidHostnames"
+      ]
+    },
+    "backup-restore": {
+      "description": "Backup and Restore configuration properties. Only mongodump-based backup and AWS S3 (for backup storage) is supported currently",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "title": "Backup/restore node cpus",
+          "description": "Node cpu requirements for backup and restore process",
+          "type": "number",
+          "default": 2.0
+        },
+        "mem": {
+          "title": "Backup/restore node mem",
+          "description": "Node mem requirements for backup and restore process, in megabytes",
+          "type": "integer",
+          "default": 1024
+        },
+        "s3": {
+          "title": "AWS S3 configuration",
+          "description": "Backup and Restore Amazon Web Services S3 configuration properties",
+          "type": "object",
+          "properties": {
+            "region": {
+              "title": "region",
+              "description": "Backup and restore s3 region for upload",
+              "type": "string",
+              "default": "us-east-1",
+              "enum": [
+                "ap-northeast-1",
+                "ap-northeast-2",
+                "ap-northeast-3",
+                "ap-south-1",
+                "ap-southeast-1",
+                "ap-southeast-2",
+                "ca-central-1",
+                "cn-north-1",
+                "cn-northwest-1",
+                "eu-central-1",
+                "eu-west-1",
+                "eu-west-2",
+                "eu-west-3",
+                "sa-east-1",
+                "us-east-1",
+                "us-east-2",
+                "us-west-1",
+                "us-west-2"
+              ]
+            },
+            "accessKey": {
+              "title": "access_key",
+              "description": "Backup and restore s3 access key",
+              "type": "string",
+              "default": ""
+            },
+            "secretKey": {
+              "title": "secret_key",
+              "description": "Backup and restore s3 secret key",
+              "type": "string",
+              "default": ""
+            }
+          },
+          "allOf": [
+            {
+              "properties": {
+                "accessKey": {
+                  "maxLength": 20
+                }
+              }
+            },
+            {
+              "properties": {
+                "secretKey": {
+                  "maxLength": 40
+                }
+              }
+            },
+            {
+              "required": [
+                "region"
+              ]
+            }
+          ]
+        },
+        "restore": {
+          "title": "Restore",
+          "description": "Restore configuration properties",
+          "type": "object",
+          "properties": {
+            "s3Url": {
+              "description": "AWS S3 URL to mongodump backup directory in 's3://<bucket-name>/<path>/' format. A URL for the backup is required for restore!",
+              "type": "string",
+              "default": ""
+            },
+            "restoreAfterInit": {
+              "description": "Restore replica set from backup after initiation",
+              "type": "boolean",
+              "default": false
+            },
+            "gzip": {
+              "description": "Enable gzip on restore. Backup data must be gzip compressed",
+              "type": "boolean",
+              "default": true
+            },
+            "dropCollections": {
+              "description": "Drop collections during restore. This is usually required to avoid duplicate key errors on restore",
+              "type": "boolean",
+              "default": true
+            },
+            "oplogReplay": {
+              "description": "Replay the backup oplog after restoring the collections, strongly recommended!",
+              "type": "boolean",
+              "default": true
+            },
+            "numParallelCollections": {
+              "description": "Number of collections to restore in parallel",
+              "type": "integer",
+              "default": 4
+            }
+          },
+          "allOf": [
+            {
+              "not": {
+                "properties": {
+                  "s3Url": {
+                    "enum": [
+                      ""
+                    ]
+                  },
+                  "restoreAfterInit": {
+                    "enum": [
+                      true
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "required": [
+                "restoreAfterInit",
+                "gzip",
+                "dropCollections",
+                "oplogReplay",
+                "numParallelCollections"
+              ]
+            }
+          ]
+        },
+        "backup": {
+          "title": "Backup",
+          "description": "Backup configuration properties",
+          "type": "object",
+          "properties": {
+            "upload": {
+              "description": "Backup upload configuration properties",
+              "type": "object",
+              "properties": {
+                "s3bucketName": {
+                  "title": "bucket_name",
+                  "description": "Backup upload s3 bucket name",
+                  "type": "string",
+                  "default": ""
+                },
+                "s3bucketPrefix": {
+                  "title": "bucket_prefix",
+                  "description": "Backup upload s3 bucket key prefix",
+                  "type": "string",
+                  "default": "/"
+                },
+                "threads": {
+                  "title": "upload.threads",
+                  "description": "Upload thread count",
+                  "type": "integer",
+                  "default": 4
+                },
+                "retries": {
+                  "title": "upload.retries",
+                  "description": "Upload chunk retry count",
+                  "type": "integer",
+                  "default": 5
+                },
+                "s3chunkSizeMb": {
+                  "title": "chunk_size_mb",
+                  "description": "Backup and restore s3 chunk size in megabytes",
+                  "type": "integer",
+                  "default": 50,
+                  "minimum": 1
+                }
+              },
+              "required": [
+                "s3bucketPrefix",
+                "threads",
+                "retries",
+                "s3chunkSizeMb"
+              ]
+            },
+            "verbose": {
+              "description": "Enable verbose logging of backup",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "upload",
+            "verbose"
+          ]
+        },
+        "hiddenSecondary": {
+          "title": "Backup Hidden Secondary Node",
+          "description": "MongoDB Hidden-secondary backup node configuration properties. A Hidden-secondary node is recommended for low impact backups as it does not receive application traffic and cannot win a failover-election",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Add dedicated MongoDB backup node",
+              "description": "Add a hidden-secondary MongoDB node dedicated to backup operations. This node cannot become primary and is invible to MongoDB drivers. The node will inherit any config options passed to the other mongod nodes",
+              "type": "boolean",
+              "default": false
+            },
+            "cpus": {
+              "title": "Dedicated MongoDB backup node cpus",
+              "description": "MongoDB backup hidden-secondary node cpu requirements",
+              "type": "number",
+              "default": 1.0
+            },
+            "mem": {
+              "title": "Dedicated MongoDB backup node mem",
+              "description": "MongoDB backup hidden-secondary node mem requirements, in megabytes",
+              "type": "integer",
+              "default": 1024
+            }
+          },
+          "required": [
+            "enabled",
+            "cpus",
+            "mem"
+          ]
+        }
+      }
+    },
+    "dcos-metrics": {
+      "description": "DC/OS Metrics configuration properties",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable DC/OS Metrics",
+          "description": "Enable the sending of MongoDB metrics to DC/OS Metrics",
+          "type": "boolean",
+          "default": false
+        },
+        "intervalSecs": {
+          "title": "Metrics Collect Interval",
+          "description": "The frequency to collect MongoDB metrics, in seconds",
+          "type": "integer",
+          "default": 10,
+          "minimum": 1
+        }
+      },
+      "required": [
+        "enabled",
+        "intervalSecs"
+      ]
+    },
+    "admin": {
+      "description": "Admin task configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "Admin node cpu requirements",
+          "type": "number",
+          "default": 0.2
+        },
+        "mem": {
+          "description": "Admin node mem requirements. Must be 64 or greater",
+          "type": "integer",
+          "default": 64,
+          "minimum": 64
+        },
+        "init": {
+          "description": "Init task configuration properties. This task runs once on initiation of a new MongoDB Replica Set",
+          "type": "object",
+          "properties": {
+            "initiateDelay": {
+              "description": "The delay before starting the ReplicaSet initialization, must end in 's' for seconds, 'm' for minutes, etc",
+              "type": "string",
+              "default": "15s"
+            },
+            "maxConnectTries": {
+              "description": "The number of times to try to connect to a database host",
+              "type": "integer",
+              "default": 30,
+              "minimum": 1
+            },
+            "maxInitReplsetTries": {
+              "description": "The number of times to try to initiate the replica set",
+              "type": "integer",
+              "default": 60,
+              "minimum": 1
+            },
+            "maxAddUsersTries": {
+              "description": "The number of times to try to add database users",
+              "type": "integer",
+              "default": 60,
+              "minimum": 1
+            },
+            "retrySleep": {
+              "description": "The duration to wait between retries",
+              "type": "string",
+              "default": "3s"
+            }
+          }
+        },
+        "watchdog": {
+          "description": "Watchdog daemon configuration properties. This daemon watches the DC/OS API for changes and updates the MongoDB Replica Set",
+          "type": "object",
+          "properties": {
+            "apiPoll": {
+              "description": "DCOS API poll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+              "type": "string",
+              "default": "10s"
+            },
+            "apiTimeout": {
+              "description": "Pod API timeout than apiPoll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+              "type": "string",
+              "default": "5s"
+            },
+            "replsetPoll": {
+              "description": "MongoDB replica set state poll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+              "type": "string",
+              "default": "5s"
+            },
+            "replsetTimeout": {
+              "description": "MongoDB replica set timeout, should be less than replsetPoll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+              "type": "string",
+              "default": "3s"
+            },
+            "metricsPort": {
+              "description": "Prometheus Metrics server port, default '0' uses a random available port",
+              "type": "integer",
+              "default": 0,
+              "maximum": 65535
+            }
+          }
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "init"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/percona-mongo/100/marathon.json.mustache
+++ b/repo/packages/P/percona-mongo/100/marathon.json.mustache
@@ -1,0 +1,236 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./mongo-scheduler/bin/dcos-mongo ./mongo-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.secret_name}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.secret_name}}"
+    }
+  },
+  {{/service.secret_name}}
+  "env": {
+    "PACKAGE_NAME": "percona-mongo",
+    "PACKAGE_VERSION": "0.3.0-3.6.5",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1533048791323",
+    "PACKAGE_BUILD_TIME_STR": "Tue Jul 31 2018 14:53:11 +0000",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "SLEEP_DURATION": "{{service.sleep}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    "FRAMEWORK_HOST": "{{service.name}}.autoip.dcos.thisdcos.directory",
+
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "MONGODB_TOOLS_URI": "{{resource.assets.uris.mongodb-tools-zip}}",
+    "MONGODB_TOOLS_ADMIN_URI": "{{resource.assets.uris.mongodb-tools-admin-zip}}",
+    "RESTORE_S3_CLI_URI": "{{resource.assets.uris.s3-cli-tar-gz}}",
+    "RESTORE_SCRIPT_URI": "{{resource.assets.uris.restore-s3-sh}}",
+    "PSMDB_DOCKER_IMAGE": "{{resource.assets.container.docker.percona-server-mongodb}}",
+    "ADMIN_DOCKER_IMAGE": "{{resource.assets.container.docker.admin}}",
+    "MCB_DOCKER_IMAGE": "{{resource.assets.container.docker.mongodb-consistent-backup}}",
+
+    "MONGODB_PORT": "{{mongodb.port}}",
+    "MONGODB_COUNT": "{{mongodb.count}}",
+    "MONGODB_CPUS": "{{mongodb.cpus}}",
+    "MONGODB_MEM": "{{mongodb.mem}}",
+    "MONGODB_DISK_SIZE": "{{mongodb.disk}}",
+    "MONGODB_DISK_TYPE": "{{mongodb.diskType}}",
+    "MONGODB_REPLSET": "{{mongodb.replicaSetName}}",
+    "MONGODB_USER_ADMIN_USER": "{{mongodb-credentials.userAdminUser}}",
+    "MONGODB_USER_ADMIN_PASSWORD": "{{mongodb-credentials.userAdminPassword}}",
+    "MONGODB_CLUSTER_ADMIN_USER": "{{mongodb-credentials.clusterAdminUser}}",
+    "MONGODB_CLUSTER_ADMIN_PASSWORD": "{{mongodb-credentials.clusterAdminPassword}}",
+    "MONGODB_BACKUP_USER": "{{mongodb-credentials.backupUser}}",
+    "MONGODB_BACKUP_PASSWORD": "{{mongodb-credentials.backupPassword}}",
+    "MONGODB_CLUSTER_MONITOR_USER": "{{mongodb-credentials.clusterMonitorUser}}",
+    "MONGODB_CLUSTER_MONITOR_PASSWORD": "{{mongodb-credentials.clusterMonitorPassword}}",
+    "MONGODB_KEY": "{{mongodb-credentials.key}}",
+    {{#mongodb.placement.constraint}}
+        "MONGODB_NODE_PLACEMENT": "{{{mongodb.placement.constraint}}}",
+    {{/mongodb.placement.constraint}}
+
+    "MONGODB_STORAGE_ENGINE": "{{mongodb.storageEngine}}",
+
+    "MONGODB_NOFILE_LIMIT": "{{mongodb-advanced.container.openFileLimit}}",
+    "MONGODB_NPROC_LIMIT": "{{mongodb-advanced.container.processLimit}}",
+
+    "MONGODB_SECURITY_REDACT_CLIENT_LOG_DATA": "{{mongodb-advanced.security.redactClientLogData}}",
+
+    "MONGODB_STORAGE_INDEX_BUILD_RETRY": "{{mongodb-advanced.storage.indexBuildRetry}}",
+    "MONGODB_STORAGE_JOURNAL_ENABLED": "{{mongodb-advanced.storage.journal.enabled}}",
+    "MONGODB_STORAGE_JOURNAL_COMMIT_INTERVAL_MS": "{{mongodb-advanced.storage.journal.commitIntervalMs}}",
+    "MONGODB_STORAGE_DIRECTORY_PER_DB": "{{mongodb-advanced.storage.directoryPerDB}}",
+    "MONGODB_STORAGE_SYNC_PERIOD_SECS": "{{mongodb-advanced.storage.syncPeriodSecs}}",
+
+    "MONGODB_STORAGE_MMAPV1_PREALLOC_DATA_FILES": "{{mongodb-advanced.storage.mmapv1.preallocDataFiles}}",
+    "MONGODB_STORAGE_MMAPV1_NS_SIZE": "{{mongodb-advanced.storage.mmapv1.nsSize}}",
+    "MONGODB_STORAGE_MMAPV1_QUOTA_ENFORCED": "{{mongodb-advanced.storage.mmapv1.quotaEnforced}}",
+    "MONGODB_STORAGE_MMAPV1_MAX_FILES_PER_DB": "{{mongodb-advanced.storage.mmapv1.quotaMaxFilesPerDB}}",
+    "MONGODB_STORAGE_MMAPV1_SMALLFILES": "{{mongodb-advanced.storage.mmapv1.smallFiles}}",
+
+    "MONGODB_STORAGE_WIREDTIGER_ENGINE_CONFIG_JOURNAL_COMPRESSOR": "{{mongodb-advanced.storage.wiredTiger.engineConfigJournalCompressor}}",
+    "MONGODB_STORAGE_WIREDTIGER_ENGINE_CONFIG_DIRECTORY_FOR_INDEXES": "{{mongodb-advanced.storage.wiredTiger.engineConfigDirectoryForIndexes}}",
+    "MONGODB_STORAGE_WIREDTIGER_COLLECTION_CONFIG_BLOCK_COMPRESSOR": "{{mongodb-advanced.storage.wiredTiger.collectionConfigBlockCompressor}}",
+    "MONGODB_STORAGE_WIREDTIGER_INDEX_CONFIG_PREFIX_COMPRESSION": "{{mongodb-advanced.storage.wiredTiger.indexConfigPrefixCompression}}",
+
+    "MONGODB_SET_PARAMETER_AUDIT_AUTHORIZATION_SUCCESS": "{{mongodb-advanced.auditLog.auditAuthorizationSuccess}}",
+    "MONGODB_SET_PARAMETER_FAIL_INDEX_KEY_TOO_LONG": "{{mongodb-advanced.setParameter.failIndexKeyTooLong}}",
+    "MONGODB_SET_PARAMETER_MAX_INDEX_BUILD_MEMORY_USAGE_MB": "{{mongodb-advanced.setParameter.maxIndexBuildMemoryUsageMB}}",
+    "MONGODB_SET_PARAMETER_LOG_USER_IDS": "{{mongodb-advanced.setParameter.logUserIds}}",
+    "MONGODB_SET_PARAMETER_TTL_MONITOR_ENABLED": "{{mongodb-advanced.setParameter.ttlMonitorEnabled}}",
+    "MONGODB_SET_PARAMETER_TTL_MONITOR_SLEEP_SECS": "{{mongodb-advanced.setParameter.ttlMonitorSleepSecs}}",
+    "MONGODB_SET_PARAMETER_WIREDTIGER_CONCURRENT_READ_TRANSACTIONS": "{{mongodb-advanced.setParameter.wiredTigerConcurrentReadTransactions}}",
+    "MONGODB_SET_PARAMETER_WIREDTIGER_CONCURRENT_WRITE_TRANSACTIONS": "{{mongodb-advanced.setParameter.wiredTigerConcurrentWriteTransactions}}",
+
+    "MONGODB_NET_MAX_INCOMING_CONNECTIONS": "{{mongodb-advanced.net.maxIncomingConnections}}",
+    "MONGODB_NET_TRANSPORT_LAYER": "{{mongodb-advanced.net.transportLayer}}",
+    "MONGODB_NET_SERVICE_EXECUTOR": "{{mongodb-advanced.net.serviceExecutor}}",
+
+    {{#mongodb-ssl.enabled}}
+    "MONGODB_NET_SSL_ENABLED": "{{mongodb-ssl.enabled}}",
+    {{#mongodb-ssl.name}}
+    "MONGODB_SSL_NAME": "{{mongodb-ssl.name}}",
+    "MONGODB_NET_SSL_PEM_KEY_FILE": "{{mongodb-ssl.name}}.pem",
+    "MONGODB_NET_SSL_CA_FILE": "{{mongodb-ssl.name}}.ca",
+    {{/mongodb-ssl.name}}
+    {{^mongodb-ssl.name}}
+    "MONGODB_SSL_NAME": "mongodb_{{service.name}}_{{mongodb.replicaSetName}}",
+    "MONGODB_NET_SSL_PEM_KEY_FILE": "mongodb_{{service.name}}_{{mongodb.replicaSetName}}.pem",
+    "MONGODB_NET_SSL_CA_FILE": "mongodb_{{service.name}}_{{mongodb.replicaSetName}}.ca",
+    {{/mongodb-ssl.name}}
+    "MONGODB_NET_SSL_MODE": "{{mongodb-ssl.mode}}",
+    "MONGODB_NET_SSL_ALLOW_CONNECTIONS_WITHOUT_CERTIFICATES": "{{mongodb-ssl.allowConnectionsWithoutCertificates}}",
+    "MONGODB_NET_SSL_ALLOW_INVALID_CERTIFICATES": "{{mongodb-ssl.allowInvalidCertificates}}",
+    "MONGODB_NET_SSL_ALLOW_INVALID_HOSTNAMES": "{{mongodb-ssl.allowInvalidHostnames}}",
+    "MONGODB_NET_SSL_DISABLED_PROTOCOLS": "{{mongodb-ssl.disabledProtocols}}",
+    {{#mongodb-ssl.allowInvalidCertificates}}
+    "MONGODB_NET_SSL_INSECURE": "true",
+    {{/mongodb-ssl.allowInvalidCertificates}}
+    {{^mongodb-ssl.allowInvalidCertificates}}
+    {{#mongodb-ssl.allowInvalidHostnames}}
+    "MONGODB_NET_SSL_INSECURE": "true",
+    {{/mongodb-ssl.allowInvalidHostnames}}
+    {{/mongodb-ssl.allowInvalidCertificates}}
+    {{/mongodb-ssl.enabled}}
+
+    "MONGODB_OPERATION_PROFILING_MODE": "{{mongodb-advanced.operationProfiling.mode}}",
+    "MONGODB_OPERATION_PROFILING_SLOWOP_THRESHOLD_MS": "{{mongodb-advanced.operationProfiling.slowOpThresholdMs}}",
+    "MONGODB_OPERATION_PROFILING_RATE_LIMIT": "{{mongodb-advanced.operationProfiling.rateLimit}}",
+
+    "MONGODB_REPLICATION_SECONDARY_INDEX_PREFETCH": "{{mongodb-advanced.replication.secondaryIndexPrefetch}}",
+
+    "MONGODB_AUDIT_LOG_ENABLED": "{{mongodb-advanced.auditLog.enabled}}",
+    "MONGODB_AUDIT_LOG_FILTER": "{{mongodb-advanced.auditLog.filter}}",
+
+    "MONGODB_SYSTEM_LOG_VERBOSITY": "{{mongodb-advanced.systemLog.verbosity}}",
+    "MONGODB_SYSTEM_LOG_TRACE_ALL_EXCEPTIONS": "{{mongodb-advanced.systemLog.traceAllExceptions}}",
+    "MONGODB_SYSTEM_LOG_TIMESTAMP_FORMAT": "{{mongodb-advanced.systemLog.timestampFormat}}",
+
+    {{#service.virtual_networks}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{node.virtual_network}}",
+    "CNI_PLUGIN_LABELS": "{{node.cni_plugin_labels}}",
+    {{/service.virtual_networks}}
+
+    "ADMIN_CPUS": "{{admin.cpus}}",
+    "ADMIN_MEM": "{{admin.mem}}",
+    "INIT_INITIATE_DELAY": "{{admin.init.initiateDelay}}",
+    "INIT_MAX_CONNECT_TRIES": "{{admin.init.maxConnectTries}}",
+    "INIT_MAX_INIT_REPLSET_TRIES": "{{admin.init.maxInitReplsetTries}}",
+    "INIT_MAX_ADD_USERS_TRIES": "{{admin.init.maxAddUsersTries}}",
+    "INIT_RETRY_SLEEP": "{{admin.init.retrySleep}}",
+    "WATCHDOG_API_TIMEOUT": "{{admin.watchdog.apiTimeout}}",
+    "WATCHDOG_API_POLL": "{{admin.watchdog.apiPoll}}",
+    "WATCHDOG_REPLSET_TIMEOUT": "{{admin.watchdog.replsetTimeout}}",
+    "WATCHDOG_REPLSET_POLL": "{{admin.watchdog.replsetPoll}}",
+    "WATCHDOG_METRICS_PORT": "{{admin.watchdog.metricsPort}}",
+
+    "BACKUP_RESTORE_S3_REGION": "{{backup-restore.s3.region}}",
+    "BACKUP_RESTORE_S3_ACCESS_KEY": "{{backup-restore.s3.accessKey}}",
+    "BACKUP_RESTORE_S3_SECRET_KEY": "{{backup-restore.s3.secretKey}}",
+
+    "BACKUP_CPUS": "{{backup-restore.cpus}}",
+    "BACKUP_MEM": "{{backup-restore.mem}}",
+    "BACKUP_HIDDEN_SECONDARY_ENABLED": "{{backup-restore.hiddenSecondary.enabled}}",
+    "BACKUP_HIDDEN_SECONDARY_CPUS": "{{backup-restore.hiddenSecondary.cpus}}",
+    "BACKUP_HIDDEN_SECONDARY_MEM": "{{backup-restore.hiddenSecondary.mem}}",
+    "BACKUP_VERBOSE": "{{backup-restore.backup.verbose}}",
+    "BACKUP_UPLOAD_THREADS": "{{backup-restore.backup.upload.threads}}",
+    "BACKUP_UPLOAD_RETRIES": "{{backup-restore.backup.upload.retries}}",
+    "BACKUP_UPLOAD_S3_CHUNK_SIZE_MB": "{{backup-restore.backup.upload.s3chunkSizeMb}}",
+    "BACKUP_UPLOAD_S3_BUCKET_NAME": "{{backup-restore.backup.upload.s3bucketName}}",
+    "BACKUP_UPLOAD_S3_BUCKET_PREFIX": "{{backup-restore.backup.upload.s3bucketPrefix}}",
+
+    "RESTORE_S3_URL": "{{backup-restore.restore.s3Url}}",
+    "RESTORE_AFTER_INIT": "{{backup-restore.restore.restoreAfterInit}}",
+    "RESTORE_GZIP_ENABLED": "{{backup-restore.restore.gzip}}",
+    "RESTORE_OPLOG_REPLAY": "{{backup-restore.restore.oplogReplay}}",
+    "RESTORE_DROP_COLLECTIONS": "{{backup-restore.restore.dropCollections}}",
+    "RESTORE_NUM_PARALLEL_COLLECTIONS": "{{backup-restore.restore.numParallelCollections}}",
+
+    "PMM_ENABLED": "false",
+
+    "DCOS_METRICS_ENABLED": "{{dcos-metrics.enabled}}",
+    "DCOS_METRICS_INTERVAL_SECS": "{{dcos-metrics.intervalSecs}}",
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    {{#service.secret_name}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\": [{\"file\": \"libdcos_security.so\", \"modules\": [{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    {{/service.secret_name}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "{{resource.assets.uris.bootstrap-zip}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/deploy",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    },
+    {
+      "protocol": "HTTP",
+      "path": "/v1/plans/recovery",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/percona-mongo/100/package.json
+++ b/repo/packages/P/percona-mongo/100/package.json
@@ -1,0 +1,25 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "0.2.0-3.4.13"
+  ],
+  "downgradesTo": [
+    "0.2.0-3.4.13"
+  ],
+  "minDcosReleaseVersion": "1.10",
+  "name": "percona-mongo",
+  "version": "0.3.0-3.6.5",
+  "maintainer": "mesosphere@percona.com",
+  "description": "Percona Server for MongoDB Replica Set on Mesosphere DC/OS",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "mongo",
+    "mongodb",
+    "percona",
+    "nosql"
+  ],
+  "postInstallNotes": "The DC/OS Mongo service is being installed. \n\n\tDocumentation: https://docs.mesosphere.com/service-docs/percona-mongo/\n\tIssues: mesosphere@percona.com",
+  "postUninstallNotes": "DC/OS Mongo is being uninstalled.",
+  "preInstallNotes": "Default configuration requires 3 agent nodes each with: 1.0 CPU | 1024 MB MEM | 1 1000 MB Disk"
+}

--- a/repo/packages/P/percona-mongo/100/resource.json
+++ b/repo/packages/P/percona-mongo/100/resource.json
@@ -1,0 +1,67 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "percona-server-mongodb": "percona/percona-server-mongodb:3.6.5",
+        "mongodb-consistent-backup": "perconalab/mongodb_consistent_backup:1.3.0-3.6",
+        "admin": "debian:jessie"
+      }
+    },
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz",
+      "bootstrap-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip",
+      "scheduler-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/mongo-scheduler.zip",
+      "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip",
+      "mongodb-tools-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/mongodb-tools.zip",
+      "mongodb-tools-admin-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/mongodb-tools-admin.zip",
+      "s3-cli-tar-gz": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/s3-cli.zip",
+      "restore-s3-sh": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/restore-s3.sh"
+    }
+  },
+  "images": {
+    "icon-small": "https://www.percona.com/sites/default/files/PSfMDB-48.png",
+    "icon-medium": "https://www.percona.com/sites/default/files/PSfMDB-96.png",
+    "icon-large": "https://www.percona.com/sites/default/files/PSfMDB-256.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "a28b3735eb10c5f8f1cf8572b81494f74d72e5507f45ee8914ed3b559ac91309"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "bc737d25ba6776e87c800a950b8ae62dace0db68d514cfa7ba9c1bd0856cef19"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "839a35f4b0e8d25f2611ac0d482ec126738ad8858eabfb7421be033d30df4faa"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release percona-mongo 0.3.0-3.6.5 (automated commit)

CC: @ryadav88 

Description:
dc/os percona mongo service release 0.3.0

Source URL: https://percona-dcos-mongo.s3.amazonaws.com/autodelete7d/percona-mongo/20180731-145306-VUgBrrO6mkd4Z7R0/stub-universe-percona-mongo.json

Changes between revisions 1 => 100:
0 files added: []
0 files removed: []
4 files changed:

```
--- 1/config.json
+++ 100/config.json
@@ -53,12 +53,22 @@
             "ALL"
           ],
           "default": "INFO"
+        },
+        "mesos_api_version": {
+          "description": "The Mesos API version to be used by the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "V0",
+            "V1"
+          ],
+          "default": "V1"
         }
       },
       "required": [
         "name",
         "sleep",
-        "user"
+        "user",
+        "mesos_api_version"
       ]
     },
     "mongodb": {
@@ -66,19 +76,22 @@
       "type": "object",
       "properties": {
         "cpus": {
-          "description": "MongoDB server node cpu requirements",
+          "description": "MongoDB server node cpu requirements. Example: 1 equals one CPU, 0.1 equals 10% of one CPU, etc",
           "type": "number",
-          "default": 1
+          "default": 1,
+          "minimum": 0.1
         },
         "mem": {
-          "description": "MongoDB server node mem requirements",
+          "description": "MongoDB server node mem requirements, in megabytes",
           "type": "integer",
-          "default": 1024
+          "default": 1024,
+          "minimum": 1024
         },
         "disk": {
           "description": "MongoDB server node disk requirements, in megabytes",
           "type": "integer",
-          "default": 1000
+          "default": 1000,
+          "minimum": 1
         },
         "diskType": {
           "description": "MongoDB server node disk type, see DCOS documentation regarding Disk Resources for more info",
@@ -107,80 +120,40 @@
           "default": "rs"
         },
         "port": {
-          "description": "MongoDB server listening port",
+          "description": "MongoDB server listening port. Must be a number between 1024 and 65535",
           "type": "integer",
-          "default": 27017
-        },
-        "version": {
-          "description": "Percona MongoDB server version. See Pre-Install Notes for supported versions, use other versions at your own risk!",
-          "type": "string",
-          "enum": [
-            "3.4.10",
-            "3.4.13"
-          ],
-          "default": "3.4.13"
-        },
-        "constraint": {
-          "description": "Marathon-style constraint for MongoDB server nodes (use empty string to override the default hostname UNIQUE behavior)",
-          "type": "string",
-          "default": "[['hostname', 'UNIQUE']]"
-        },
-        "backupUser": {
-          "description": "MongoDB backup user name",
-          "type": "string",
-          "default": "backup"
-        },
-        "backupPassword": {
-          "description": "MongoDB backup password",
-          "type": "string",
-          "default": "backuppassword"
-        },
-        "userAdminUser": {
-          "description": "MongoDB userAdmin user name",
-          "type": "string",
-          "default": "useradmin"
-        },
-        "userAdminPassword": {
-          "description": "MongoDB userAdmin password",
-          "type": "string",
-          "default": "useradminpassword"
-        },
-        "clusterAdminUser": {
-          "description": "MongoDB clusterAdmin user name",
-          "type": "string",
-          "default": "clusteradmin"
-        },
-        "clusterAdminPassword": {
-          "description": "MongoDB clusterAdmin password",
-          "type": "string",
-          "default": "clusteradminpassword"
-        },
-        "clusterMonitorUser": {
-          "description": "MongoDB clusterMonitor user name",
-          "type": "string",
-          "default": "clustermonitor"
-        },
-        "clusterMonitorPassword": {
-          "description": "MongoDB clusterMonitor password",
-          "type": "string",
-          "default": "clustermonitorpassword"
-        },
-        "key": {
-          "description": "The key to be used for intra-node communication, e.g. generated by 'openssl rand -base64 756'",
-          "type": "string",
-          "default": "VCeZ9zWjiNJQDZxXBZA4jfeI9YHUrWmRJDe7DKOG34b/mzER0hncruRlKLYT9HNUiU7ABxvNQ7jj1mSgmDpVt+XfKEpI3TTCJYjEAf/8G9Saeu8pdETCAd/l8xLZOAYbZd2yjhIWagiOjDz1i56GN+R51I11mSLUcGdhXVmSOCV6rrrqAtY+3+0KaWPFOnbkTHJdm3mPrts+oFT2VjGhg2yNzcfCI9FwEVPX3PWW5dbryEAHIBUapXSsMJcBFlD730DWk/MbEZSV/B/hkaFEDXgvEJszTLT6U9a2Dg4v7+eN97mK/87iKMDPIXZ5wzjbH9XNYHFVY5ensP6pmdscU9osY2MdCYhFotJHUJfGmMNbj2d1tvcc4GuFMqGcFrTyrr2E9QKm4QOtRnxLAeE2AIX0XbXxyEEbDGkKpJRLiiJRIREHh4VP6DZDzhntgcuOwWBhCLiRGDID0m1UyDe1qMXk+yy1mSRWAdfQtjXTVdS1o+AIBCxM0L0rM3rSto1PeA3CJcN1CjTfWq0t4t9mUOy4QO/juXaZCsvRDl8FKUsjnQfnocsRlWrqCGI7ONsbJdaEuiKxtu7H1WR0A+qdtBK/tZmTgbN9q0CCaP7Y1a48R5UHJAPS3HobOrqxNXEgYn+rhADUt0/ahRMuOBMTx/zm+VG8BFl8AmjOPQItvNOc9A08bKPg7lEqlzzcsTMa9QEJcW1sN9Io2F+ibKsiK9CdlPhPEUh2zMtex5e9LbT/102cmqJezq/16/xy9GYC7GwgYkrMoEbEfKdtUvVyQRijy4UE7bl9bdEgrIEY4Rs+TlR1zIRc8nl1RgL1pQp0V/gOuU/a5G5UMfIu9uZe5kgsS7T/8TQ3bzA9JpLVyCJx9rp8jvmcWO4RfOa6rKHT6pAjo1tf+VJ/mdJAwebxcpD/OPhEmfuTH5WqS3Vb/vWRbkFfC6nn+P2oB95+bF2yvA5PnkwswMTiI9Q/zSW8b4QrKyBXbd003c4FxplAGoQr2ukY"
+          "default": 27017,
+          "minimum": 1025,
+          "maximum": 65535
         },
         "storageEngine": {
           "title": "storage.engine",
-          "description": "Percona MongoDB storage engine (options: wiredTiger, rocksdb, mmapv1 or inMemory)",
+          "description": "Percona MongoDB storage engine (options: wiredTiger, mmapv1 or inMemory)",
           "type": "string",
           "enum": [
             "wiredTiger",
-            "rocksdb",
             "mmapv1",
             "inMemory"
           ],
           "default": "wiredTiger"
+        },
+        "placement": {
+          "title": "MongoDB Node Placement",
+          "description": "MongoDB Node Placement configuration properties. By default all data-bearing MongoDB tasks run on unique DC/OS agent hosts for high-availability",
+          "type": "object",
+          "properties": {
+            "constraint": {
+              "description": "Marathon-style constraint for MongoDB server nodes (use empty string to override the default hostname UNIQUE behavior)",
+              "type": "string",
+              "default": "[[\"hostname\", \"UNIQUE\"]]",
+              "media": {
+                "type": "application/x-zone-constraints+json"
+              }
+            }
+          },
+          "required": [
+            "constraint"
+          ]
         }
       },
       "required": [
@@ -190,671 +163,960 @@
         "count",
         "replicaSetName",
         "port",
-        "version",
-        "constraint",
-        "backupUser",
-        "backupPassword",
-        "userAdminUser",
-        "userAdminPassword",
-        "clusterAdminUser",
-        "clusterAdminPassword",
-        "clusterMonitorUser",
-        "clusterMonitorPassword",
-        "key",
+        "placement",
         "storageEngine"
+      ]
+    },
+    "mongodb-credentials": {
+      "title": "MongoDB Credentials",
+      "description": "MongoDB System Users and Key configuration properties. Note: for security, system passwords must be 10-characters or longer. The 'key' should be generated using the command 'openssl rand -base64 756'.",
+      "type": "object",
+      "properties": {
+        "backupUser": {
+          "description": "MongoDB backup user name",
+          "type": "string",
+          "default": "backup"
+        },
+        "backupPassword": {
+          "description": "MongoDB backup password, must be 10 characters or longer",
+          "type": "string",
+          "default": ""
+        },
+        "userAdminUser": {
+          "description": "MongoDB userAdmin user name",
+          "type": "string",
+          "default": "useradmin"
+        },
+        "userAdminPassword": {
+          "description": "MongoDB userAdmin password, must be 10 characters or longer",
+          "type": "string",
+          "default": ""
+        },
+        "clusterAdminUser": {
+          "description": "MongoDB clusterAdmin user name",
+          "type": "string",
+          "default": "clusteradmin"
+        },
+        "clusterAdminPassword": {
+          "description": "MongoDB clusterAdmin password, must be 10 characters or longer",
+          "type": "string",
+          "default": ""
+        },
+        "clusterMonitorUser": {
+          "description": "MongoDB clusterMonitor user name",
+          "type": "string",
+          "default": "clustermonitor"
+        },
+        "clusterMonitorPassword": {
+          "description": "MongoDB clusterMonitor password, must be 10 characters or longer",
+          "type": "string",
+          "default": ""
+        },
+        "key": {
+          "description": "The key to be used for intra-node replica set communication. The key must be 1024 characters long. We strongly recommend a new key is generated by running 'openssl rand -base64 756'",
+          "type": "string",
+          "default": ""
+        }
+      },
+      "allOf": [
+        {
+          "properties": {
+            "backupPassword": {
+              "minLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "userAdminPassword": {
+              "minLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "clusterAdminPassword": {
+              "minLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "clusterMonitorPassword": {
+              "minLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "key": {
+              "minLength": 1023,
+              "maxLength": 1024
+            }
+          }
+        },
+        {
+          "required": [
+            "backupUser",
+            "backupPassword",
+            "userAdminUser",
+            "userAdminPassword",
+            "clusterAdminUser",
+            "clusterAdminPassword",
+            "clusterMonitorUser",
+            "clusterMonitorPassword",
+            "key"
+          ]
+        }
       ]
     },
     "mongodb-advanced": {
       "description": "MongoDB server advanced server configuration properties. Adjust with caution!",
       "type": "object",
       "properties": {
-        "openFileLimit": {
-          "title": "Open Files Limit (ulimit)",
-          "description": "Maximum number of open files inside the container ('NOFILE' ulimit setting)",
-          "type": "number",
-          "default": 64000
-        },
-        "processLimit": {
-          "title": "Max Processes Limit (ulimit)",
-          "description": "Maximum number of processes running inside the container ('NPROC' ulimit setting)",
-          "type": "number",
-          "default": 64000
-        },
-        "securityRedactClientLogData": {
-          "title": "security.redactClientLogData",
-          "description": "Prevents writing of potentially sensitive data stored on the database to the diagnostic log",
-          "type": "boolean",
-          "default": false
-        },
-        "storageIndexBuildRetry": {
-          "title": "storage.indexBuildRetry",
-          "description": "Specifies whether mongod rebuilds incomplete indexes on the next start up",
-          "type": "boolean",
-          "default": true
-        },
-        "storageJournalEnabled": {
-          "title": "storage.journal.enabled",
-          "description": "Enable or disable the durability journal to ensure data files remain valid and recoverable",
-          "type": "boolean",
-          "default": true
-        },
-        "storageJournalCommitIntervalMs": {
-          "title": "storage.journal.commitIntervalMs",
-          "description": "The maximum amount of time in milliseconds that the mongod process allows between journal operations",
-          "type": "integer",
-          "default": 100
-        },
-        "storageDirectoryPerDB": {
-          "title": "storage.directoryPerDB",
-          "description": "When true, MongoDB uses a separate directory to store data for each database",
-          "type": "boolean",
-          "default": false
-        },
-        "storageSyncPeriodSecs": {
-          "title": "storage.syncPeriodSecs",
-          "description": "The amount of time that can pass before MongoDB flushes data to the data files via an fsync operation",
-          "type": "integer",
-          "default": 60
-        },
-        "storageMMAPv1PreallocDataFiles": {
-          "title": "storage.mmapv1.preallocDataFiles",
-          "description": "Enables or disables the preallocation of data files. By default, MongoDB does not preallocate data files",
-          "type": "boolean",
-          "default": true
-        },
-        "storageMMAPv1NsSize": {
-          "title": "storage.mmapv1.nsSize",
-          "description": "The default size for namespace files, which are files that end in .ns. Each collection and index counts as a namespace",
-          "type": "integer",
-          "default": 16
-        },
-        "storageMMAPv1QuotaEnforced": {
-          "title": "storage.mmapv1.quota.enforced",
-          "description": "Enable or disable the enforcement of a maximum limit for the number data files each database can have",
-          "type": "boolean",
-          "default": false
-        },
-        "storageMMAPv1QuotaMaxFilesPerDB": {
-          "title": "storage.mmapv1.quota.maxFilesPerDB",
-          "description": "The limit on the number of data files per database",
-          "type": "integer",
-          "default": 8
-        },
-        "storageMMAPv1SmallFiles": {
-          "title": "storage.mmapv1.smallFiles",
-          "description": "When true, MongoDB uses a smaller default file size",
-          "type": "boolean",
-          "default": false
-        },
-        "storageRocksDBCompression": {
-          "title": "storage.rocksdb.compression",
-          "description": "Specifies the block compression algorithm for data collection. Possible values: none, snappy, zlib, lz4, lz4hc",
-          "type": "string",
-          "enum": [
-            "snappy",
-            "none",
-            "zlib",
-            "lz4",
-            "lz4hc"
-          ],
-          "default": "snappy"
-        },
-        "storageRocksDBMaxWriteMBPerSec": {
-          "title": "storage.rocksdb.maxWriteMBPerSec",
-          "description": "Specifies the maximum speed at which RocksDB writes to storage in megabytes per second. Decrease this value to reduce read latency spikes during compactions. However, reducing it too much might slow down writes",
-          "type": "integer",
-          "default": 1024
-        },
-        "storageRocksDBCrashSafeCounters": {
-          "title": "storage.rocksdb.crashSafeCounters",
-          "description": "Specifies whether to correct counters after a crash. Enabling this can affect write performance",
-          "type": "boolean",
-          "default": false
-        },
-        "storageWiredTigerEngineConfigJournalCompressor": {
-          "title": "storage.wiredTiger.engineConfig.journalCompressor",
-          "description": "The type of compression to use to compress WiredTiger journal data. Available compressors are: none, snappy, zlib",
-          "type": "string",
-          "enum": [
-            "snappy",
-            "none",
-            "zlib"
-          ],
-          "default": "snappy"
-        },
-        "storageWiredTigerEngineConfigDirectoryForIndexes": {
-          "title": "storage.wiredTiger.engineConfig.directoryForIndexes",
-          "description": "When true, mongod stores indexes and collections in separate subdirectories under the data (i.e. storage.dbPath) directory",
-          "type": "boolean",
-          "default": false
-        },
-        "storageWiredTigerCollectionConfigBlockCompressor": {
-          "title": "storage.wiredTiger.collectionConfig.blockCompressor",
-          "description": "The default type of compression to use to compress collection data. You can override this on a per-collection basis when creating collections. Available compressors are: none, snappy, zlib",
-          "type": "string",
-          "enum": [
-            "snappy",
-            "none",
-            "zlib"
-          ],
-          "default": "snappy"
-        },
-        "storageWiredTigerIndexConfigPrefixCompression": {
-          "title": "storage.wiredTiger.indexConfig.prefixCompression",
-          "description": "Specify true to enable prefix compression for index data, or false to disable prefix compression for index data",
-          "type": "boolean",
-          "default": true
-        },
-        "setParameterFailIndexKeyTooLong": {
-          "title": "setParameter: failIndexKeyTooLong",
-          "description": "Enable failing of updates and inserts that have indexed values longer than the Index Key Length Limit",
-          "type": "boolean",
-          "default": true
-        },
-        "setParameterMaxIndexBuildMemoryUsageMB": {
-          "title": "setParameter: maxIndexBuildMemoryUsageMB",
-          "description": "Limits the amount of memory that simultaneous foreground index builds on one collection may consume for the duration of the builds",
-          "type": "integer",
-          "default": 500
-        },
-        "setParameterLogUserIds": {
-          "title": "setParameter: logUserIds",
-          "description": "Enable logging of user IDs. 1 = true, 0 = false",
-          "enum": [
-            0,
-            1
-          ],
-          "type": "integer",
-          "default": 0
-        },
-        "setParameterTTLMonitorEnabled": {
-          "title": "setParameter: ttlMonitorEnabled",
-          "description": "Enable background thread that is responsible for deleting documents from collections with TTL indexes",
-          "type": "boolean",
-          "default": true
-        },
-        "setParameterTTLMonitorSleepSecs": {
-          "title": "setParameter: ttlMonitorSleepSecs",
-          "description": "Defines the number of seconds to wait between checking TTL Indexes for old documents and removing them",
-          "type": "integer",
-          "default": 60
-        },
-        "setParameterRocksDBConcurrentReadTransactions": {
-          "title": "setParameter: rocksdbConcurrentReadTransactions",
-          "description": "Maximum number of concurrently running read transactions in the RocksDB engine",
-          "type": "integer",
-          "default": 128
-        },
-        "setParameterRocksDBConcurrentWriteTransactions": {
-          "title": "setParameter: rocksdbConcurrentWriteTransactions",
-          "description": "Maximum number of concurrently running write transactions in the RocksDB engine",
-          "type": "integer",
-          "default": 128
-        },
-        "setParameterWiredTigerConcurrentReadTransactions": {
-          "title": "setParameter: wiredTigerConcurrentReadTransactions",
-          "description": "Maximum number of concurrently running read transactions in the WiredTiger engine",
-          "type": "integer",
-          "default": 128
-        },
-        "setParameterWiredTigerConcurrentWriteTransactions": {
-          "title": "setParameter: wiredTigerConcurrentWriteTransactions",
-          "description": "Maximum number of concurrently running write transactions in the WiredTiger engine",
-          "type": "integer",
-          "default": 128
-        },
-        "netMaxIncomingConnections": {
-          "title": "net.maxIncomingConnections",
-          "description": "Specify the maximum number of incoming connections",
-          "type": "number",
-          "default": 51200
-        },
-        "operationProfilingMode": {
-          "title": "operationProfiling.mode",
-          "description": "Percona MongoDB operation profiling mode (options: slowOp, all or off)",
-          "type": "string",
-          "enum": [
-            "slowOp",
-            "off",
-            "all"
-          ],
-          "default": "slowOp"
-        },
-        "operationProfilingSlowOpThresholdMs": {
-          "title": "operationProfiling.slowOpThresholdMs",
-          "description": "Percona MongoDB operation profiling slowOp mode threshold in milliseconds",
-          "type": "integer",
-          "default": 100
-        },
-        "operationProfilingRateLimit": {
-          "title": "operationProfiling.rateLimit",
-          "description": "Percona MongoDB operation profiling rate limiting value",
-          "type": "integer",
-          "default": 1
-        },
-        "replicationSecondaryIndexPrefetch": {
-          "title": "replication.secondaryIndexPrefetch",
-          "description": "The indexes that secondary members of a replica set load into memory before applying operations from the oplog",
-          "type": "string",
-          "enum": [
-            "none",
-            "_id_only",
-            "all"
-          ],
-          "default": "all"
-        },
-        "replicationEnableMajorityReadConcern": {
-          "title": "replication.enableMajorityReadConcern",
-          "description": "Enables read concern level of 'majority'",
-          "type": "boolean",
-          "default": false
-        },
-        "systemLogVerbosity": {
-          "title": "systemLog.verbosity",
-          "description": "The default log message verbosity level for components. The verbosity level determines the amount of Informational and Debug messages MongoDB outputs. The verbosity level can range from 0 to 5",
-          "type": "integer",
-          "enum": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5
-          ],
-          "default": 0
-        },
-        "systemTraceAllExceptions": {
-          "title": "systemLog.traceAllExceptions",
-          "description": "Print verbose information for debugging. Use for additional logging for support-related troubleshooting",
-          "type": "boolean",
-          "default": false
-        },
-        "systemLogTimestampFormat": {
-          "title": "systemLog.timestampFormat",
-          "description": "The time format for timestamps in log messages. Specify one of the following values: ctime, iso8601-utc, iso8601-local",
-          "type": "string",
-          "enum": [
-            "iso8601-local",
-            "ctime",
-            "iso8601-utc"
-          ],
-          "default": "iso8601-local"
+        "container": {
+          "title": "Linux Container",
+          "description": "MongoDB Linux Container configuration properties",
+          "type": "object",
+          "properties": {
+            "openFileLimit": {
+              "title": "Open Files Limit (ulimit)",
+              "description": "Maximum number of open files inside the container ('NOFILE' ulimit setting)",
+              "type": "number",
+              "default": 64000,
+              "minimum": 1024
+            },
+            "processLimit": {
+              "title": "Max Processes Limit (ulimit)",
+              "description": "Maximum number of processes running inside the container ('NPROC' ulimit setting)",
+              "type": "number",
+              "default": 64000,
+              "minimum": 1024
+            }
+          },
+          "required": [
+            "openFileLimit",
+            "processLimit"
+          ]
+        },
+        "security": {
+          "description": "MongoDB security configuration properties",
+          "type": "object",
+          "properties": {
+            "redactClientLogData": {
+              "title": "security.redactClientLogData",
+              "description": "The Percona Log Redaction feature prevents writing of potentially sensitive data stored on the database to the diagnostic log",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "redactClientLogData"
+          ]
+        },
+        "storage": {
+          "description": "MongoDB storage-level configuration properties",
+          "type": "object",
+          "properties": {
+            "indexBuildRetry": {
+              "title": "storage.indexBuildRetry",
+              "description": "Specifies whether mongod rebuilds incomplete indexes on the next start up",
+              "type": "boolean",
+              "default": true
+            },
+            "directoryPerDB": {
+              "title": "storage.directoryPerDB",
+              "description": "When true, MongoDB uses a separate directory to store data for each database",
+              "type": "boolean",
+              "default": false
+            },
+            "syncPeriodSecs": {
+              "title": "storage.syncPeriodSecs",
+              "description": "The amount of time that can pass before MongoDB flushes data to the data files via an fsync operation",
+              "type": "integer",
+              "default": 60,
+              "minimum": 0
+            },
+            "journal": {
+              "title": "Journaling",
+              "description": "MongoDB Storage Journal configuration properties",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "title": "storage.journal.enabled",
+                  "description": "Enable or disable the durability journal to ensure data files remain valid and recoverable",
+                  "type": "boolean",
+                  "default": true
+                },
+                "commitIntervalMs": {
+                  "title": "storage.journal.commitIntervalMs",
+                  "description": "The maximum amount of time in milliseconds that the mongod process allows between journal operations",
+                  "type": "integer",
+                  "default": 100,
+                  "minimum": 1
+                }
+              },
+              "required": [
+                "enabled",
+                "commitIntervalMs"
+              ]
+            },
+            "mmapv1": {
+              "title": "MMAPv1 Storage Engine",
+              "description": "MongoDB MMAPv1 storage-engine configuration properties",
+              "type": "object",
+              "properties": {
+                "preallocDataFiles": {
+                  "title": "storage.mmapv1.preallocDataFiles",
+                  "description": "Enables or disables the preallocation of data files. By default, MongoDB does not preallocate data files",
+                  "type": "boolean",
+                  "default": true
+                },
+                "nsSize": {
+                  "title": "storage.mmapv1.nsSize",
+                  "description": "The default size for namespace files, which are files that end in .ns. Each collection and index counts as a namespace",
+                  "type": "integer",
+                  "default": 16,
+                  "minimum": 1
+                },
+                "quotaEnforced": {
+                  "title": "storage.mmapv1.quota.enforced",
+                  "description": "Enable or disable the enforcement of a maximum limit for the number data files each database can have",
+                  "type": "boolean",
+                  "default": false
+                },
+                "quotaMaxFilesPerDB": {
+                  "title": "storage.mmapv1.quota.maxFilesPerDB",
+                  "description": "The limit on the number of data files per database",
+                  "type": "integer",
+                  "default": 8,
+                  "minimum": 1
+                },
+                "smallFiles": {
+                  "title": "storage.mmapv1.smallFiles",
+                  "description": "When true, MongoDB uses a smaller default file size",
+                  "type": "boolean",
+                  "default": false
+                }
+              },
+              "required": [
+                "preallocDataFiles",
+                "nsSize",
+                "quotaEnforced",
+                "quotaMaxFilesPerDB",
+                "smallFiles"
+              ]
+            },
+            "wiredTiger": {
+              "title": "WiredTiger Storage Engine",
+              "description": "MongoDB WiredTiger storage-engine configuration properties",
+              "type": "object",
+              "properties": {
+                "engineConfigJournalCompressor": {
+                  "title": "storage.wiredTiger.engineConfig.journalCompressor",
+                  "description": "The type of compression to use to compress WiredTiger journal data. Available compressors are: none, snappy, zlib",
+                  "type": "string",
+                  "enum": [
+                    "snappy",
+                    "none",
+                    "zlib"
+                  ],
+                  "default": "snappy"
+                },
+                "engineConfigDirectoryForIndexes": {
+                  "title": "storage.wiredTiger.engineConfig.directoryForIndexes",
+                  "description": "When true, mongod stores indexes and collections in separate subdirectories under the data (i.e. storage.dbPath) directory",
+                  "type": "boolean",
+                  "default": false
+                },
+                "collectionConfigBlockCompressor": {
+                  "title": "storage.wiredTiger.collectionConfig.blockCompressor",
+                  "description": "The default type of compression to use to compress collection data. You can override this on a per-collection basis when creating collections. Available compressors are: none, snappy, zlib",
+                  "type": "string",
+                  "enum": [
+                    "snappy",
+                    "none",
+                    "zlib"
+                  ],
+                  "default": "snappy"
+                },
+                "indexConfigPrefixCompression": {
+                  "title": "storage.wiredTiger.indexConfig.prefixCompression",
+                  "description": "Specify true to enable prefix compression for index data, or false to disable prefix compression for index data",
+                  "type": "boolean",
+                  "default": true
+                }
+              },
+              "required": [
+                "engineConfigJournalCompressor",
+                "engineConfigDirectoryForIndexes",
+                "collectionConfigBlockCompressor",
+                "indexConfigPrefixCompression"
+              ]
+            }
+          },
+          "required": [
+            "indexBuildRetry",
+            "directoryPerDB",
+            "syncPeriodSecs",
+            "journal",
+            "mmapv1",
+            "wiredTiger"
+          ]
+        },
+        "setParameter": {
+          "title": "Server Parameters",
+          "description": "MongoDB Server Parameter (setParameter) configuration properties",
+          "type": "object",
+          "properties": {
+            "failIndexKeyTooLong": {
+              "title": "setParameter: failIndexKeyTooLong",
+              "description": "Enable failing of updates and inserts that have indexed values longer than the Index Key Length Limit",
+              "type": "boolean",
+              "default": true
+            },
+            "maxIndexBuildMemoryUsageMB": {
+              "title": "setParameter: maxIndexBuildMemoryUsageMB",
+              "description": "Limits the amount of memory that simultaneous foreground index builds on one collection may consume for the duration of the builds",
+              "type": "integer",
+              "default": 500
+            },
+            "logUserIds": {
+              "title": "setParameter: logUserIds",
+              "description": "Enable logging of user IDs. 1 = true, 0 = false",
+              "enum": [
+                0,
+                1
+              ],
+              "type": "integer",
+              "default": 0
+            },
+            "ttlMonitorEnabled": {
+              "title": "setParameter: ttlMonitorEnabled",
+              "description": "Enable background thread that is responsible for deleting documents from collections with TTL indexes",
+              "type": "boolean",
+              "default": true
+            },
+            "ttlMonitorSleepSecs": {
+              "title": "setParameter: ttlMonitorSleepSecs",
+              "description": "Defines the number of seconds to wait between checking TTL Indexes for old documents and removing them",
+              "type": "integer",
+              "default": 60,
+              "minimum": 1
+            },
+            "wiredTigerConcurrentReadTransactions": {
+              "title": "setParameter: wiredTigerConcurrentReadTransactions",
+              "description": "Maximum number of concurrently running read transactions in the WiredTiger engine",
+              "type": "integer",
+              "default": 128,
+              "minimum": 1
+            },
+            "wiredTigerConcurrentWriteTransactions": {
+              "title": "setParameter: wiredTigerConcurrentWriteTransactions",
+              "description": "Maximum number of concurrently running write transactions in the WiredTiger engine",
+              "type": "integer",
+              "default": 128,
+              "minimum": 1
+            }
+          },
+          "required": [
+            "failIndexKeyTooLong",
+            "maxIndexBuildMemoryUsageMB",
+            "logUserIds",
+            "ttlMonitorEnabled",
+            "ttlMonitorSleepSecs",
+            "wiredTigerConcurrentReadTransactions",
+            "wiredTigerConcurrentWriteTransactions"
+          ]
+        },
+        "net": {
+          "title": "Network",
+          "description": "MongoDB Network configuration properties",
+          "type": "object",
+          "properties": {
+            "maxIncomingConnections": {
+              "title": "net.maxIncomingConnections",
+              "description": "Specify the maximum number of incoming connections",
+              "type": "number",
+              "default": 51200,
+              "minimum": 1
+            },
+            "transportLayer": {
+              "title": "net.transportLayer",
+              "description": "The networking implementation the mongos or mongod uses. To revert to the pre-version 3.6 implementation, change this option to 'legacy'",
+              "type": "string",
+              "enum": [
+                "asio",
+                "legacy"
+              ],
+              "default": "asio"
+            },
+            "serviceExecutor": {
+              "title": "net.serviceExecutor",
+              "description": "Determines the threading and execution model mongos or mongod uses to execute client requests.",
+              "type": "string",
+              "enum": [
+                "synchronous",
+                "adaptive"
+              ],
+              "default": "synchronous"
+            }
+          },
+          "required": [
+            "maxIncomingConnections",
+            "transportLayer",
+            "serviceExecutor"
+          ]
+        },
+        "operationProfiling": {
+          "title": "Operation Profiling",
+          "description": "MongoDB Operation Profiling configuration properties",
+          "type": "object",
+          "properties": {
+            "mode": {
+              "title": "operationProfiling.mode",
+              "description": "Percona MongoDB operation profiling mode (options: slowOp, all or off)",
+              "type": "string",
+              "enum": [
+                "slowOp",
+                "off",
+                "all"
+              ],
+              "default": "slowOp"
+            },
+            "slowOpThresholdMs": {
+              "title": "operationProfiling.slowOpThresholdMs",
+              "description": "Percona MongoDB operation profiling slowOp mode threshold in milliseconds",
+              "type": "integer",
+              "default": 100,
+              "minimum": 1
+            },
+            "rateLimit": {
+              "title": "operationProfiling.rateLimit",
+              "description": "Percona MongoDB operation profiling rate limiting value",
+              "type": "integer",
+              "default": 1
+            }
+          },
+          "required": [
+            "mode",
+            "slowOpThresholdMs",
+            "rateLimit"
+          ]
+        },
+        "replication": {
+          "description": "MongoDB Replication configuration properties",
+          "type": "object",
+          "properties": {
+            "secondaryIndexPrefetch": {
+              "title": "replication.secondaryIndexPrefetch",
+              "description": "The indexes that secondary members of a replica set load into memory before applying operations from the oplog",
+              "type": "string",
+              "enum": [
+                "none",
+                "_id_only",
+                "all"
+              ],
+              "default": "all"
+            }
+          },
+          "required": [
+            "secondaryIndexPrefetch"
+          ]
+        },
+        "auditLog": {
+          "title": "Percona AuditLog",
+          "description": "Percona Server for MongoDB AuditLog configuration properties. The audit log is written to the file 'auditLog.bson' in the MongoDB data path",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Enable PSMDB Audit Log",
+              "description": "Enables the Percona Server for MongoDB audit log feature",
+              "type": "boolean",
+              "default": false
+            },
+            "filter": {
+              "title": "auditLog.filter",
+              "description": "The filter document (in json style) to be used for filtering the Percona Server for MongoDB audit log",
+              "type": "string",
+              "default": "{}"
+            },
+            "auditAuthorizationSuccess": {
+              "title": "setParameter: auditAuthorizationSuccess",
+              "description": "Enables the logging of all read and write operations",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "enabled",
+            "filter",
+            "auditAuthorizationSuccess"
+          ]
+        },
+        "systemLog": {
+          "title": "System Log",
+          "description": "MongoDB System Log configuration properties",
+          "type": "object",
+          "properties": {
+            "verbosity": {
+              "title": "systemLog.verbosity",
+              "description": "The default log message verbosity level for components. The verbosity level determines the amount of Informational and Debug messages MongoDB outputs. The verbosity level can range from 0 to 5",
+              "type": "integer",
+              "enum": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5
+              ],
+              "default": 0
+            },
+            "traceAllExceptions": {
+              "title": "systemLog.traceAllExceptions",
+              "description": "Print verbose information for debugging. Use for additional logging for support-related troubleshooting",
+              "type": "boolean",
+              "default": false
+            },
+            "timestampFormat": {
+              "title": "systemLog.timestampFormat",
+              "description": "The time format for timestamps in log messages. Specify one of the following values: ctime, iso8601-utc, iso8601-local",
+              "type": "string",
+              "enum": [
+                "iso8601-local",
+                "ctime",
+                "iso8601-utc"
+              ],
+              "default": "iso8601-local"
+            }
+          },
+          "required": [
+            "verbosity",
+            "traceAllExceptions",
+            "timestampFormat"
+          ]
         }
       },
       "required": [
-        "openFileLimit",
-        "processLimit",
-        "storageIndexBuildRetry",
-        "storageJournalEnabled",
-        "storageJournalCommitIntervalMs",
-        "storageDirectoryPerDB",
-        "storageSyncPeriodSecs",
-        "storageMMAPv1PreallocDataFiles",
-        "storageMMAPv1NsSize",
-        "storageMMAPv1QuotaEnforced",
-        "storageMMAPv1QuotaMaxFilesPerDB",
-        "storageMMAPv1SmallFiles",
-        "storageRocksDBCompression",
-        "storageRocksDBMaxWriteMBPerSec",
-        "storageRocksDBCrashSafeCounters",
-        "storageWiredTigerEngineConfigJournalCompressor",
-        "storageWiredTigerEngineConfigDirectoryForIndexes",
-        "storageWiredTigerCollectionConfigBlockCompressor",
-        "storageWiredTigerIndexConfigPrefixCompression",
-        "setParameterFailIndexKeyTooLong",
-        "setParameterMaxIndexBuildMemoryUsageMB",
-        "setParameterLogUserIds",
-        "setParameterTTLMonitorEnabled",
-        "setParameterTTLMonitorSleepSecs",
-        "setParameterRocksDBConcurrentReadTransactions",
-        "setParameterRocksDBConcurrentWriteTransactions",
-        "setParameterWiredTigerConcurrentReadTransactions",
-        "setParameterWiredTigerConcurrentWriteTransactions",
-        "netMaxIncomingConnections",
-        "operationProfilingMode",
-        "operationProfilingSlowOpThresholdMs",
-        "operationProfilingRateLimit",
-        "replicationSecondaryIndexPrefetch",
-        "replicationEnableMajorityReadConcern",
-        "systemLogVerbosity",
-        "systemTraceAllExceptions",
-        "systemLogTimestampFormat"
+        "container",
+        "security",
+        "net",
+        "storage",
+        "setParameter",
+        "operationProfiling",
+        "replication",
+        "auditLog",
+        "systemLog"
       ]
     },
-    "mongodb-auditlog": {
-      "description": "Percona Server for MongoDB AuditLog configuration properties. The audit log is written to the file 'auditLog.bson' in the MongoDB data path",
+    "mongodb-ssl": {
+      "title": "MongoDB SSL",
+      "description": "MongoDB SSL configuration properties. This section requires DC/OS Enterprise Edition!",
       "type": "object",
       "properties": {
         "enabled": {
-          "title": "Enable PSMDB Audit Log",
-          "description": "Enables the Percona Server for MongoDB audit log feature",
+          "title": "Enable MongoDB SSL Support",
+          "description": "Enables SSL support for Percona Server for MongoDB server",
           "type": "boolean",
           "default": false
         },
-        "filter": {
-          "title": "auditLog.filter",
-          "description": "The filter document (in json style) to be used for filtering the Percona Server for MongoDB audit log",
-          "type": "string",
-          "default": "{}"
-        },
-        "auditAuthorizationSuccess": {
-          "title": "setParameter: auditAuthorizationSuccess",
-          "description": "Enables the logging of all read and write operations",
+        "mode": {
+          "title": "MongoDB SSL Mode",
+          "description": "MongoDB SSL mode. See documentation for net.ssl.mode for more information",
+          "type": "string",
+          "enum": [
+            "allowSSL",
+            "preferSSL",
+            "requireSSL"
+          ],
+          "default": "preferSSL"
+        },
+        "name": {
+          "title": "DC/OS SSL Name",
+          "description": "Name of the SSL certificates that are auto-generated by DC/OS. Leave empty to auto-generate as 'SERVICENAME-REPLSETNAME'",
+          "type": "string",
+          "default": ""
+        },
+        "allowConnectionsWithoutCertificates": {
+          "title": "net.ssl.allowConnectionsWithoutCertificates",
+          "description": "Allow MongoDB to accept connections when the client does not present a certificate when establishing the connection",
           "type": "boolean",
           "default": false
+        },
+        "allowInvalidCertificates": {
+          "title": "net.ssl.allowInvalidCertificates",
+          "description": "Disable the validation checks for TLS/SSL certificates on other servers in the cluster and allow invalid certificates",
+          "type": "boolean",
+          "default": false
+        },
+        "allowInvalidHostnames": {
+          "title": "net.ssl.allowInvalidHostnames",
+          "description": "Disable the validation of the hostnames in TLS/SSL certificates, allowing mongod to connect to MongoDB instances if the hostname their certificates do not match the specified hostname",
+          "type": "boolean",
+          "default": false
+        },
+        "disabledProtocols": {
+          "title": "net.ssl.disabledProtocols",
+          "description": "Prevents server from accepting incoming connections that use a specific protocol or protocols. net.ssl.disabledProtocols recognizes the following protocols: TLS1_0, TLS1_1, and TLS1_2. Specifying an unrecognized protocol will prevent the server from starting. To specify multiple protocols, use a comma separated list of protocols",
+          "type": "string",
+          "default": ""
         }
       },
       "required": [
         "enabled",
-        "filter",
-        "auditAuthorizationSuccess"
+        "mode",
+        "allowConnectionsWithoutCertificates",
+        "allowInvalidCertificates",
+        "allowInvalidHostnames"
       ]
     },
-    "init": {
-      "description": "MongoDB init node configuration properties",
+    "backup-restore": {
+      "description": "Backup and Restore configuration properties. Only mongodump-based backup and AWS S3 (for backup storage) is supported currently",
       "type": "object",
       "properties": {
         "cpus": {
-          "description": "MongoDB init node cpu requirements",
+          "title": "Backup/restore node cpus",
+          "description": "Node cpu requirements for backup and restore process",
+          "type": "number",
+          "default": 2.0
+        },
+        "mem": {
+          "title": "Backup/restore node mem",
+          "description": "Node mem requirements for backup and restore process, in megabytes",
+          "type": "integer",
+          "default": 1024
+        },
+        "s3": {
+          "title": "AWS S3 configuration",
+          "description": "Backup and Restore Amazon Web Services S3 configuration properties",
+          "type": "object",
+          "properties": {
+            "region": {
+              "title": "region",
+              "description": "Backup and restore s3 region for upload",
+              "type": "string",
+              "default": "us-east-1",
+              "enum": [
+                "ap-northeast-1",
+                "ap-northeast-2",
+                "ap-northeast-3",
+                "ap-south-1",
+                "ap-southeast-1",
+                "ap-southeast-2",
+                "ca-central-1",
+                "cn-north-1",
+                "cn-northwest-1",
+                "eu-central-1",
+                "eu-west-1",
+                "eu-west-2",
+                "eu-west-3",
+                "sa-east-1",
+                "us-east-1",
+                "us-east-2",
+                "us-west-1",
+                "us-west-2"
+              ]
+            },
+            "accessKey": {
+              "title": "access_key",
+              "description": "Backup and restore s3 access key",
+              "type": "string",
+              "default": ""
+            },
+            "secretKey": {
+              "title": "secret_key",
+              "description": "Backup and restore s3 secret key",
+              "type": "string",
+              "default": ""
+            }
+          },
+          "allOf": [
+            {
+              "properties": {
+                "accessKey": {
+                  "maxLength": 20
+                }
+              }
+            },
+            {
+              "properties": {
+                "secretKey": {
+                  "maxLength": 40
+                }
+              }
+            },
+            {
+              "required": [
+                "region"
+              ]
+            }
+          ]
+        },
+        "restore": {
+          "title": "Restore",
+          "description": "Restore configuration properties",
+          "type": "object",
+          "properties": {
+            "s3Url": {
+              "description": "AWS S3 URL to mongodump backup directory in 's3://<bucket-name>/<path>/' format. A URL for the backup is required for restore!",
+              "type": "string",
+              "default": ""
+            },
+            "restoreAfterInit": {
+              "description": "Restore replica set from backup after initiation",
+              "type": "boolean",
+              "default": false
+            },
+            "gzip": {
+              "description": "Enable gzip on restore. Backup data must be gzip compressed",
+              "type": "boolean",
+              "default": true
+            },
+            "dropCollections": {
+              "description": "Drop collections during restore. This is usually required to avoid duplicate key errors on restore",
+              "type": "boolean",
+              "default": true
+            },
+            "oplogReplay": {
+              "description": "Replay the backup oplog after restoring the collections, strongly recommended!",
+              "type": "boolean",
+              "default": true
+            },
+            "numParallelCollections": {
+              "description": "Number of collections to restore in parallel",
+              "type": "integer",
+              "default": 4
+            }
+          },
+          "allOf": [
+            {
+              "not": {
+                "properties": {
+                  "s3Url": {
+                    "enum": [
+                      ""
+                    ]
+                  },
+                  "restoreAfterInit": {
+                    "enum": [
+                      true
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "required": [
+                "restoreAfterInit",
+                "gzip",
+                "dropCollections",
+                "oplogReplay",
+                "numParallelCollections"
+              ]
+            }
+          ]
+        },
+        "backup": {
+          "title": "Backup",
+          "description": "Backup configuration properties",
+          "type": "object",
+          "properties": {
+            "upload": {
+              "description": "Backup upload configuration properties",
+              "type": "object",
+              "properties": {
+                "s3bucketName": {
+                  "title": "bucket_name",
+                  "description": "Backup upload s3 bucket name",
+                  "type": "string",
+                  "default": ""
+                },
+                "s3bucketPrefix": {
+                  "title": "bucket_prefix",
+                  "description": "Backup upload s3 bucket key prefix",
+                  "type": "string",
+                  "default": "/"
+                },
+                "threads": {
+                  "title": "upload.threads",
+                  "description": "Upload thread count",
+                  "type": "integer",
+                  "default": 4
+                },
+                "retries": {
+                  "title": "upload.retries",
+                  "description": "Upload chunk retry count",
+                  "type": "integer",
+                  "default": 5
+                },
+                "s3chunkSizeMb": {
+                  "title": "chunk_size_mb",
+                  "description": "Backup and restore s3 chunk size in megabytes",
+                  "type": "integer",
+                  "default": 50,
+                  "minimum": 1
+                }
+              },
+              "required": [
+                "s3bucketPrefix",
+                "threads",
+                "retries",
+                "s3chunkSizeMb"
+              ]
+            },
+            "verbose": {
+              "description": "Enable verbose logging of backup",
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "required": [
+            "upload",
+            "verbose"
+          ]
+        },
+        "hiddenSecondary": {
+          "title": "Backup Hidden Secondary Node",
+          "description": "MongoDB Hidden-secondary backup node configuration properties. A Hidden-secondary node is recommended for low impact backups as it does not receive application traffic and cannot win a failover-election",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "title": "Add dedicated MongoDB backup node",
+              "description": "Add a hidden-secondary MongoDB node dedicated to backup operations. This node cannot become primary and is invible to MongoDB drivers. The node will inherit any config options passed to the other mongod nodes",
+              "type": "boolean",
+              "default": false
+            },
+            "cpus": {
+              "title": "Dedicated MongoDB backup node cpus",
+              "description": "MongoDB backup hidden-secondary node cpu requirements",
+              "type": "number",
+              "default": 1.0
+            },
+            "mem": {
+              "title": "Dedicated MongoDB backup node mem",
+              "description": "MongoDB backup hidden-secondary node mem requirements, in megabytes",
+              "type": "integer",
+              "default": 1024
+            }
+          },
+          "required": [
+            "enabled",
+            "cpus",
+            "mem"
+          ]
+        }
+      }
+    },
+    "dcos-metrics": {
+      "description": "DC/OS Metrics configuration properties",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "title": "Enable DC/OS Metrics",
+          "description": "Enable the sending of MongoDB metrics to DC/OS Metrics",
+          "type": "boolean",
+          "default": false
+        },
+        "intervalSecs": {
+          "title": "Metrics Collect Interval",
+          "description": "The frequency to collect MongoDB metrics, in seconds",
+          "type": "integer",
+          "default": 10,
+          "minimum": 1
+        }
+      },
+      "required": [
+        "enabled",
+        "intervalSecs"
+      ]
+    },
+    "admin": {
+      "description": "Admin task configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "Admin node cpu requirements",
           "type": "number",
           "default": 0.2
         },
         "mem": {
-          "description": "MongoDB init node mem requirements",
+          "description": "Admin node mem requirements. Must be 64 or greater",
           "type": "integer",
-          "default": 96
-        },
-        "initiateDelay": {
-          "description": "The delay before starting the ReplicaSet initialization, must end in 's' for seconds, 'm' for minutes, etc",
-          "type": "string",
-          "default": "15s"
-        },
-        "maxConnectTries": {
-          "description": "The number of times to try to connect to a database host",
-          "type": "integer",
-          "default": 30
-        },
-        "maxInitReplsetTries": {
-          "description": "The number of times to try to initiate the replica set",
-          "type": "integer",
-          "default": 60
-        },
-        "maxAddUsersTries": {
-          "description": "The number of times to try to add database users",
-          "type": "integer",
-          "default": 60
-        },
-        "retrySleep": {
-          "description": "The duration to wait between retries",
-          "type": "string",
-          "default": "3s"
+          "default": 64,
+          "minimum": 64
+        },
+        "init": {
+          "description": "Init task configuration properties. This task runs once on initiation of a new MongoDB Replica Set",
+          "type": "object",
+          "properties": {
+            "initiateDelay": {
+              "description": "The delay before starting the ReplicaSet initialization, must end in 's' for seconds, 'm' for minutes, etc",
+              "type": "string",
+              "default": "15s"
+            },
+            "maxConnectTries": {
+              "description": "The number of times to try to connect to a database host",
+              "type": "integer",
+              "default": 30,
+              "minimum": 1
+            },
+            "maxInitReplsetTries": {
+              "description": "The number of times to try to initiate the replica set",
+              "type": "integer",
+              "default": 60,
+              "minimum": 1
+            },
+            "maxAddUsersTries": {
+              "description": "The number of times to try to add database users",
+              "type": "integer",
+              "default": 60,
+              "minimum": 1
+            },
+            "retrySleep": {
+              "description": "The duration to wait between retries",
+              "type": "string",
+              "default": "3s"
+            }
+          }
+        },
+        "watchdog": {
+          "description": "Watchdog daemon configuration properties. This daemon watches the DC/OS API for changes and updates the MongoDB Replica Set",
+          "type": "object",
+          "properties": {
+            "apiPoll": {
+              "description": "DCOS API poll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+              "type": "string",
+              "default": "10s"
+            },
+            "apiTimeout": {
+              "description": "Pod API timeout than apiPoll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+              "type": "string",
+              "default": "5s"
+            },
+            "replsetPoll": {
+              "description": "MongoDB replica set state poll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+              "type": "string",
+              "default": "5s"
+            },
+            "replsetTimeout": {
+              "description": "MongoDB replica set timeout, should be less than replsetPoll frequency, must end in 's' for seconds, 'm' for minutes, etc",
+              "type": "string",
+              "default": "3s"
+            },
+            "metricsPort": {
+              "description": "Prometheus Metrics server port, default '0' uses a random available port",
+              "type": "integer",
+              "default": 0,
+              "maximum": 65535
+            }
+          }
         }
       },
       "required": [
         "cpus",
-        "mem"
-      ]
-    },
-    "watchdog": {
-      "description": "MongoDB watchdog node configuration properties",
-      "type": "object",
-      "properties": {
-        "cpus": {
-          "description": "MongoDB watchdog node cpu requirements",
-          "type": "number",
-          "default": 0.2
-        },
-        "mem": {
-          "description": "MongoDB watchdog node mem requirements",
-          "type": "integer",
-          "default": 96
-        },
-        "delayWatcherStart": {
-          "description": "Amount of time to delay starting replica set watchers, must end in 's' for seconds, 'm' for minutes, etc",
-          "type": "string",
-          "default": "20s"
-        },
-        "apiPoll": {
-          "description": "DCOS API poll frequency, must end in 's' for seconds, 'm' for minutes, etc",
-          "type": "string",
-          "default": "10s"
-        },
-        "apiTimeout": {
-          "description": "Pod API timeout than apiPoll frequency, must end in 's' for seconds, 'm' for minutes, etc",
-          "type": "string",
-          "default": "5s"
-        },
-        "replsetPoll": {
-          "description": "MongoDB replica set state poll frequency, must end in 's' for seconds, 'm' for minutes, etc",
-          "type": "string",
-          "default": "5s"
-        },
-        "replsetTimeout": {
-          "description": "MongoDB replica set timeout, should be less than replsetPoll frequency, must end in 's' for seconds, 'm' for minutes, etc",
-          "type": "string",
-          "default": "3s"
-        },
-        "replsetConfUpdatePoll": {
-          "description": "MongoDB replica set config update frequency, must end in 's' for seconds, 'm' for minutes, etc",
-          "type": "string",
-          "default": "10s"
-        }
-      },
-      "required": [
-        "cpus",
-        "mem"
-      ]
-    },
-    "backup": {
-      "description": "Percona-Lab/mongodb_consistent_backup Backup configuration properties. Only mongodump-based backup and AWS S3 (for backup storage) is supported currently",
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "title": "Enable backups",
-          "description": "Enable backups",
-          "type": "boolean",
-          "default": false
-        },
-        "hiddenSecondaryEnabled": {
-          "title": "Add dedicated MongoDB backup node",
-          "description": "Add a hidden-secondary MongoDB node dedicated to backup operations. This node cannot become primary and is invible to MongoDB drivers. The node will inherit any config options passed to the other mongod nodes",
-          "type": "boolean",
-          "default": true
-        },
-        "hiddenSecondaryCpus": {
-          "title": "Dedicated MongoDB backup node cpus",
-          "description": "MongoDB backup hidden-secondary node cpu requirements",
-          "type": "number",
-          "default": 1.0
-        },
-        "hiddenSecondaryMem": {
-          "title": "Dedicated MongoDB backup node mem",
-          "description": "MongoDB backup hidden-secondary node mem requirements, in megabytes",
-          "type": "integer",
-          "default": 1024
-        },
-        "backupCpus": {
-          "title": "Backup node cpus",
-          "description": "mongodb_consistent_backup node cpu requirements",
-          "type": "number",
-          "default": 2.0
-        },
-        "backupMem": {
-          "title": "Backup node mem",
-          "description": "mongodb_consistent_backup node mem requirements, in megabytes",
-          "type": "integer",
-          "default": 1024
-        },
-        "backupVersion": {
-          "title": "mongodb_consistent_backup version",
-          "description": "mongodb_consistent_backup version Dockerhub tag, see perconalab/mongodb_consistent_backup Dockerhub page for available versions. Version must be 1.3.0 or greater!",
-          "type": "string",
-          "default": "1.3.0"
-        },
-        "archiveMethod": {
-          "title": "archive.method",
-          "description": "mongodb_consistent_backup archive method (none or tar)",
-          "enum": [
-            "none",
-            "tar"
-          ],
-          "type": "string",
-          "default": "none"
-        },
-        "uploadThreads": {
-          "title": "upload.threads",
-          "description": "mongodb_consistent_backup upload thread count",
-          "type": "integer",
-          "default": 4
-        },
-        "uploadRetries": {
-          "title": "upload.retries",
-          "description": "mongodb_consistent_backup upload retry count",
-          "type": "integer",
-          "default": 5
-        },
-        "uploadS3Region": {
-          "title": "upload.s3.region",
-          "description": "mongodb_consistent_backup upload s3 region for upload",
-          "type": "string",
-          "default": "us-east-1"
-        },
-        "uploadS3AccessKey": {
-          "title": "upload.s3.access_key",
-          "description": "mongodb_consistent_backup upload s3 access key",
-          "type": "string",
-          "default": ""
-        },
-        "uploadS3SecretKey": {
-          "title": "upload.s3.secret_key",
-          "description": "mongodb_consistent_backup upload s3 secret key",
-          "type": "string",
-          "default": ""
-        },
-        "uploadS3BucketName": {
-          "title": "upload.s3.bucket_name",
-          "description": "mongodb_consistent_backup upload s3 bucket name",
-          "type": "string",
-          "default": ""
-        },
-        "uploadS3BucketPrefix": {
-          "title": "upload.s3.bucket_prefix",
-          "description": "mongodb_consistent_backup upload s3 bucket key prefix",
-          "type": "string",
-          "default": "/"
-        },
-        "uploadS3ObjectACL": {
-          "title": "upload.s3.object_acl",
-          "description": "mongodb_consistent_backup upload s3 object acl",
-          "type": "string",
-          "default": ""
-        },
-        "uploadS3UploadChunkSizeMb": {
-          "title": "upload.s3.chunk_size_mb",
-          "description": "mongodb_consistent_backup upload s3 chunk size in megabytes",
-          "type": "integer",
-          "default": 50
-        },
-        "verbose": {
-          "description": "Enable mongodb_consistent_backup verbose logging",
-          "type": "boolean",
-          "default": false
-        }
-      },
-      "required": [
-        "enabled",
-        "hiddenSecondaryEnabled",
-        "hiddenSecondaryCpus",
-        "hiddenSecondaryMem",
-        "backupCpus",
-        "backupMem",
-        "backupVersion",
-        "archiveMethod",
-        "uploadThreads",
-        "uploadRetries",
-        "uploadS3Region",
-        "uploadS3BucketPrefix",
-        "uploadS3UploadChunkSizeMb",
-        "verbose"
-      ]
-    },
-    "percona-pmm": {
-      "description": "Percona PMM monitoring configuration properties. This section assumes you have setup a PMM server beforehand, ie: it does NOT create a PMM server!",
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "title": "Enable Percona PMM monitoring",
-          "description": "Enable Percona Monitoring & Management (PMM) monitoring of MongoDB and Linux",
-          "type": "boolean",
-          "default": false
-        },
-        "enableQueryAnalytics": {
-          "title": "Enable PMM Query Analytics (QAN) for MongoDB",
-          "description": "Enable Percona PMM Query Analytics (QAN) for MongoDB. This feature uses query profiles to analyse MongoDB queries and commands",
-          "type": "boolean",
-          "default": true
-        },
-        "clientVersion": {
-          "title": "Percona PMM client version",
-          "description": "Percona PMM client version, currently only the versions displayed are supported!",
-          "type": "string",
-          "enum": [
-            "1.8.1"
-          ],
-          "default": "1.8.1"
-        },
-        "serverAddress": {
-          "title": "Percona PMM server address",
-          "description": "Percona PMM server address. Include a port number after a colon for non-standard ports, ie: 'pmm.my-domain.com:8080'",
-          "type": "string",
-          "default": "pmm-server.marathon.l4lb.thisdcos.directory:80"
-        },
-        "serverUseSSL": {
-          "title": "Use SSL connections",
-          "description": "Use SSL for communication with the PMM server",
-          "type": "boolean",
-          "default": false
-        },
-        "serverUseInsecureSSL": {
-          "title": "Use Insecure SSL connections",
-          "description": "Use SSL without validation for communication with the PMM server",
-          "type": "boolean",
-          "default": false
-        },
-        "serverUser": {
-          "title": "PMM Server username",
-          "description": "Username to be used for connections to the PMM Server. Automatically enables authentication",
-          "type": "string",
-          "default": ""
-        },
-        "serverPassword": {
-          "title": "PMM Server password",
-          "description": "Password to be used for connections to the PMM Server. A PMM Server username is required",
-          "type": "string",
-          "default": ""
-        },
-        "linuxMetricsExporterPort": {
-          "title": "PMM Client Linux metrics port",
-          "description": "Port to run the Linux operating system metrics exporter on, default of '0' will use a random, available port (recommended)",
-          "type": "integer",
-          "default": 0
-        },
-        "mongodbMetricsExporterPort": {
-          "title": "PMM Client MongoDB metrics port",
-          "description": "Port to run the MongoDB database metrics exporter on, default of '0' will use a random, available port (recommended)",
-          "type": "integer",
-          "default": 0
-        }
-      },
-      "required": [
-        "enabled",
-        "enableQueryAnalytics",
-        "clientVersion",
-        "serverAddress",
-        "serverUseSSL",
-        "serverUseInsecureSSL",
-        "linuxMetricsExporterPort",
-        "mongodbMetricsExporterPort"
+        "mem",
+        "init"
       ]
     }
   }
--- 1/marathon.json.mustache
+++ 100/marathon.json.mustache
@@ -3,7 +3,7 @@
   "cpus": 1.0,
   "mem": 1024,
   "instances": 1,
-  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jre*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./mongo-scheduler/bin/mongo ./mongo-scheduler/svc.yml",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH &&  export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" &&  ./mongo-scheduler/bin/dcos-mongo ./mongo-scheduler/svc.yml",
   "labels": {
     "DCOS_COMMONS_API_VERSION": "v1",
     "DCOS_COMMONS_UNINSTALL": "true",
@@ -22,18 +22,25 @@
   {{/service.secret_name}}
   "env": {
     "PACKAGE_NAME": "percona-mongo",
-    "PACKAGE_VERSION": "0.2.0-3.4.13",
-    "PACKAGE_BUILD_TIME_EPOCH_MS": "1522411894991",
-    "PACKAGE_BUILD_TIME_STR": "Fri Mar 30 2018 12:11:34 +0000",
+    "PACKAGE_VERSION": "0.3.0-3.6.5",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1533048791323",
+    "PACKAGE_BUILD_TIME_STR": "Tue Jul 31 2018 14:53:11 +0000",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
     "FRAMEWORK_NAME": "{{service.name}}",
     "SLEEP_DURATION": "{{service.sleep}}",
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_PRINCIPAL": "{{service.principal}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
-
-    "CONFIG_TEMPLATE_PATH": "mongo-scheduler",
+    "FRAMEWORK_HOST": "{{service.name}}.autoip.dcos.thisdcos.directory",
+
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     "MONGODB_TOOLS_URI": "{{resource.assets.uris.mongodb-tools-zip}}",
+    "MONGODB_TOOLS_ADMIN_URI": "{{resource.assets.uris.mongodb-tools-admin-zip}}",
+    "RESTORE_S3_CLI_URI": "{{resource.assets.uris.s3-cli-tar-gz}}",
+    "RESTORE_SCRIPT_URI": "{{resource.assets.uris.restore-s3-sh}}",
+    "PSMDB_DOCKER_IMAGE": "{{resource.assets.container.docker.percona-server-mongodb}}",
+    "ADMIN_DOCKER_IMAGE": "{{resource.assets.container.docker.admin}}",
+    "MCB_DOCKER_IMAGE": "{{resource.assets.container.docker.mongodb-consistent-backup}}",
 
     "MONGODB_PORT": "{{mongodb.port}}",
     "MONGODB_COUNT": "{{mongodb.count}}",
@@ -42,78 +49,95 @@
     "MONGODB_DISK_SIZE": "{{mongodb.disk}}",
     "MONGODB_DISK_TYPE": "{{mongodb.diskType}}",
     "MONGODB_REPLSET": "{{mongodb.replicaSetName}}",
-    "MONGODB_USER_ADMIN_USER": "{{mongodb.userAdminUser}}",
-    "MONGODB_USER_ADMIN_PASSWORD": "{{mongodb.userAdminPassword}}",
-    "MONGODB_CLUSTER_ADMIN_USER": "{{mongodb.clusterAdminUser}}",
-    "MONGODB_CLUSTER_ADMIN_PASSWORD": "{{mongodb.clusterAdminPassword}}",
-    "MONGODB_BACKUP_USER": "{{mongodb.backupUser}}",
-    "MONGODB_BACKUP_PASSWORD": "{{mongodb.backupPassword}}",
-    "MONGODB_CLUSTER_MONITOR_USER": "{{mongodb.clusterMonitorUser}}",
-    "MONGODB_CLUSTER_MONITOR_PASSWORD": "{{mongodb.clusterMonitorPassword}}",
-    "MONGODB_KEY": "{{mongodb.key}}",
-    {{#mongodb.constraint}}
-        "MONGODB_CONSTRAINT": "{{mongodb.constraint}}",
-    {{/mongodb.constraint}}
-    "MONGODB_VERSION": "{{mongodb.version}}",
+    "MONGODB_USER_ADMIN_USER": "{{mongodb-credentials.userAdminUser}}",
+    "MONGODB_USER_ADMIN_PASSWORD": "{{mongodb-credentials.userAdminPassword}}",
+    "MONGODB_CLUSTER_ADMIN_USER": "{{mongodb-credentials.clusterAdminUser}}",
+    "MONGODB_CLUSTER_ADMIN_PASSWORD": "{{mongodb-credentials.clusterAdminPassword}}",
+    "MONGODB_BACKUP_USER": "{{mongodb-credentials.backupUser}}",
+    "MONGODB_BACKUP_PASSWORD": "{{mongodb-credentials.backupPassword}}",
+    "MONGODB_CLUSTER_MONITOR_USER": "{{mongodb-credentials.clusterMonitorUser}}",
+    "MONGODB_CLUSTER_MONITOR_PASSWORD": "{{mongodb-credentials.clusterMonitorPassword}}",
+    "MONGODB_KEY": "{{mongodb-credentials.key}}",
+    {{#mongodb.placement.constraint}}
+        "MONGODB_NODE_PLACEMENT": "{{{mongodb.placement.constraint}}}",
+    {{/mongodb.placement.constraint}}
+
     "MONGODB_STORAGE_ENGINE": "{{mongodb.storageEngine}}",
 
-    "MONGODB_NOFILE_LIMIT": "{{mongodb-advanced.openFileLimit}}",
-    "MONGODB_NPROC_LIMIT": "{{mongodb-advanced.processLimit}}",
-    
-    "MONGODB_SECURITY_JAVASCRIPT_ENABLED": "{{mongodb-advanced.securityJavascriptEnabled}}",
-    "MONGODB_SECURITY_REDACT_CLIENT_LOG_DATA": "{{mongodb-advanced.securityRedactClientLogData}}",
-
-    "MONGODB_STORAGE_INDEX_BUILD_RETRY": "{{mongodb-advanced.storageIndexBuildRetry}}",
-    "MONGODB_STORAGE_JOURNAL_COMMIT_INTERVAL_MS": "{{mongodb-advanced.storageJournalCommitIntervalMs}}",
-    "MONGODB_STORAGE_DIRECTORY_PER_DB": "{{mongodb-advanced.storageDirectoryPerDB}}",
-    "MONGODB_STORAGE_SYNC_PERIOD_SECS": "{{mongodb-advanced.storageSyncPeriodSecs}}",
-
-    "MONGODB_STORAGE_MMAPV1_PREALLOC_DATA_FILES": "{{mongodb-advanced.storageMMAPv1PreallocDataFiles}}",
-    "MONGODB_STORAGE_MMAPV1_NS_SIZE": "{{mongodb-advanced.storageMMAPv1NsSize}}",
-    "MONGODB_STORAGE_MMAPV1_QUOTA_ENFORCED": "{{mongodb-advanced.storageMMAPv1QuotaEnforced}}",
-    "MONGODB_STORAGE_MMAPV1_MAX_FILES_PER_DB": "{{mongodb-advanced.storageMMAPv1QuotaMaxFilesPerDB}}",
-    "MONGODB_STORAGE_MMAPV1_SMALLFILES": "{{mongodb-advanced.storageMMAPv1SmallFiles}}",
-
-    "MONGODB_STORAGE_WIREDTIGER_ENGINE_CONFIG_CACHE_SIZE_GB": "{{mongodb-advanced.storageWiredTigerEngineConfigCacheSizeGB}}",
-    "MONGODB_STORAGE_WIREDTIGER_ENGINE_CONFIG_JOURNAL_COMPRESSOR": "{{mongodb-advanced.storageWiredTigerEngineConfigJournalCompressor}}",
-    "MONGODB_STORAGE_WIREDTIGER_ENGINE_CONFIG_DIRECTORY_FOR_INDEXES": "{{mongodb-advanced.storageWiredTigerEngineConfigDirectoryForIndexes}}",
-    "MONGODB_STORAGE_WIREDTIGER_COLLECTION_CONFIG_BLOCK_COMPRESSOR": "{{mongodb-advanced.storageWiredTigerCollectionConfigBlockCompressor}}",
-    "MONGODB_STORAGE_WIREDTIGER_INDEX_CONFIG_PREFIX_COMPRESSION": "{{mongodb-advanced.storageWiredTigerIndexConfigPrefixCompression}}",
-
-    "MONGODB_STORAGE_ROCKSDB_CACHE_SIZE_GB": "{{mongodb-advanced.storageRocksDBCacheSizeGB}}",
-    "MONGODB_STORAGE_ROCKSDB_COMPRESSION": "{{mongodb-advanced.storageRocksDBCompression}}",
-    "MONGODB_STORAGE_ROCKSDB_WRITE_MB_PER_SEC": "{{mongodb-advanced.storageRocksDBMaxWriteMBPerSec}}",
-    "MONGODB_STORAGE_ROCKSDB_CRASH_SAFE_COUNTERS": "{{mongodb-advanced.storageRocksDBCrashSafeCounters}}",
-
-    "MONGODB_SET_PARAMETER_AUDIT_AUTHORIZATION_SUCCESS": "{{mongodb-auditlog.auditAuthorizationSuccess}}",
-    "MONGODB_SET_PARAMETER_FAIL_INDEX_KEY_TOO_LONG": "{{mongodb-advanced.setParameterFailIndexKeyTooLong}}",
-    "MONGODB_SET_PARAMETER_NO_TABLE_SCAN": "{{mongodb-advanced.setParameterNoTableScan}}",
-    "MONGODB_SET_PARAMETER_DISABLE_JAVASCRIPT_JIT": "{{mongodb-advanced.setParameterDisableJavaScriptJIT}}",
-    "MONGODB_SET_PARAMETER_MAX_INDEX_BUILD_MEMORY_USAGE_MB": "{{mongodb-advanced.setParameterMaxIndexBuildMemoryUsageMB}}",
-    "MONGODB_SET_PARAMETER_LOG_USER_IDS": "{{mongodb-advanced.setParameterLogUserIds}}",
-    "MONGODB_SET_PARAMETER_REPL_WRITER_THREAD_COUNT": "{{mongodb-advanced.setParameterReplWriterThreadCount}}",
-    "MONGODB_SET_PARAMETER_TTL_MONITOR_ENABLED": "{{mongodb-advanced.setParameterTTLMonitorEnabled}}",
-    "MONGODB_SET_PARAMETER_TTL_MONITOR_SLEEP_SECS": "{{mongodb-advanced.setParameterTTLMonitorSleepSecs}}",
-    "MONGODB_SET_PARAMETER_ROCKSDB_CONCURRENT_READ_TRANSACTIONS": "{{mongodb-advanced.setParameterRocksDBConcurrentReadTransactions}}",
-    "MONGODB_SET_PARAMETER_ROCKSDB_CONCURRENT_WRITE_TRANSACTIONS": "{{mongodb-advanced.setParameterRocksDBConcurrentWriteTransactions}}",
-    "MONGODB_SET_PARAMETER_WIREDTIGER_CONCURRENT_READ_TRANSACTIONS": "{{mongodb-advanced.setParameterWiredTigerConcurrentReadTransactions}}",
-    "MONGODB_SET_PARAMETER_WIREDTIGER_CONCURRENT_WRITE_TRANSACTIONS": "{{mongodb-advanced.setParameterWiredTigerConcurrentWriteTransactions}}",
-
-    "MONGODB_NET_MAX_INCOMING_CONNECTIONS": "{{mongodb-advanced.netMaxIncomingConnections}}",
-
-    "MONGODB_OPERATION_PROFILING_MODE": "{{mongodb-advanced.operationProfilingMode}}",
-    "MONGODB_OPERATION_PROFILING_SLOWOP_THRESHOLD_MS": "{{mongodb-advanced.operationProfilingSlowOpThresholdMs}}",
-    "MONGODB_OPERATION_PROFILING_RATE_LIMIT": "{{mongodb-advanced.operationProfilingRateLimit}}",
-
-    "MONGODB_REPLICATION_SECONDARY_INDEX_PREFETCH": "{{mongodb-advanced.replicationSecondaryIndexPrefetch}}",
-    "MONGODB_REPLICATION_ENABLE_MAJORITY_READ_CONCERN": "{{mongodb-advanced.replicationEnableMajorityReadConcern}}",
-
-    "MONGODB_AUDIT_LOG_ENABLED": "{{mongodb-auditlog.enabled}}",
-    "MONGODB_AUDIT_LOG_FILTER": "{{mongodb-auditlog.filter}}",
-
-    "MONGODB_SYSTEM_LOG_VERBOSITY": "{{mongodb-advanced.systemLogVerbosity}}",
-    "MONGODB_SYSTEM_LOG_TRACE_ALL_EXCEPTIONS": "{{mongodb-advanced.systemTraceAllExceptions}}",
-    "MONGODB_SYSTEM_LOG_TIMESTAMP_FORMAT": "{{mongodb-advanced.systemLogTimestampFormat}}",
+    "MONGODB_NOFILE_LIMIT": "{{mongodb-advanced.container.openFileLimit}}",
+    "MONGODB_NPROC_LIMIT": "{{mongodb-advanced.container.processLimit}}",
+
+    "MONGODB_SECURITY_REDACT_CLIENT_LOG_DATA": "{{mongodb-advanced.security.redactClientLogData}}",
+
+    "MONGODB_STORAGE_INDEX_BUILD_RETRY": "{{mongodb-advanced.storage.indexBuildRetry}}",
+    "MONGODB_STORAGE_JOURNAL_ENABLED": "{{mongodb-advanced.storage.journal.enabled}}",
+    "MONGODB_STORAGE_JOURNAL_COMMIT_INTERVAL_MS": "{{mongodb-advanced.storage.journal.commitIntervalMs}}",
+    "MONGODB_STORAGE_DIRECTORY_PER_DB": "{{mongodb-advanced.storage.directoryPerDB}}",
+    "MONGODB_STORAGE_SYNC_PERIOD_SECS": "{{mongodb-advanced.storage.syncPeriodSecs}}",
+
+    "MONGODB_STORAGE_MMAPV1_PREALLOC_DATA_FILES": "{{mongodb-advanced.storage.mmapv1.preallocDataFiles}}",
+    "MONGODB_STORAGE_MMAPV1_NS_SIZE": "{{mongodb-advanced.storage.mmapv1.nsSize}}",
+    "MONGODB_STORAGE_MMAPV1_QUOTA_ENFORCED": "{{mongodb-advanced.storage.mmapv1.quotaEnforced}}",
+    "MONGODB_STORAGE_MMAPV1_MAX_FILES_PER_DB": "{{mongodb-advanced.storage.mmapv1.quotaMaxFilesPerDB}}",
+    "MONGODB_STORAGE_MMAPV1_SMALLFILES": "{{mongodb-advanced.storage.mmapv1.smallFiles}}",
+
+    "MONGODB_STORAGE_WIREDTIGER_ENGINE_CONFIG_JOURNAL_COMPRESSOR": "{{mongodb-advanced.storage.wiredTiger.engineConfigJournalCompressor}}",
+    "MONGODB_STORAGE_WIREDTIGER_ENGINE_CONFIG_DIRECTORY_FOR_INDEXES": "{{mongodb-advanced.storage.wiredTiger.engineConfigDirectoryForIndexes}}",
+    "MONGODB_STORAGE_WIREDTIGER_COLLECTION_CONFIG_BLOCK_COMPRESSOR": "{{mongodb-advanced.storage.wiredTiger.collectionConfigBlockCompressor}}",
+    "MONGODB_STORAGE_WIREDTIGER_INDEX_CONFIG_PREFIX_COMPRESSION": "{{mongodb-advanced.storage.wiredTiger.indexConfigPrefixCompression}}",
+
+    "MONGODB_SET_PARAMETER_AUDIT_AUTHORIZATION_SUCCESS": "{{mongodb-advanced.auditLog.auditAuthorizationSuccess}}",
+    "MONGODB_SET_PARAMETER_FAIL_INDEX_KEY_TOO_LONG": "{{mongodb-advanced.setParameter.failIndexKeyTooLong}}",
+    "MONGODB_SET_PARAMETER_MAX_INDEX_BUILD_MEMORY_USAGE_MB": "{{mongodb-advanced.setParameter.maxIndexBuildMemoryUsageMB}}",
+    "MONGODB_SET_PARAMETER_LOG_USER_IDS": "{{mongodb-advanced.setParameter.logUserIds}}",
+    "MONGODB_SET_PARAMETER_TTL_MONITOR_ENABLED": "{{mongodb-advanced.setParameter.ttlMonitorEnabled}}",
+    "MONGODB_SET_PARAMETER_TTL_MONITOR_SLEEP_SECS": "{{mongodb-advanced.setParameter.ttlMonitorSleepSecs}}",
+    "MONGODB_SET_PARAMETER_WIREDTIGER_CONCURRENT_READ_TRANSACTIONS": "{{mongodb-advanced.setParameter.wiredTigerConcurrentReadTransactions}}",
+    "MONGODB_SET_PARAMETER_WIREDTIGER_CONCURRENT_WRITE_TRANSACTIONS": "{{mongodb-advanced.setParameter.wiredTigerConcurrentWriteTransactions}}",
+
+    "MONGODB_NET_MAX_INCOMING_CONNECTIONS": "{{mongodb-advanced.net.maxIncomingConnections}}",
+    "MONGODB_NET_TRANSPORT_LAYER": "{{mongodb-advanced.net.transportLayer}}",
+    "MONGODB_NET_SERVICE_EXECUTOR": "{{mongodb-advanced.net.serviceExecutor}}",
+
+    {{#mongodb-ssl.enabled}}
+    "MONGODB_NET_SSL_ENABLED": "{{mongodb-ssl.enabled}}",
+    {{#mongodb-ssl.name}}
+    "MONGODB_SSL_NAME": "{{mongodb-ssl.name}}",
+    "MONGODB_NET_SSL_PEM_KEY_FILE": "{{mongodb-ssl.name}}.pem",
+    "MONGODB_NET_SSL_CA_FILE": "{{mongodb-ssl.name}}.ca",
+    {{/mongodb-ssl.name}}
+    {{^mongodb-ssl.name}}
+    "MONGODB_SSL_NAME": "mongodb_{{service.name}}_{{mongodb.replicaSetName}}",
+    "MONGODB_NET_SSL_PEM_KEY_FILE": "mongodb_{{service.name}}_{{mongodb.replicaSetName}}.pem",
+    "MONGODB_NET_SSL_CA_FILE": "mongodb_{{service.name}}_{{mongodb.replicaSetName}}.ca",
+    {{/mongodb-ssl.name}}
+    "MONGODB_NET_SSL_MODE": "{{mongodb-ssl.mode}}",
+    "MONGODB_NET_SSL_ALLOW_CONNECTIONS_WITHOUT_CERTIFICATES": "{{mongodb-ssl.allowConnectionsWithoutCertificates}}",
+    "MONGODB_NET_SSL_ALLOW_INVALID_CERTIFICATES": "{{mongodb-ssl.allowInvalidCertificates}}",
+    "MONGODB_NET_SSL_ALLOW_INVALID_HOSTNAMES": "{{mongodb-ssl.allowInvalidHostnames}}",
+    "MONGODB_NET_SSL_DISABLED_PROTOCOLS": "{{mongodb-ssl.disabledProtocols}}",
+    {{#mongodb-ssl.allowInvalidCertificates}}
+    "MONGODB_NET_SSL_INSECURE": "true",
+    {{/mongodb-ssl.allowInvalidCertificates}}
+    {{^mongodb-ssl.allowInvalidCertificates}}
+    {{#mongodb-ssl.allowInvalidHostnames}}
+    "MONGODB_NET_SSL_INSECURE": "true",
+    {{/mongodb-ssl.allowInvalidHostnames}}
+    {{/mongodb-ssl.allowInvalidCertificates}}
+    {{/mongodb-ssl.enabled}}
+
+    "MONGODB_OPERATION_PROFILING_MODE": "{{mongodb-advanced.operationProfiling.mode}}",
+    "MONGODB_OPERATION_PROFILING_SLOWOP_THRESHOLD_MS": "{{mongodb-advanced.operationProfiling.slowOpThresholdMs}}",
+    "MONGODB_OPERATION_PROFILING_RATE_LIMIT": "{{mongodb-advanced.operationProfiling.rateLimit}}",
+
+    "MONGODB_REPLICATION_SECONDARY_INDEX_PREFETCH": "{{mongodb-advanced.replication.secondaryIndexPrefetch}}",
+
+    "MONGODB_AUDIT_LOG_ENABLED": "{{mongodb-advanced.auditLog.enabled}}",
+    "MONGODB_AUDIT_LOG_FILTER": "{{mongodb-advanced.auditLog.filter}}",
+
+    "MONGODB_SYSTEM_LOG_VERBOSITY": "{{mongodb-advanced.systemLog.verbosity}}",
+    "MONGODB_SYSTEM_LOG_TRACE_ALL_EXCEPTIONS": "{{mongodb-advanced.systemLog.traceAllExceptions}}",
+    "MONGODB_SYSTEM_LOG_TIMESTAMP_FORMAT": "{{mongodb-advanced.systemLog.timestampFormat}}",
 
     {{#service.virtual_networks}}
     "ENABLE_VIRTUAL_NETWORK": "yes",
@@ -121,56 +145,46 @@
     "CNI_PLUGIN_LABELS": "{{node.cni_plugin_labels}}",
     {{/service.virtual_networks}}
 
-    "INIT_CPUS": "{{init.cpus}}",
-    "INIT_MEM": "{{init.mem}}",
-    "INIT_INITIATE_DELAY": "{{init.initiateDelay}}",
-    "INIT_MAX_CONNECT_TRIES": "{{init.maxConnectTries}}",
-    "INIT_MAX_INIT_REPLSET_TRIES": "{{init.maxInitReplsetTries}}",
-    "INIT_MAX_ADD_USERS_TRIES": "{{init.maxAddUsersTries}}",
-    "INIT_RETRY_SLEEP": "{{init.retrySleep}}",
-
-    "WATCHDOG_CPUS": "{{watchdog.cpus}}",
-    "WATCHDOG_MEM": "{{watchdog.mem}}",
-    "WATCHDOG_API_TIMEOUT": "{{watchdog.apiTimeout}}",
-    "WATCHDOG_API_POLL": "{{watchdog.apiPoll}}",
-    "WATCHDOG_REPLSET_TIMEOUT": "{{watchdog.replsetTimeout}}",
-    "WATCHDOG_REPLSET_POLL": "{{watchdog.replsetPoll}}",
-    "WATCHDOG_REPLSET_CONF_UPDATE_POLL": "{{watchdog.replsetConfUpdatePoll}}",
-    "WATCHDOG_DELAY_WATCHER_START": "{{watchdog.delayWatcherStart}}",
-
-    "BACKUP_ENABLED": "{{backup.enabled}}",
-    {{#backup.enabled}}
-    "BACKUP_HIDDEN_SECONDARY_ENABLED": "{{backup.hiddenSecondaryEnabled}}",
-    "BACKUP_HIDDEN_SECONDARY_CPUS": "{{backup.hiddenSecondaryCpus}}",
-    "BACKUP_HIDDEN_SECONDARY_MEM": "{{backup.hiddenSecondaryMem}}",
-    "BACKUP_CPUS": "{{backup.backupCpus}}",
-    "BACKUP_MEM": "{{backup.backupMem}}",
-    "BACKUP_VERSION": "{{backup.backupVersion}}",
-    "BACKUP_VERBOSE": "{{backup.verbose}}",
-    "BACKUP_ARCHIVE_METHOD": "{{backup.archiveMethod}}",
-    "BACKUP_UPLOAD_THREADS": "{{backup.uploadThreads}}",
-    "BACKUP_UPLOAD_RETRIES": "{{backup.uploadRetries}}",
-    "BACKUP_UPLOAD_S3_REGION": "{{backup.uploadS3Region}}",
-    "BACKUP_UPLOAD_S3_ACCESS_KEY": "{{backup.uploadS3AccessKey}}",
-    "BACKUP_UPLOAD_S3_SECRET_KEY": "{{backup.uploadS3SecretKey}}",
-    "BACKUP_UPLOAD_S3_BUCKET_NAME": "{{backup.uploadS3BucketName}}",
-    "BACKUP_UPLOAD_S3_BUCKET_PREFIX": "{{backup.uploadS3BucketPrefix}}",
-    "BACKUP_UPLOAD_S3_OBJECT_ACL": "{{backup.uploadS3ObjectACL}}",
-    "BACKUP_UPLOAD_S3_CHUNK_SIZE_MB": "{{backup.uploadS3UploadChunkSizeMb}}",
-    {{/backup.enabled}}
-
-    "PMM_ENABLED": "{{percona-pmm.enabled}}",
-    {{#percona-pmm.enabled}}
-    "PMM_ENABLE_QUERY_ANALYTICS": "{{percona-pmm.enableQueryAnalytics}}",
-    "PMM_CLIENT_VERSION": "{{percona-pmm.clientVersion}}",
-    "PMM_SERVER_ADDRESS": "{{percona-pmm.serverAddress}}",
-    "PMM_SERVER_USE_SSL": "{{percona-pmm.serverUseSSL}}",
-    "PMM_SERVER_USE_INSECURE_SSL": "{{percona-pmm.serverUseInsecureSSL}}",
-    "PMM_SERVER_USER": "{{percona-pmm.serverUser}}",
-    "PMM_SERVER_PASSWORD": "{{percona-pmm.serverPassword}}",
-    "PMM_LINUX_METRICS_EXPORTER_PORT": "{{percona-pmm.linuxMetricsExporterPort}}",
-    "PMM_MONGODB_METRICS_EXPORTER_PORT": "{{percona-pmm.mongodbMetricsExporterPort}}",
-    {{/percona-pmm.enabled}}
+    "ADMIN_CPUS": "{{admin.cpus}}",
+    "ADMIN_MEM": "{{admin.mem}}",
+    "INIT_INITIATE_DELAY": "{{admin.init.initiateDelay}}",
+    "INIT_MAX_CONNECT_TRIES": "{{admin.init.maxConnectTries}}",
+    "INIT_MAX_INIT_REPLSET_TRIES": "{{admin.init.maxInitReplsetTries}}",
+    "INIT_MAX_ADD_USERS_TRIES": "{{admin.init.maxAddUsersTries}}",
+    "INIT_RETRY_SLEEP": "{{admin.init.retrySleep}}",
+    "WATCHDOG_API_TIMEOUT": "{{admin.watchdog.apiTimeout}}",
+    "WATCHDOG_API_POLL": "{{admin.watchdog.apiPoll}}",
+    "WATCHDOG_REPLSET_TIMEOUT": "{{admin.watchdog.replsetTimeout}}",
+    "WATCHDOG_REPLSET_POLL": "{{admin.watchdog.replsetPoll}}",
+    "WATCHDOG_METRICS_PORT": "{{admin.watchdog.metricsPort}}",
+
+    "BACKUP_RESTORE_S3_REGION": "{{backup-restore.s3.region}}",
+    "BACKUP_RESTORE_S3_ACCESS_KEY": "{{backup-restore.s3.accessKey}}",
+    "BACKUP_RESTORE_S3_SECRET_KEY": "{{backup-restore.s3.secretKey}}",
+
+    "BACKUP_CPUS": "{{backup-restore.cpus}}",
+    "BACKUP_MEM": "{{backup-restore.mem}}",
+    "BACKUP_HIDDEN_SECONDARY_ENABLED": "{{backup-restore.hiddenSecondary.enabled}}",
+    "BACKUP_HIDDEN_SECONDARY_CPUS": "{{backup-restore.hiddenSecondary.cpus}}",
+    "BACKUP_HIDDEN_SECONDARY_MEM": "{{backup-restore.hiddenSecondary.mem}}",
+    "BACKUP_VERBOSE": "{{backup-restore.backup.verbose}}",
+    "BACKUP_UPLOAD_THREADS": "{{backup-restore.backup.upload.threads}}",
+    "BACKUP_UPLOAD_RETRIES": "{{backup-restore.backup.upload.retries}}",
+    "BACKUP_UPLOAD_S3_CHUNK_SIZE_MB": "{{backup-restore.backup.upload.s3chunkSizeMb}}",
+    "BACKUP_UPLOAD_S3_BUCKET_NAME": "{{backup-restore.backup.upload.s3bucketName}}",
+    "BACKUP_UPLOAD_S3_BUCKET_PREFIX": "{{backup-restore.backup.upload.s3bucketPrefix}}",
+
+    "RESTORE_S3_URL": "{{backup-restore.restore.s3Url}}",
+    "RESTORE_AFTER_INIT": "{{backup-restore.restore.restoreAfterInit}}",
+    "RESTORE_GZIP_ENABLED": "{{backup-restore.restore.gzip}}",
+    "RESTORE_OPLOG_REPLAY": "{{backup-restore.restore.oplogReplay}}",
+    "RESTORE_DROP_COLLECTIONS": "{{backup-restore.restore.dropCollections}}",
+    "RESTORE_NUM_PARALLEL_COLLECTIONS": "{{backup-restore.restore.numParallelCollections}}",
+
+    "PMM_ENABLED": "false",
+
+    "DCOS_METRICS_ENABLED": "{{dcos-metrics.enabled}}",
+    "DCOS_METRICS_INTERVAL_SECS": "{{dcos-metrics.intervalSecs}}",
 
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
@@ -185,8 +199,7 @@
     "{{resource.assets.uris.jre-tar-gz}}",
     "{{resource.assets.uris.scheduler-zip}}",
     "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
-    "{{resource.assets.uris.bootstrap-zip}}",
-    "{{resource.assets.uris.mongodb-tools-zip}}"
+    "{{resource.assets.uris.bootstrap-zip}}"
   ],
   "upgradeStrategy":{
     "minimumHealthCapacity": 0,
--- 1/package.json
+++ 100/package.json
@@ -1,25 +1,25 @@
 {
-    "packagingVersion": "4.0",
-    "upgradesFrom": [
-        "*"
-    ],
-    "downgradesTo": [
-        "*"
-    ],
-    "minDcosReleaseVersion": "1.10",
-    "name": "percona-mongo",
-    "version": "0.2.0-3.4.13",
-    "maintainer": "mesosphere@percona.com",
-    "description": "Percona Server for MongoDB Replica Set on Mesosphere DC/OS",
-    "selected": false,
-    "framework": true,
-    "tags": [
-        "mongo",
-        "mongodb",
-        "percona",
-        "nosql"
-    ],
-    "postInstallNotes": "The DC/OS Mongo service is being installed. \n\n\tDocumentation: https://docs.mesosphere.com/service-docs/percona-mongo/\n\tIssues: mesosphere@percona.com",
-    "postUninstallNotes": "DC/OS Mongo is being uninstalled.",
-    "preInstallNotes": "Default configuration requires 3 agent nodes each with: 1.0 CPU | 1024 MB MEM | 1 1000 MB Disk"
-}
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "0.2.0-3.4.13"
+  ],
+  "downgradesTo": [
+    "0.2.0-3.4.13"
+  ],
+  "minDcosReleaseVersion": "1.10",
+  "name": "percona-mongo",
+  "version": "0.3.0-3.6.5",
+  "maintainer": "mesosphere@percona.com",
+  "description": "Percona Server for MongoDB Replica Set on Mesosphere DC/OS",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "mongo",
+    "mongodb",
+    "percona",
+    "nosql"
+  ],
+  "postInstallNotes": "The DC/OS Mongo service is being installed. \n\n\tDocumentation: https://docs.mesosphere.com/service-docs/percona-mongo/\n\tIssues: mesosphere@percona.com",
+  "postUninstallNotes": "DC/OS Mongo is being uninstalled.",
+  "preInstallNotes": "Default configuration requires 3 agent nodes each with: 1.0 CPU | 1024 MB MEM | 1 1000 MB Disk"
+}--- 1/resource.json
+++ 100/resource.json
@@ -1,12 +1,22 @@
 {
   "assets": {
+    "container": {
+      "docker": {
+        "percona-server-mongodb": "percona/percona-server-mongodb:3.6.5",
+        "mongodb-consistent-backup": "perconalab/mongodb_consistent_backup:1.3.0-3.6",
+        "admin": "debian:jessie"
+      }
+    },
     "uris": {
-      "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz",
-      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
-      "scheduler-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/mongo-scheduler.zip",
-      "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.30.3/executor.zip",
-      "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.30.3/bootstrap.zip",
-      "mongodb-tools-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/mongodb-tools.zip"
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz",
+      "bootstrap-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip",
+      "scheduler-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/mongo-scheduler.zip",
+      "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip",
+      "mongodb-tools-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/mongodb-tools.zip",
+      "mongodb-tools-admin-zip": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/mongodb-tools-admin.zip",
+      "s3-cli-tar-gz": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/s3-cli.zip",
+      "restore-s3-sh": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/restore-s3.sh"
     }
   },
   "images": {
@@ -21,11 +31,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "dc1748bd88b423ea2632c034555024a5e579208f5766c345c04f555e7b5ba817"
+              "value": "a28b3735eb10c5f8f1cf8572b81494f74d72e5507f45ee8914ed3b559ac91309"
             }
           ],
           "kind": "executable",
-          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/dcos-service-cli-darwin"
+          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -33,11 +43,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "d17c2418988dabf056595e7280b754342064fbceb880d363121115c6524c614a"
+              "value": "bc737d25ba6776e87c800a950b8ae62dace0db68d514cfa7ba9c1bd0856cef19"
             }
           ],
           "kind": "executable",
-          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/dcos-service-cli-linux"
+          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -45,11 +55,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "d2aeddbd3e11c4c2fbba8cb538427a52eaf5b036ae638af928e8268ff9aa77b3"
+              "value": "839a35f4b0e8d25f2611ac0d482ec126738ad8858eabfb7421be033d30df4faa"
             }
           ],
           "kind": "executable",
-          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.2.0-3.4.13/dcos-service-cli.exe"
+          "url": "https://percona-dcos-mongo.s3.amazonaws.com/dcos-mongo/assets/0.3.0-3.6.5/dcos-service-cli.exe"
         }
       }
     }
```
