### PR TITLE
deprecate mongo packages in favor of percona-mongo

### DIFF
--- a/repo/packages/M/mongodb-admin/0/package.json
+++ b/repo/packages/M/mongodb-admin/0/package.json
@@ -1,6 +1,6 @@
 {
   "packagingVersion": "3.0",
-  "minDcosReleaseVersion": "1.7",
+  "minDcosReleaseVersion": "9999",
   "name": "mongodb-admin",
   "version": "0.0.20-0.1",
   "scm": "https://github.com/mrvautin/adminMongo",

--- a/repo/packages/M/mongodb-admin/1/package.json
+++ b/repo/packages/M/mongodb-admin/1/package.json
@@ -1,6 +1,6 @@
 {
   "packagingVersion": "3.0",
-  "minDcosReleaseVersion": "1.7",
+  "minDcosReleaseVersion": "9999",
   "name": "mongodb-admin",
   "version": "0.0.20-0.2",
   "scm": "https://github.com/mrvautin/adminMongo",

--- a/repo/packages/M/mongodb-replicaset/0/package.json
+++ b/repo/packages/M/mongodb-replicaset/0/package.json
@@ -12,7 +12,7 @@
   "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.",
   "postInstallNotes": "The MongoDB ReplicaSet service was installed!",
   "postUninstallNotes": "The MongoDB ReplicaSet service was unistalled!",
-  "minDcosReleaseVersion" : "1.8",
+  "minDcosReleaseVersion" : "9999",
   "licenses": [
     {
       "name": "MIT License",

--- a/repo/packages/M/mongodb/0/package.json
+++ b/repo/packages/M/mongodb/0/package.json
@@ -1,6 +1,6 @@
 {
   "packagingVersion": "3.0",
-  "minDcosReleaseVersion": "1.7",
+  "minDcosReleaseVersion": "9999",
   "name": "mongodb",
   "version": "3.2-0.1",
   "scm": "https://github.com/tutumcloud/tutum-docker-mongodb",

--- a/repo/packages/M/mongodb/1/package.json
+++ b/repo/packages/M/mongodb/1/package.json
@@ -1,6 +1,6 @@
 {
   "packagingVersion": "3.0",
-  "minDcosReleaseVersion": "1.7",
+  "minDcosReleaseVersion": "9999",
   "name": "mongodb",
   "version": "3.2-0.2",
   "scm": "https://github.com/tutumcloud/tutum-docker-mongodb",


### PR DESCRIPTION
these mongo packages were built by an SE and are not supported or maintained anymore. 
Deprecating in favour of `Percona-Mongo`