### PR TITLE
gen_universe.py should support older versions of python

### DIFF
--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -724,7 +724,8 @@ def _populate_dcos_version_json_to_folder(dcos_version, outdir):
     :return: None
     """
     repo_dir = outdir / dcos_version / 'package'
-    pathlib.Path(repo_dir).mkdir(parents=True, exist_ok=True)
+    pathlib.Path(repo_dir).rmdir()
+    pathlib.Path(repo_dir).mkdir(parents=True)
     repo_file = pathlib.Path(outdir / 'repo-up-to-{}.json'.format(dcos_version))
     with repo_file.open('r',  encoding='utf-8') as f:
         data = json.loads(f.read())

--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -38,6 +38,10 @@ def main():
         print('The path in --out-dir [{}] is not a directory. Please create it'
               ' before running this script.'.format(args.outdir))
         return
+    print('Paths present in [{}]: {}'.format(
+        str(args.outdir),
+        [str(p) for p in list(args.outdir.glob('*'))])
+    )
 
     if not args.repository.is_dir():
         print('The path in --repository [{}] is not a directory.'.format(
@@ -724,7 +728,10 @@ def _populate_dcos_version_json_to_folder(dcos_version, outdir):
     :return: None
     """
     repo_dir = outdir / dcos_version / 'package'
-    pathlib.Path(repo_dir).rmdir()
+    print('Paths present in [{}]: {}'.format(
+        str(repo_dir),
+        [str(p) for p in list(repo_dir.glob('*'))])
+    )
     pathlib.Path(repo_dir).mkdir(parents=True)
     repo_file = pathlib.Path(outdir / 'repo-up-to-{}.json'.format(dcos_version))
     with repo_file.open('r',  encoding='utf-8') as f:


### PR DESCRIPTION
Previous [commit to universe](https://github.com/mesosphere/universe/commit/31e06ce4a603abf5df38d6b8a001d3c0e17d33e7) broke for customers using older versions of python. 

I am not reverting the documentation note on min python being 3.5 to encourage people to use higher versions of python.