### PR TITLE
Updated CEREBRO_VERSION string to 0.7.2

### DIFF
--- a/repo/packages/C/cerebro/1/marathon.json.mustache
+++ b/repo/packages/C/cerebro/1/marathon.json.mustache
@@ -24,7 +24,7 @@
     "CEREBRO_LDAP_BASE": "{{authentication.ldap.base}}",
     "CEREBRO_LDAP_METHOD": "{{authentication.ldap.method}}",
     "CEREBRO_LDAP_DOMAIN": "{{authentication.ldap.domain}}",
-    "CEREBRO_VERSION": "0.7.1",
+    "CEREBRO_VERSION": "0.7.2",
     "ES_1": "{{elastic.cluster_1}}",
     "ES_2": "{{elastic.cluster_2}}",
     "ES_3": "{{elastic.cluster_3}}",


### PR DESCRIPTION
When this is set incorrect the cerebro package will fail to launch because this string is evaluated by the bootstrap.sh script and will cause a failure because it checks for a previous version:

```
I0807 12:40:08.788480     7 executor.cpp:651] Forked command at 12
sh: ./cerebro-0.7.1/bin/cerebro: No such file or directory
I0807 12:40:08.872782     8 executor.cpp:938] Command exited with status 127 (pid: 12)
```
