### PR TITLE
Introduce the new dcos-core-cli package

### DIFF
--- a/repo/packages/D/dcos-core-cli/1000/package.json
+++ b/repo/packages/D/dcos-core-cli/1000/package.json
@@ -1,0 +1,10 @@
+{
+  "packagingVersion": "3.0",
+  "name": "dcos-core-cli",
+  "version": "0.5.11",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.10",
+  "description": "Core DC/OS CLI",
+  "tags": [ "mesosphere", "core", "plugin" ],
+  "selected": false
+}

--- a/repo/packages/D/dcos-core-cli/1000/resource.json
+++ b/repo/packages/D/dcos-core-cli/1000/resource.json
@@ -1,0 +1,45 @@
+{
+    "assets": {
+    },
+
+    "cli": {
+        "binaries": {
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "baf32537b6afd79a6b4a74140fe6a7efb1362e9c0b44bcbf2cc39587ed15956a"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/plugins/dcos-core-cli/0.5.11/linux/x86-64/dcos-core-cli.zip"
+                }
+            },
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "5e1ccb2930460db5c5ef55d9876e7d381ff13f317510242b8f8266e9a1aca47a"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/plugins/dcos-core-cli/0.5.11/darwin/x86-64/dcos-core-cli.zip"
+                }
+            },
+            "windows": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "96bf496790ff498c19424d2ea9b6252ccc613cf0896424bc5378ff464ccac5b0"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/plugins/dcos-core-cli/0.5.11/windows/x86-64/dcos-core-cli.zip"
+                }
+            }
+        }
+    }
+}

--- a/repo/packages/D/dcos-core-cli/1100/package.json
+++ b/repo/packages/D/dcos-core-cli/1100/package.json
@@ -1,0 +1,10 @@
+{
+  "packagingVersion": "3.0",
+  "name": "dcos-core-cli",
+  "version": "0.6.4",
+  "maintainer": "support@mesosphere.io",
+  "minDcosReleaseVersion": "1.11",
+  "description": "Core DC/OS CLI",
+  "tags": [ "mesosphere", "core", "plugin" ],
+  "selected": false
+}

--- a/repo/packages/D/dcos-core-cli/1100/resource.json
+++ b/repo/packages/D/dcos-core-cli/1100/resource.json
@@ -1,0 +1,45 @@
+{
+    "assets": {
+    },
+
+    "cli": {
+        "binaries": {
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "37b1dedb29d335c895ec3a5e39a740f8a1b57bc7a78397ec1927036fe580fe4d"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/plugins/dcos-core-cli/0.6.4/linux/x86-64/dcos-core-cli.zip"
+                }
+            },
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "f33ebf64739083a4ef22f5a759febe4182f69d07090b0cf354a4e182f4d953b7"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/plugins/dcos-core-cli/0.6.4/darwin/x86-64/dcos-core-cli.zip"
+                }
+            },
+            "windows": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "ac3ea915ebe70767d0463af3e3c2e1dd7cde26cf12fbdbf06057f1bede9b5791"
+                        }
+                    ],
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/plugins/dcos-core-cli/0.6.4/windows/x86-64/dcos-core-cli.zip"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
It contains the core subcommands (marathon, job, service, etc.).

It is part of our CLI refactoring which removes the need for user to switch to the correct CLI each time they attach to a different cluster.

The core commands are now tied to a DC/OS cluster, this is in line with the dcos-enterprise-cli package.

https://jira.mesosphere.com/browse/DCOS_OSS-3731