### PR TITLE
Deprecate 'percona-mongo' for rename to 'percona-server-mongodb'

### DIFF
--- a/repo/packages/P/percona-mongo/0/package.json
+++ b/repo/packages/P/percona-mongo/0/package.json
@@ -6,7 +6,7 @@
     "downgradesTo": [
         "*"
     ],
-    "minDcosReleaseVersion": "1.10",
+    "minDcosReleaseVersion": "9999",
     "name": "percona-mongo",
     "version": "0.1.0-3.4.10",
     "maintainer": "mesosphere@percona.com",

--- a/repo/packages/P/percona-mongo/1/package.json
+++ b/repo/packages/P/percona-mongo/1/package.json
@@ -6,7 +6,7 @@
     "downgradesTo": [
         "*"
     ],
-    "minDcosReleaseVersion": "1.10",
+    "minDcosReleaseVersion": "9999",
     "name": "percona-mongo",
     "version": "0.2.0-3.4.13",
     "maintainer": "mesosphere@percona.com",

--- a/repo/packages/P/percona-mongo/100/package.json
+++ b/repo/packages/P/percona-mongo/100/package.json
@@ -6,7 +6,7 @@
   "downgradesTo": [
     "0.2.0-3.4.13"
   ],
-  "minDcosReleaseVersion": "1.10",
+  "minDcosReleaseVersion": "9999",
   "name": "percona-mongo",
   "version": "0.3.0-3.6.5",
   "maintainer": "mesosphere@percona.com",

--- a/repo/packages/P/percona-mongo/200/package.json
+++ b/repo/packages/P/percona-mongo/200/package.json
@@ -6,7 +6,7 @@
   "downgradesTo": [
     "0.3.0-3.6.5"
   ],
-  "minDcosReleaseVersion": "1.10",
+  "minDcosReleaseVersion": "9999",
   "name": "percona-mongo",
   "version": "0.3.1-3.6.5",
   "maintainer": "mesosphere@percona.com",


### PR DESCRIPTION
This is part of the rename in https://github.com/mesosphere/universe/pull/1973.

Note: the current 'percona-mongo' beta-versions will be deprecated by this change.

CC @ryadav88