### PR TITLE
Release v5 package version

### DIFF
--- a/repo/meta/schema/vX-repo-definitions.json
+++ b/repo/meta/schema/vX-repo-definitions.json
@@ -603,7 +603,7 @@
       "packagingVersion": {
         "type": "string",
         "enum": [
-          "4.0"
+          "5.0"
         ]
       },
       "name": {


### PR DESCRIPTION
How I tested this change : 

Ran the following locally : 
```
env DOCKER_IMAGE=<custom_org> DOCKER_TAG=<custom_tag> ./docker/server/build.bash build
```
Used the generated marathon definition to create a universe server which was able to serve a v5 package.
