### PR TITLE
Revert setting selected=true for beta packages

### DIFF
--- a/repo/packages/B/beta-kubernetes/0/package.json
+++ b/repo/packages/B/beta-kubernetes/0/package.json
@@ -8,7 +8,7 @@
   "version": "2.0.0-1.12.0-beta",
   "maintainer": "support@mesosphere.com",
   "description": "Kubernetes",
-  "selected": true,
+  "selected": false,
   "framework": true,
   "tags": [
     "kubernetes"

--- a/repo/packages/B/beta-mke/0/package.json
+++ b/repo/packages/B/beta-mke/0/package.json
@@ -11,7 +11,7 @@
   "version": "2.0.0-1.12.0-beta",
   "maintainer": "support@mesosphere.io",
   "description": "Mesosphere Kubernetes Engine",
-  "selected": true,
+  "selected": false,
   "framework": true,
   "tags": [
     "kubernetes"


### PR DESCRIPTION
Revert https://github.com/mesosphere/universe/pull/1987#issuecomment-422229175 since I've learnt `beta-` packages shouldn't be `selected=true`.