### PR TITLE
prometheus add pushgateway resource

### DIFF
--- a/repo/packages/P/prometheus/1/marathon.json.mustache
+++ b/repo/packages/P/prometheus/1/marathon.json.mustache
@@ -47,7 +47,6 @@
     "NODE_DISK": "{{node.disk}}",
     "NODE_DISK_TYPE": "{{node.disk_type}}",
 
-    "PUSHGATEWAY_IMAGE": "{{resource.assets.container.docker.pushgateway}}",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
@@ -61,6 +60,7 @@
 
     "PROMETHEUS_URI": "{{resource.assets.uris.prometheus-tar-gz}}",
     "ALERTMANAGER_URI": "{{resource.assets.uris.alertmanager-tar-gz}}",
+    "PUSHGATEWAY_URI": "{{resource.assets.uris.pushgateway-tar-gz}}",
     "JQ_URI": "{{resource.assets.uris.jq}}",
     "DCOS_CLI_URI": "{{resource.assets.uris.dcos-cli}}",
 

--- a/repo/packages/P/prometheus/1/resource.json
+++ b/repo/packages/P/prometheus/1/resource.json
@@ -11,9 +11,10 @@
             "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip", 
             "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip", 
             "scheduler-zip": "https://ecosystem-repo.s3.amazonaws.com/sdk/artifacts/0.42.1/operator-scheduler.zip", 
-            "svc": "https://ecosystem-repo.s3.amazonaws.com/prometheus/artifacts/0.1.1-2.3.2/svc.yml", 
+            "svc": "https://gist.githubusercontent.com/joaohf/7369386d3fe80e838b07986f64aab923/raw/svc.yml",
             "prometheus-tar-gz": "https://github.com/prometheus/prometheus/releases/download/v2.3.2/prometheus-2.3.2.linux-amd64.tar.gz", 
             "alertmanager-tar-gz": "https://github.com/prometheus/alertmanager/releases/download/v0.15.1/alertmanager-0.15.1.linux-amd64.tar.gz", 
+            "pushgateway-tar-gz": "https://github.com/prometheus/pushgateway/releases/download/v0.6.0/pushgateway-0.6.0.linux-amd64.tar.gz",
             "jq": "https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64", 
             "dcos-cli": "https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.11/dcos"
         }


### PR DESCRIPTION
This PR uses the svc.yml from https://gist.githubusercontent.com/joaohf/7369386d3fe80e838b07986f64aab923/raw/svc.yml

The main purpose here is to run pushgateway in the same way done with alertmanager and prometheus

I've tested using dcos 1.11.6