### PR TITLE
Bump converter resources

### DIFF
--- a/converter/marathon.json
+++ b/converter/marathon.json
@@ -11,7 +11,7 @@
     }
   },
   "env": {
-    "MAX_REPO_SIZE": "20",
+    "MAX_REPO_SIZE": "10",
     "LOGLEVEL": "INFO"
   },
   "networks": [

--- a/converter/marathon.json
+++ b/converter/marathon.json
@@ -1,8 +1,8 @@
 {
   "id": "/transform",
-  "instances": 1,
-  "cpus": 0.25,
-  "mem": 128,
+  "instances": 3,
+  "cpus": 1,
+  "mem": 4096,
   "requirePorts": true,
   "container": {
     "type": "DOCKER",


### PR DESCRIPTION
This PR does a couple of things:

- Increases the resource requirements for converter task. This was needed to address 
```
Task id
transform.ab011d87-c5a6-11e8-8f1d-f23923e2dd2d
State
TASK_FAILED
Message
Memory limit exceeded: Requested: 160MB Maximum Used: 160MB MEMORY STATISTICS: cache 0 rss 167772160 rss_huge 0 mapped_file 0 swap 0 pgpgin 9798832 pgpgout 9757872 pgfault 7577422 pgmajfault 24 inactive_anon 0 active_anon 167723008 inactive_file 0 active_file 0 unevictable 0 hierarchical_memory_limit 167772160 hierarchical_memsw_limit 9223372036854771712 total_cache 0 total_rss 167772160 total_rss_huge 0 total_mapped_file 0 total_swap 0 total_pgpgin 9798832 total_pgpgout 9757872 total_pgfault 7577422 total_pgmajfault 24 total_inactive_anon 0 total_active_anon 167723008 total_inactive_file 0 total_active_file 0 total_unevictable 0
```
The above failure was resulting in 5xx.

- Decrease the max repo size limit. This was needed to because we saw the following in logs:
```
[2018-10-02 16:44:19,518|Thread-3600-do_GET(55)|DEBUG]: 
GET /transform?url=https://downloads.mesosphere.com/universe/repo/repo-up-to-1.10.json HTTP/1.1
Host: universe-converter.mesosphere.com
User-Agent: cosmos/0.5.0 dcos/1.10.ignore
```

converter service should not be used to download the `repo.json` files. This is needed because we server both `.json` and `.json.gz` files and cosmos 0.5.x and above uses `Accept-Encoding:gzip` to try and download the gzipped file (which is ~3MB vs the `.json` file which is ~17MB). 

These changes were already made in universe converter that is running in prod cluster and I am just making the same changes here so that the future deployments adhere to the same settings.