### PR TITLE
Allow changing docker registry url

### DIFF
--- a/scripts/local-universe.py
+++ b/scripts/local-universe.py
@@ -18,7 +18,6 @@ import urllib.parse
 import urllib.request
 
 HTTP_ROOT = "http://master.mesos:8082/"
-DOCKER_ROOT = "master.mesos:5000"
 
 
 def main():
@@ -37,6 +36,10 @@ def main():
     parser.add_argument(
         '--server_url',
         default=HTTP_ROOT,
+        help="URL for http server")
+    parser.add_argument(
+        '--docker_url',
+        default="master.mesos:5000",
         help="URL for http server")
     parser.add_argument(
         '--repository',
@@ -108,6 +111,7 @@ def main():
                     pathlib.Path(args.repository),
                     repo_artifacts,
                     args.server_url,
+                    args.docker_url,
                     args.nonlocal_images,
                     args.nonlocal_cli
                 )
@@ -412,6 +416,7 @@ def prepare_repository(
     source_repo,
     dest_repo,
     http_root,
+    docker_root,
     skip_images,
     skip_cli
 ):
@@ -458,7 +463,7 @@ def prepare_repository(
         if 'assets' in resource:
             if 'container' in resource["assets"]:
                 resource["assets"]["container"]["docker"] = {
-                    n: format_image_name(DOCKER_ROOT, image_name)
+                    n: format_image_name(docker_root, image_name)
                     for n, image_name in resource["assets"]["container"].get(
                         "docker", {}).items()}
 


### PR DESCRIPTION
This PR allows modifying hardcoded constant `DOCKER_ROOT` when deploying to local universe. The default value doesn't change.