### PR TITLE
DCOS-45192 Working dcos-ui package

### DIFF
--- a/repo/packages/D/dcos-ui/1/package.json
+++ b/repo/packages/D/dcos-ui/1/package.json
@@ -1,0 +1,12 @@
+{
+  "packagingVersion": "4.0",
+  "name": "dcos-ui",
+  "version": "2.37.0",
+  "tags": ["dcos-ui", "dcos","ui"],
+  "maintainer": "frontend-dev@mesosphere.io",
+  "description": "DC/OS UI",
+  "scm": "https://github.com/dcos/dcos-ui",
+  "website": "https://dcos.io/",
+  "framework": false,
+  "minDcosReleaseVersion": "1.12"
+}

--- a/repo/packages/D/dcos-ui/1/resource.json
+++ b/repo/packages/D/dcos-ui/1/resource.json
@@ -1,0 +1,7 @@
+{
+  "assets": {
+    "uris": {
+      "dcos-ui-bundle": "https://downloads.mesosphere.com/dcos-ui/master%2Bdcos-ui-v2.37.0.tar.gz"
+    }
+  }
+}


### PR DESCRIPTION
When trying to download rev 0 through cosmos `https://downloads.mesosphere.io/dcos-ui/master%2Bdcos-ui-v2.24.4.tar.gz`
fails, but `https://downloads.mesosphere.com/dcos-ui/master%2Bdcos-ui-v2.24.4.tar.gz` succeeds.
Adding a new package revision with the working resource uri.