### PR TITLE
Update user agent for local universe

### DIFF
--- a/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
+++ b/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
@@ -28,6 +28,11 @@ server {
     set $universe_version v5;
   }
 
+  # We assume a user is running the latest DC/OS if their User-Agent is unknown
+  # Historically, we assumed 1.6.1 until its deprecation.
+  # User-Agent was added to cosmos in DC/OS Release 1.8
+  set $dcos_release_version 1.13;
+
   if ($http_user_agent ~ ".*dcos\/1\.8.*") {
     set $dcos_release_version 1.8;
   }


### PR DESCRIPTION
We recommend using `package-registry` as an alternative to local universe but in OSS clusters `local-universe` is the only alternative and we should still continue to support that. Adding `1.13` UserAgent to local universe nginx server config.