### PR TITLE
Fix licenses and tags for elastic stack

### DIFF
--- a/repo/packages/B/beta-elastic/0/package.json
+++ b/repo/packages/B/beta-elastic/0/package.json
@@ -14,5 +14,23 @@
     "elasticsearch",
     "x-pack"
   ],
-  "version": "1.0.9-5.3.0-beta"
+  "version": "1.0.9-5.3.0-beta",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    },
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-elastic/1/package.json
+++ b/repo/packages/B/beta-elastic/1/package.json
@@ -14,5 +14,23 @@
     "elasticsearch",
     "x-pack"
   ],
-  "version": "1.0.10-5.3.0-beta"
+  "version": "1.0.10-5.3.0-beta",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    },
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-elastic/10/package.json
+++ b/repo/packages/B/beta-elastic/10/package.json
@@ -21,5 +21,15 @@
   ],
   "preInstallNotes": "This DC/OS Service is currently a beta candidate undergoing testing as part of a formal beta test program.\n\nThere may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nDefault configuration requires 3 agent nodes each with: CPU: 4.0 | Memory: 9216MB | Disk: 13500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk\n\nIngest node: No instances by default | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nContact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
   "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-elastic/2/package.json
+++ b/repo/packages/B/beta-elastic/2/package.json
@@ -13,5 +13,15 @@
     "elasticsearch",
     "x-pack"
   ],
-  "version": "1.0.11-5.4.0-beta"
+  "version": "1.0.11-5.4.0-beta",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-elastic/3/package.json
+++ b/repo/packages/B/beta-elastic/3/package.json
@@ -13,5 +13,15 @@
     "elasticsearch",
     "x-pack"
   ],
-  "version": "1.0.12-5.4.0-beta"
+  "version": "1.0.12-5.4.0-beta",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-elastic/4/package.json
+++ b/repo/packages/B/beta-elastic/4/package.json
@@ -13,5 +13,15 @@
     "elasticsearch",
     "x-pack"
   ],
-  "version": "1.0.13-5.4.1-beta"
+  "version": "1.0.13-5.4.1-beta",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-elastic/5/package.json
+++ b/repo/packages/B/beta-elastic/5/package.json
@@ -12,8 +12,17 @@
   "tags": [
     "elastic",
     "elasticsearch",
-    "kibana",
     "x-pack"
   ],
-  "version": "1.0.14-5.5.0-beta"
+  "version": "1.0.14-5.5.0-beta",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-elastic/6/package.json
+++ b/repo/packages/B/beta-elastic/6/package.json
@@ -12,8 +12,17 @@
   "tags": [
     "elastic",
     "elasticsearch",
-    "kibana",
     "x-pack"
   ],
-  "version": "1.0.15-5.5.1-beta"
+  "version": "1.0.15-5.5.1-beta",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-elastic/7/package.json
+++ b/repo/packages/B/beta-elastic/7/package.json
@@ -12,10 +12,19 @@
   "tags": [
     "elastic",
     "elasticsearch",
-    "kibana",
     "x-pack"
   ],
   "version": "1.0.16-5.5.1-beta",
   "upgradesFrom": ["1.0.15-5.5.1-beta"],
-  "downgradesTo": ["1.0.15-5.5.1-beta"]
+  "downgradesTo": ["1.0.15-5.5.1-beta"],
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-elastic/8/package.json
+++ b/repo/packages/B/beta-elastic/8/package.json
@@ -14,10 +14,19 @@
     "tags": [
         "elastic",
         "elasticsearch",
-        "kibana",
         "x-pack"
     ],
     "preInstallNotes": "This DC/OS Service is currently a beta candidate undergoing testing as part of a formal beta test program.\n\nThere may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nDefault configuration requires 3 agent nodes each with: CPU: 4.0 | Memory: 9216MB | Disk: 13500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk\n\nIngest node: No instances by default | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nContact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
     "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/beta-elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/beta-elastic/uninstall to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/beta-elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-elastic/9/package.json
+++ b/repo/packages/B/beta-elastic/9/package.json
@@ -16,10 +16,19 @@
     "tags": [
         "elastic",
         "elasticsearch",
-        "kibana",
         "x-pack"
     ],
     "preInstallNotes": "This DC/OS Service is currently a beta candidate undergoing testing as part of a formal beta test program.\n\nThere may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nDefault configuration requires 3 agent nodes each with: CPU: 4.0 | Memory: 9216MB | Disk: 13500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk\n\nIngest node: No instances by default | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nContact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
     "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/beta-elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/beta-elastic/uninstall to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/beta-elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-kibana/0/package.json
+++ b/repo/packages/B/beta-kibana/0/package.json
@@ -10,8 +10,19 @@
   "preInstallNotes": "This DC/OS Service is currently a beta candidate and undergoing beta testing as part of a formal beta test program. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Contact Mesosphere before deploying this beta candidate data service framework. Product support is available to approved participants in the beta test program.",
   "selected": false,
   "tags": [
+    "elastic",
     "kibana",
     "x-pack"
   ],
-  "version": "1.0.12-5.4.0-beta"
+  "version": "1.0.12-5.4.0-beta",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-kibana/1/package.json
+++ b/repo/packages/B/beta-kibana/1/package.json
@@ -10,8 +10,19 @@
   "preInstallNotes": "This DC/OS Service is currently a beta candidate undergoing testing as part of a formal beta test program. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Contact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
   "selected": false,
   "tags": [
+    "elastic",
     "kibana",
     "x-pack"
   ],
-  "version": "1.0.13-5.4.1-beta"
+  "version": "1.0.13-5.4.1-beta",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-kibana/2/package.json
+++ b/repo/packages/B/beta-kibana/2/package.json
@@ -11,9 +11,18 @@
   "selected": false,
   "tags": [
     "elastic",
-    "elasticsearch",
     "kibana",
     "x-pack"
   ],
-  "version": "1.0.14-5.4.1-beta"
+  "version": "1.0.14-5.4.1-beta",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-kibana/3/package.json
+++ b/repo/packages/B/beta-kibana/3/package.json
@@ -11,9 +11,18 @@
   "selected": false,
   "tags": [
     "elastic",
-    "elasticsearch",
     "kibana",
     "x-pack"
   ],
-  "version": "1.0.15-5.5.1-beta"
+  "version": "1.0.15-5.5.1-beta",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-kibana/4/package.json
+++ b/repo/packages/B/beta-kibana/4/package.json
@@ -11,9 +11,18 @@
   "selected": false,
   "tags": [
     "elastic",
-    "elasticsearch",
     "kibana",
     "x-pack"
   ],
-  "version": "1.0.16-5.5.1-beta"
+  "version": "1.0.16-5.5.1-beta",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-kibana/5/package.json
+++ b/repo/packages/B/beta-kibana/5/package.json
@@ -13,11 +13,20 @@
     "framework": true,
     "tags": [
         "elastic",
-        "elasticsearch",
         "kibana",
         "x-pack"
     ],
     "preInstallNotes": "This DC/OS service is currently a beta candidate undergoing testing as part of a formal beta test program. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nDefault configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM\n\nContact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
     "postInstallNotes": "The DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/beta-elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/beta-elastic/uninstall to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/beta-elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-kibana/6/package.json
+++ b/repo/packages/B/beta-kibana/6/package.json
@@ -15,11 +15,20 @@
     "framework": true,
     "tags": [
         "elastic",
-        "elasticsearch",
         "kibana",
         "x-pack"
     ],
     "preInstallNotes": "This DC/OS service is currently a beta candidate undergoing testing as part of a formal beta test program. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nDefault configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM\n\nContact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
     "postInstallNotes": "The DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/services/beta-elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/beta-elastic/uninstall to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/beta-elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/B/beta-kibana/7/package.json
+++ b/repo/packages/B/beta-kibana/7/package.json
@@ -15,11 +15,20 @@
   "framework": true,
   "tags": [
     "elastic",
-    "elasticsearch",
     "kibana",
     "x-pack"
   ],
   "preInstallNotes": "This DC/OS service is currently a beta candidate undergoing testing as part of a formal beta test program. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nDefault configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM\n\nContact Mesosphere before deploying this beta candidate service. Product support is available to approved participants in the beta test program.",
   "postInstallNotes": "The DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/services/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/elastic/uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/0/package.json
+++ b/repo/packages/E/elastic/0/package.json
@@ -9,9 +9,28 @@
   "postUninstallNotes": "DC/OS elastic service has been uninstalled.",
   "selected": true,
   "tags": [
+    "elastic",
     "kibana",
     "elasticsearch",
     "x-pack"
   ],
-  "version": "1.0.3-5.1.2"
+  "version": "1.0.3-5.1.2",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    },
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/1/package.json
+++ b/repo/packages/E/elastic/1/package.json
@@ -9,9 +9,28 @@
   "postUninstallNotes": "DC/OS elastic service has been uninstalled.",
   "selected": true,
   "tags": [
+    "elastic",
     "kibana",
     "elasticsearch",
     "x-pack"
   ],
-  "version": "1.0.4-5.1.2"
+  "version": "1.0.4-5.1.2",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    },
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/100/package.json
+++ b/repo/packages/E/elastic/100/package.json
@@ -16,10 +16,19 @@
   "tags": [
     "elastic",
     "elasticsearch",
-    "kibana",
     "x-pack"
   ],
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: CPU: 4.0 | Memory: 9216MB | Disk: 13500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk\n\nIngest node: No instances by default | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk",
   "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/2/package.json
+++ b/repo/packages/E/elastic/2/package.json
@@ -9,9 +9,28 @@
   "postUninstallNotes": "DC/OS elastic service has been uninstalled.",
   "selected": true,
   "tags": [
+    "elastic",
     "kibana",
     "elasticsearch",
     "x-pack"
   ],
-  "version": "1.0.5-5.2.1"
+  "version": "1.0.5-5.2.1",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    },
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/200/package.json
+++ b/repo/packages/E/elastic/200/package.json
@@ -16,10 +16,19 @@
   "tags": [
     "elastic",
     "elasticsearch",
-    "kibana",
     "x-pack"
   ],
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: CPU: 4.0 | Memory: 9216MB | Disk: 13500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk\n\nIngest node: No instances by default | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk",
   "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/3/package.json
+++ b/repo/packages/E/elastic/3/package.json
@@ -9,9 +9,28 @@
   "postUninstallNotes": "DC/OS elastic service has been uninstalled.",
   "selected": true,
   "tags": [
+    "elastic",
     "kibana",
     "elasticsearch",
     "x-pack"
   ],
-  "version": "1.0.6-5.2.2"
+  "version": "1.0.6-5.2.2",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    },
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/300/package.json
+++ b/repo/packages/E/elastic/300/package.json
@@ -16,10 +16,19 @@
   "tags": [
     "elastic",
     "elasticsearch",
-    "kibana",
     "x-pack"
   ],
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: CPU: 4.0 | Memory: 9216MB | Disk: 13500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk\n\nIngest node: No instances by default | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk",
   "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/4/package.json
+++ b/repo/packages/E/elastic/4/package.json
@@ -9,9 +9,28 @@
   "postUninstallNotes": "DC/OS elastic service has been uninstalled.",
   "selected": true,
   "tags": [
+    "elastic",
     "kibana",
     "elasticsearch",
     "x-pack"
   ],
-  "version": "1.0.7-5.2.2"
+  "version": "1.0.7-5.2.2",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    },
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/400/package.json
+++ b/repo/packages/E/elastic/400/package.json
@@ -16,10 +16,19 @@
   "tags": [
     "elastic",
     "elasticsearch",
-    "kibana",
     "x-pack"
   ],
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: CPU: 4.0 | Memory: 9216MB | Disk: 13500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk\n\nIngest node: No instances by default | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk",
   "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/5/package.json
+++ b/repo/packages/E/elastic/5/package.json
@@ -9,9 +9,28 @@
   "postUninstallNotes": "DC/OS elastic service has been uninstalled.",
   "selected": true,
   "tags": [
+    "elastic",
     "kibana",
     "elasticsearch",
     "x-pack"
   ],
-  "version": "1.0.8-5.2.2"
+  "version": "1.0.8-5.2.2",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    },
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/6/package.json
+++ b/repo/packages/E/elastic/6/package.json
@@ -12,8 +12,17 @@
   "tags": [
     "elastic",
     "elasticsearch",
-    "kibana",
     "x-pack"
   ],
-  "version": "2.0.0-5.5.1"
+  "version": "2.0.0-5.5.1",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/7/package.json
+++ b/repo/packages/E/elastic/7/package.json
@@ -12,10 +12,19 @@
     "tags": [
         "elastic",
         "elasticsearch",
-        "kibana",
         "x-pack"
     ],
     "preInstallNotes": "Default configuration requires 3 agent nodes each with: CPU: 4.5 | Memory: 11264MB | Disk: 15500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nIngest node: 1 instance | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk",
     "postInstallNotes": "DC/OS elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "DC/OS elastic service is being uninstalled."
+    "postUninstallNotes": "DC/OS elastic service is being uninstalled.",
+    "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/8/package.json
+++ b/repo/packages/E/elastic/8/package.json
@@ -16,10 +16,19 @@
     "tags": [
         "elastic",
         "elasticsearch",
-        "kibana",
         "x-pack"
     ],
     "preInstallNotes": "Default configuration requires 3 agent nodes each with: CPU: 4.0 | Memory: 9216MB | Disk: 13500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk\n\nIngest node: No instances by default | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk",
     "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/\n\n\tIf you installed from the UI, enter `dcos package install elastic --cli` from the DC/OS CLI to install the Elastic CLI subcommands.",
-    "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required.",
+    "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/E/elastic/9/package.json
+++ b/repo/packages/E/elastic/9/package.json
@@ -16,10 +16,19 @@
     "tags": [
         "elastic",
         "elasticsearch",
-        "kibana",
         "x-pack"
     ],
     "preInstallNotes": "Default configuration requires 3 agent nodes each with: CPU: 4.0 | Memory: 9216MB | Disk: 13500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk\n\nIngest node: No instances by default | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk",
     "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required.",
+    "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/K/kibana/0/package.json
+++ b/repo/packages/K/kibana/0/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "3.0",
   "name": "kibana",
   "version": "4.5.3",
-  "tags": ["kibana", "monitoring", "logging"],
+  "tags": ["elastic", "kibana", "monitoring", "logging"],
   "maintainer": "https://dcos.io/community",
   "description": "DCOS implementation of the Kibana, running on the Elasticsearch framework.",
   "scm": "https://github.com/elastic/kibana.git",

--- a/repo/packages/K/kibana/1/package.json
+++ b/repo/packages/K/kibana/1/package.json
@@ -11,9 +11,18 @@
   "selected": true,
   "tags": [
     "elastic",
-    "elasticsearch",
     "kibana",
     "x-pack"
   ],
-  "version": "2.0.0-5.5.1"
+  "version": "2.0.0-5.5.1",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/K/kibana/100/package.json
+++ b/repo/packages/K/kibana/100/package.json
@@ -15,11 +15,20 @@
   "framework": true,
   "tags": [
     "elastic",
-    "elasticsearch",
     "kibana",
     "x-pack"
   ],
   "preInstallNotes": "Default configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM",
   "postInstallNotes": "The DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/services/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/elastic/uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/K/kibana/2/package.json
+++ b/repo/packages/K/kibana/2/package.json
@@ -11,11 +11,20 @@
     "framework": true,
     "tags": [
         "elastic",
-        "elasticsearch",
         "kibana",
         "x-pack"
     ],
     "preInstallNotes": "Default configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM",
     "postInstallNotes": "DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "DC/OS Kibana service has been uninstalled."
+    "postUninstallNotes": "DC/OS Kibana service has been uninstalled.",
+    "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/K/kibana/200/package.json
+++ b/repo/packages/K/kibana/200/package.json
@@ -15,11 +15,20 @@
   "framework": true,
   "tags": [
     "elastic",
-    "elasticsearch",
     "kibana",
     "x-pack"
   ],
   "preInstallNotes": "Default configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM",
   "postInstallNotes": "The DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/services/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/elastic/uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/K/kibana/3/package.json
+++ b/repo/packages/K/kibana/3/package.json
@@ -15,11 +15,20 @@
     "framework": true,
     "tags": [
         "elastic",
-        "elasticsearch",
         "kibana",
         "x-pack"
     ],
     "preInstallNotes": "Default configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM",
     "postInstallNotes": "The DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required.",
+    "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/K/kibana/300/package.json
+++ b/repo/packages/K/kibana/300/package.json
@@ -15,11 +15,20 @@
   "framework": true,
   "tags": [
     "elastic",
-    "elasticsearch",
     "kibana",
     "x-pack"
   ],
   "preInstallNotes": "Default configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM",
   "postInstallNotes": "The DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/services/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/elastic/uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/K/kibana/4/package.json
+++ b/repo/packages/K/kibana/4/package.json
@@ -15,11 +15,20 @@
     "framework": true,
     "tags": [
         "elastic",
-        "elasticsearch",
         "kibana",
         "x-pack"
     ],
     "preInstallNotes": "Default configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM",
     "postInstallNotes": "The DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required.",
+    "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/K/kibana/400/package.json
+++ b/repo/packages/K/kibana/400/package.json
@@ -15,11 +15,20 @@
   "framework": true,
   "tags": [
     "elastic",
-    "elasticsearch",
     "kibana",
     "x-pack"
   ],
   "preInstallNotes": "Default configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM",
   "postInstallNotes": "The DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/services/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/elastic/uninstall to remove any persistent state if required."
+  "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/services/elastic/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/K/kibana/5/package.json
+++ b/repo/packages/K/kibana/5/package.json
@@ -15,11 +15,20 @@
     "framework": true,
     "tags": [
         "elastic",
-        "elasticsearch",
         "kibana",
         "x-pack"
     ],
     "preInstallNotes": "Default configuration requires 1 agent node with: 0.5 CPU | 2048 MB MEM",
     "postInstallNotes": "The DC/OS Kibana service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-    "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required."
+    "postUninstallNotes": "The DC/OS Kibana service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required.",
+    "licenses": [
+    {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/LICENSE.txt"
+    },
+    {
+        "name": "Elastic License",
+        "url": "https://raw.githubusercontent.com/elastic/kibana/master/x-pack/README.md"
+    }
+ ]
 }

--- a/repo/packages/L/logstash/0/package.json
+++ b/repo/packages/L/logstash/0/package.json
@@ -3,7 +3,7 @@
   "name": "logstash",
   "version": "2.3.4",
   "framework": false,
-  "tags": ["logstash", "monitoring", "logging", "elk"],
+  "tags": ["elastic", "logstash", "monitoring", "logging", "elk"],
   "maintainer": "https://dcos.io/community",
   "description": "DCOS implementation of the Logstash.",
   "scm": "https://github.com/elastic/logstash.git",


### PR DESCRIPTION
In some of these packages we are bundling elasticsearch with kibana, and some are just elasticsearch. Add appropriate license fields for both, and make sure the tags are also correct. 