### PR TITLE
Catch DC/OS 1.13 user agents in Docker Nginx config

### DIFF
--- a/docker/local-universe/default.conf
+++ b/docker/local-universe/default.conf
@@ -44,6 +44,10 @@ server {
     set $dcos_release_version 1.12;
   }
 
+  if ($http_user_agent ~ ".*dcos\/1\.13.*") {
+    set $dcos_release_version 1.13;
+  }
+
   location = /repo-1.7 {
     types {
       "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3" json;

--- a/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
+++ b/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
@@ -53,6 +53,10 @@ server {
     set $dcos_release_version 1.12;
   }
 
+  if ($http_user_agent ~ ".*dcos\/1\.13.*") {
+    set $dcos_release_version 1.13;
+  }
+
   location = /repo-1.7 {
     types {
       "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3" json;


### PR DESCRIPTION
This adds support for DC/OS 1.13 in docker nginx configurations.