### PR TITLE
#2109 Fix embedded json escaping for Grafana 5.5.0-5.1.3

### DIFF
--- a/repo/packages/G/grafana/6/marathon.json.mustache
+++ b/repo/packages/G/grafana/6/marathon.json.mustache
@@ -50,7 +50,7 @@
     "GRAFANA_URI": "{{resource.assets.uris.grafana-tar-gz}}",
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
-    "MESOS_MODULES": "{"libraries":[{"file":"libmesos-bundle\/lib\/mesos\/libdcos_security.so","modules":[{"name": "com_mesosphere_dcos_ClassicRPCAuthenticatee"},{"name":"com_mesosphere_dcos_http_Authenticatee","parameters":[{"key":"jwt_exp_timeout","value":"5mins"},{"key":"preemptive_refresh_duration","value":"30mins"}]}]}]}",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
     "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
     "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}


### PR DESCRIPTION
Fix for issue #2109

We were able to figure out it was a parsing error of the marathon Mustache template, the fix is to escape the bit of embedded json in MESOS_MODULES. (As it is also done for other packages like, like Prometheus, see: https://github.com/mesosphere/universe/blob/version-3.x/repo/packages/P/prometheus/1/marathon.json.mustache#L56 )