### PR TITLE
Update Ethereum to version 0.1.1

### DIFF
--- a/repo/packages/E/ethereum/1/config.json
+++ b/repo/packages/E/ethereum/1/config.json
@@ -1,0 +1,449 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "ethereum",
+          "title": "Service name"
+        },
+        "user": {
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root",
+          "title": "User"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": "",
+          "title": "Credential secret name (optional)"
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "mesos_api_version": {
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "type": "string",
+          "enum": [
+            "V0",
+            "V1"
+          ],
+          "default": "V1"
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        }
+      },
+      "required": [
+        "name",
+        "user"
+      ]
+    },
+    "geth": {
+      "description": "Common geth node configuration.",
+      "type": "object",
+      "properties": {
+        "network_id": {
+          "title": "Chain / Network ID",
+          "description": "Chain or Network ID.",
+          "type": "integer",
+          "default": 18
+        },
+        "syncmode": {
+          "title": "Sync mode",
+          "description": "Geth sync mode, one of fast, full (default), or light.",
+          "enum": [
+            "fast",
+            "full",
+            "light"
+          ],
+          "default": "full"
+        },
+        "create_genesis": {
+          "description": "Create a genesis.json and initialize each node with it.",
+          "type": "boolean",
+          "default": true
+        },
+        "consensus_engine": {
+          "title": "Consensus engine",
+          "description": "Consensus engine to use. One of: ethash (proof-of-work) or clique (default, proof-of-authority).",
+          "enum": [
+            "ethash",
+            "clique"
+          ],
+          "default": "clique"
+        },
+        "clique_period": {
+          "title": "Clique period",
+          "description": "Number of seconds blocks should take, used only with clique consensus engine.",
+          "type": "integer",
+          "default": 15
+        }
+      },
+      "required": [
+        "network_id",
+        "syncmode",
+        "create_genesis"
+      ]
+    },
+    "boot": {
+      "description": "Boot pod configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of Node pods to run",
+          "type": "integer",
+          "default": 1
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Node CPU requirements",
+          "type": "number",
+          "default": 0.1
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Node mem requirements (in MB)",
+          "type": "integer",
+          "default": 256
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Node persistent disk requirements (in MB)",
+          "type": "integer",
+          "default": 15000
+        },
+        "disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Placement constraints for nodes. Example: [[\"hostname\", \"UNIQUE\"]]",
+          "type": "string",
+          "default": "",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "labels": {
+          "title": "Labels",
+          "description": "Custom mesos task labels for boot nodes",
+          "type": "string",
+          "default": ""
+        },
+        "verbosity": {
+          "title": "Log Verbosity [0-9]",
+          "description": "Geth node log verbosity level",
+          "type": "integer",
+          "default": 3
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "disk_type"
+      ]
+    },
+    "ethstats": {
+      "description": "Ethstats pod configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of Node pods to run",
+          "type": "integer",
+          "default": 1
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Node CPU requirements",
+          "type": "number",
+          "default": 1
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Node mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Placement constraints for nodes. Example: [[\"hostname\", \"UNIQUE\"]]",
+          "type": "string",
+          "default": "",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "labels": {
+          "title": "Labels",
+          "description": "Custom mesos task labels for ethstats nodes",
+          "type": "string",
+          "default": ""
+        },
+        "verbosity": {
+          "title": "Log Verbosity [0-3]",
+          "description": "Ethstats node log verbosity level",
+          "type": "integer",
+          "default": 3
+        },
+        "websocket_secret": {
+          "description": "Secret for connecting to ethstats via websocket.",
+          "type": "string",
+          "default": "my-ws-secret"
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "websocket_secret"
+      ]
+    },
+    "sealer": {
+      "description": "Sealer pod configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of Node pods to run",
+          "type": "integer",
+          "default": 3
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Node CPU requirements",
+          "type": "number",
+          "default": 1
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Node mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Node persistent disk requirements (in MB)",
+          "type": "integer",
+          "default": 15000
+        },
+        "disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Placement constraints for nodes. Example: [[\"hostname\", \"UNIQUE\"]]",
+          "type": "string",
+          "default": "",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "labels": {
+          "title": "Labels",
+          "description": "Custom mesos task labels for sealer nodes",
+          "type": "string",
+          "default": ""
+        },
+        "args": {
+          "title": "CLI arguments",
+          "description": "Additional sealer node CLI arguments for the geth command. See github.com/ethereum/go-ethereum/wiki/Command-Line-Options",
+          "type": "string",
+          "default": "--metrics --mine --minerthreads=1"
+        },
+        "verbosity": {
+          "title": "Log Verbosity [0-9]",
+          "description": "Geth node log verbosity level",
+          "type": "integer",
+          "default": 3
+        },
+        "rpcapi": {
+          "title": "RPC API",
+          "description": "The API functionality to expose.",
+          "type": "string",
+          "default": "debug,db,personal,eth,network,web3,net,miner"
+        },
+        "create_accounts": {
+          "description": "Create and pre-fund an account for each sealer node when true.",
+          "type": "boolean",
+          "default": true
+        },
+        "unlock_accounts": {
+          "description": "Unlock each sealer account upon starting geth.",
+          "type": "boolean",
+          "default": true
+        },
+        "account_privatekeys": {
+          "description": "Comma separated list of private keys to use for sealer accounts. Must be used when create_account is false.",
+          "type": "string",
+          "default": ""
+        },
+        "account_secret": {
+          "description": "Account secret passphrase to use for all sealer accounts.",
+          "type": "string",
+          "default": "p@ssw0rd"
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "disk_type",
+        "create_accounts",
+        "account_secret"
+      ]
+    },
+    "client": {
+      "description": "Client pod configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Client node count",
+          "description": "Number of Node pods to run",
+          "type": "integer",
+          "default": 2
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Node CPU requirements",
+          "type": "number",
+          "default": 1
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Node mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Node persistent disk requirements (in MB)",
+          "type": "integer",
+          "default": 15000
+        },
+        "disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Placement constraints for nodes. Example: [[\"hostname\", \"UNIQUE\"]]",
+          "type": "string",
+          "default": "",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "labels": {
+          "title": "Labels",
+          "description": "Custom mesos task labels for client nodes",
+          "type": "string",
+          "default": ""
+        },
+        "args": {
+          "title": "CLI arguments",
+          "description": "Additional client node CLI arguments for the geth command. See github.com/ethereum/go-ethereum/wiki/Command-Line-Options",
+          "type": "string",
+          "default": "--metrics"
+        },
+        "verbosity": {
+          "title": "Log Verbosity [0-9]",
+          "description": "Geth node log verbosity level",
+          "type": "integer",
+          "default": 3
+        },
+        "rpcapi": {
+          "title": "RPC API",
+          "description": "The API functionality to expose.",
+          "type": "string",
+          "default": "debug,db,personal,eth,network,web3,net,miner"
+        },
+        "create_accounts": {
+          "description": "Create and pre-fund an account for each client node when true.",
+          "type": "boolean",
+          "default": true
+        },
+        "unlock_accounts": {
+          "description": "Unlock each client account upon starting geth.",
+          "type": "boolean",
+          "default": true
+        },
+        "account_privatekeys": {
+          "description": "Comma separated list of private keys to use for client accounts. Must be used when create_account is false.",
+          "type": "string",
+          "default": ""
+        },
+        "account_secret": {
+          "description": "Account secret passphrase to use for all client accounts.",
+          "type": "string",
+          "default": "p@ssw0rd"
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "disk_type",
+        "create_accounts",
+        "account_secret"
+      ]
+    }
+  }
+}

--- a/repo/packages/E/ethereum/1/config.json
+++ b/repo/packages/E/ethereum/1/config.json
@@ -146,7 +146,7 @@
           "title": "Disk size (MB)",
           "description": "Node persistent disk requirements (in MB)",
           "type": "integer",
-          "default": 15000
+          "default": 10
         },
         "disk_type": {
           "title": "Disk type [ROOT, MOUNT]",
@@ -201,13 +201,13 @@
           "title": "CPU count",
           "description": "Node CPU requirements",
           "type": "number",
-          "default": 1
+          "default": 0.1
         },
         "mem": {
           "title": "Memory size (MB)",
           "description": "Node mem requirements (in MB)",
           "type": "integer",
-          "default": 1024
+          "default": 256
         },
         "placement_constraint": {
           "title": "Placement constraint",
@@ -257,7 +257,7 @@
           "title": "CPU count",
           "description": "Node CPU requirements",
           "type": "number",
-          "default": 1
+          "default": 1.0
         },
         "mem": {
           "title": "Memory size (MB)",
@@ -358,7 +358,7 @@
           "title": "CPU count",
           "description": "Node CPU requirements",
           "type": "number",
-          "default": 1
+          "default": 1.0
         },
         "mem": {
           "title": "Memory size (MB)",

--- a/repo/packages/E/ethereum/1/marathon.json.mustache
+++ b/repo/packages/E/ethereum/1/marathon.json.mustache
@@ -1,0 +1,159 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "user": "{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -print-env=false -resolve=false -template=false && ./bootstrap_geth.sh && ./ethereum-scheduler/bin/ethereum ./ethereum-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "container": {
+    "type": "MESOS",
+    "volumes": [{
+      "containerPath": "ethdata",
+      "mode": "RW",
+      "persistent": {
+        "type": "ROOT",
+        "size": 128
+      }
+    }]
+  },
+  "env": {
+    "PACKAGE_NAME": "ethereum",
+    "PACKAGE_VERSION": "0.1.0",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1543603017878",
+    "PACKAGE_BUILD_TIME_STR": "Fri Nov 30 2018 18:36:57 +0000",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+    "TASKCFG_ALL_NETWORK_ID": "{{geth.network_id}}",
+    "TASKCFG_ALL_GETH_SYNCMODE": "{{geth.syncmode}}",
+    "TASKCFG_ALL_ETHSTATS_NODE_COUNT": "{{ethstats.count}}",
+    "TASKCFG_ALL_BOOT_NODE_COUNT": "{{boot.count}}",
+    {{#geth.create_genesis}}
+    "TASKCFG_ALL_CREATE_GENESIS": "yes",
+    {{/geth.create_genesis}}
+    "GENESIS_ENGINE": "{{geth.consensus_engine}}",
+    "GENESIS_PERIOD": "{{geth.clique_period}}",
+    "BOOT_NODE_CPUS": "{{boot.cpus}}",
+    "BOOT_NODE_MEM": "{{boot.mem}}",
+    "BOOT_NODE_DISK": "{{boot.disk}}",
+    "BOOT_NODE_DISK_TYPE": "{{boot.disk_type}}",
+    "BOOT_NODE_PLACEMENT": "{{{boot.placement_constraint}}}",
+    "BOOT_NODE_LABELS": "{{boot.labels}}",
+    "TASKCFG_BOOT_GETH_VERBOSITY": "{{boot.verbosity}}",
+    "ETHSTATS_DOCKER_IMAGE": "{{resource.assets.container.docker.ethstats_docker}}",
+    "ETHSTATS_NODE_CPUS": "{{ethstats.cpus}}",
+    "ETHSTATS_NODE_MEM": "{{ethstats.mem}}",
+    "ETHSTATS_NODE_PLACEMENT": "{{{ethstats.placement_constraint}}}",
+    "ETHSTATS_NODE_LABELS": "{{ethstats.labels}}",
+    "TASKCFG_ETHSTATS_VERBOSITY": "{{ethstats.verbosity}}",
+    "TASKCFG_ALL_WS_SECRET": "{{ethstats.websocket_secret}}",
+    "SEALER_NODE_COUNT": "{{sealer.count}}",
+    "SEALER_NODE_CPUS": "{{sealer.cpus}}",
+    "SEALER_NODE_MEM": "{{sealer.mem}}",
+    "SEALER_NODE_DISK": "{{sealer.disk}}",
+    "SEALER_NODE_DISK_TYPE": "{{sealer.disk_type}}",
+    "SEALER_NODE_PLACEMENT": "{{{sealer.placement_constraint}}}",
+    "SEALER_NODE_LABELS": "{{sealer.labels}}",
+    "TASKCFG_SEALER_GETH_ARGS": "{{sealer.args}}",
+    "TASKCFG_SEALER_GETH_VERBOSITY": "{{sealer.verbosity}}",
+    {{#sealer.rpcapi}}
+    "TASKCFG_SEALER_GETH_RPCAPI": "{{sealer.rpcapi}}",
+    "ENABLE_SEALER_RPC": "yes",
+    {{/sealer.rpcapi}}
+    {{#sealer.create_accounts}}
+    "TASKCFG_SEALER_CREATE_ACCOUNTS": "yes",
+    {{/sealer.create_accounts}}
+    {{#sealer.unlock_accounts}}
+    "TASKCFG_SEALER_UNLOCK_ACCOUNTS": "yes",
+    {{/sealer.unlock_accounts}}
+    {{#sealer.account_privatekeys}}
+    "TASKCFG_SEALER_ACCOUNT_PRIVATEKEYS": "{{sealer.account_privatekeys}}",
+    {{/sealer.account_privatekeys}}
+    "TASKCFG_SEALER_ACCOUNT_SECRET": "{{sealer.account_secret}}",
+    "CLIENT_NODE_COUNT": "{{client.count}}",
+    "CLIENT_NODE_CPUS": "{{client.cpus}}",
+    "CLIENT_NODE_MEM": "{{client.mem}}",
+    "CLIENT_NODE_DISK": "{{client.disk}}",
+    "CLIENT_NODE_DISK_TYPE": "{{client.disk_type}}",
+    "CLIENT_NODE_PLACEMENT": "{{{client.placement_constraint}}}",
+    "CLIENT_NODE_LABELS": "{{client.labels}}",
+    "TASKCFG_CLIENT_GETH_ARGS": "{{client.args}}",
+    "TASKCFG_CLIENT_GETH_VERBOSITY": "{{client.verbosity}}",
+    {{#client.rpcapi}}
+    "TASKCFG_CLIENT_GETH_RPCAPI": "{{client.rpcapi}}",
+    "ENABLE_CLIENT_RPC": "yes",
+    {{/client.rpcapi}}
+    {{#client.create_accounts}}
+    "TASKCFG_CLIENT_CREATE_ACCOUNTS": "yes",
+    {{/client.create_accounts}}
+    {{#client.unlock_accounts}}
+    "TASKCFG_CLIENT_UNLOCK_ACCOUNTS": "yes",
+    {{/client.unlock_accounts}}
+    {{#client.account_privatekeys}}
+    "TASKCFG_CLIENT_ACCOUNT_PRIVATEKEYS": "{{client.account_privatekeys}}",
+    {{/client.account_privatekeys}}
+    "TASKCFG_CLIENT_ACCOUNT_SECRET": "{{client.account_secret}}",
+    "GETH_SCRIPTS_URI": "{{resource.assets.uris.geth-scripts-zip}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.service_account_secret}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  },
+  "fetch": [
+    { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },
+    { "uri": "{{resource.assets.uris.geth-scripts-zip}}", "cache": false },
+    { "uri": "{{resource.assets.uris.jre-tar-gz}}", "cache": true },
+    { "uri": "{{resource.assets.uris.scheduler-zip}}", "cache": false },
+    { "uri": "{{resource.assets.uris.libmesos-bundle-tar-gz}}", "cache": true }
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api"
+    }
+  ]
+}

--- a/repo/packages/E/ethereum/1/marathon.json.mustache
+++ b/repo/packages/E/ethereum/1/marathon.json.mustache
@@ -34,9 +34,9 @@
   },
   "env": {
     "PACKAGE_NAME": "ethereum",
-    "PACKAGE_VERSION": "0.1.0",
-    "PACKAGE_BUILD_TIME_EPOCH_MS": "1543603017878",
-    "PACKAGE_BUILD_TIME_STR": "Fri Nov 30 2018 18:36:57 +0000",
+    "PACKAGE_VERSION": "0.1.1",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1545251073504",
+    "PACKAGE_BUILD_TIME_STR": "Wed Dec 19 2018 20:24:33 +0000",
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
@@ -79,6 +79,7 @@
     "SEALER_NODE_LABELS": "{{sealer.labels}}",
     "TASKCFG_SEALER_GETH_ARGS": "{{sealer.args}}",
     "TASKCFG_SEALER_GETH_VERBOSITY": "{{sealer.verbosity}}",
+    "TASKCFG_SEALER_NODE_MEM": "{{sealer.mem}}",
     {{#sealer.rpcapi}}
     "TASKCFG_SEALER_GETH_RPCAPI": "{{sealer.rpcapi}}",
     "ENABLE_SEALER_RPC": "yes",
@@ -102,6 +103,7 @@
     "CLIENT_NODE_LABELS": "{{client.labels}}",
     "TASKCFG_CLIENT_GETH_ARGS": "{{client.args}}",
     "TASKCFG_CLIENT_GETH_VERBOSITY": "{{client.verbosity}}",
+    "TASKCFG_CLIENT_NODE_MEM": "{{client.mem}}",
     {{#client.rpcapi}}
     "TASKCFG_CLIENT_GETH_RPCAPI": "{{client.rpcapi}}",
     "ENABLE_CLIENT_RPC": "yes",
@@ -153,7 +155,8 @@
     {
       "port": 0,
       "protocol": "tcp",
-      "name": "api"
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
     }
   ]
 }

--- a/repo/packages/E/ethereum/1/package.json
+++ b/repo/packages/E/ethereum/1/package.json
@@ -1,0 +1,28 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "*"
+  ],
+  "downgradesTo": [
+    "*"
+  ],
+  "minDcosReleaseVersion": "1.10",
+  "name": "ethereum",
+  "version": "0.1.0",
+  "maintainer": "andrew.kerrigan@issgovernance.com",
+  "description": "Ethereum on DC/OS",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "ethereum",
+    "blockchain"
+  ],
+  "licenses": [
+   {
+     "name": "MIT",
+     "url": "https://github.com/iss-lab/dcos-ethereum/blob/master/LICENSE"
+   }
+ ],
+  "postInstallNotes": "DC/OS Ethereum is being installed!\n\n\tDocumentation: https://github.com/iss-lab/dcos-ethereum\n\tIssues: https://github.com/iss-lab/dcos-ethereum/issues",
+  "postUninstallNotes": "DC/OS Ethereum is being uninstalled."
+}

--- a/repo/packages/E/ethereum/1/package.json
+++ b/repo/packages/E/ethereum/1/package.json
@@ -1,14 +1,14 @@
 {
   "packagingVersion": "4.0",
   "upgradesFrom": [
-    "*"
+    "0.1.0"
   ],
   "downgradesTo": [
-    "*"
+    "0.1.0"
   ],
   "minDcosReleaseVersion": "1.10",
   "name": "ethereum",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "maintainer": "andrew.kerrigan@issgovernance.com",
   "description": "Ethereum on DC/OS",
   "selected": false,
@@ -18,11 +18,11 @@
     "blockchain"
   ],
   "licenses": [
-   {
-     "name": "MIT",
-     "url": "https://github.com/iss-lab/dcos-ethereum/blob/master/LICENSE"
-   }
- ],
+    {
+      "name": "MIT",
+      "url": "https://github.com/iss-lab/dcos-ethereum/blob/master/LICENSE"
+    }
+  ],
   "postInstallNotes": "DC/OS Ethereum is being installed!\n\n\tDocumentation: https://github.com/iss-lab/dcos-ethereum\n\tIssues: https://github.com/iss-lab/dcos-ethereum/issues",
   "postUninstallNotes": "DC/OS Ethereum is being uninstalled."
 }

--- a/repo/packages/E/ethereum/1/resource.json
+++ b/repo/packages/E/ethereum/1/resource.json
@@ -1,0 +1,61 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "ethstats_docker": "ethereumex/eth-stats-dashboard:v0.0.1"
+      }
+    },
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u192-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz",
+      "bootstrap-zip": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.0/bootstrap.zip",
+      "scheduler-zip": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.0/ethereum-scheduler.zip",
+      "geth-scripts-zip": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.0/geth-scripts.zip"
+    }
+  },
+  "images": {
+    "icon-small": "https://github.com/dcos/dcos-ui/blob/master/plugins/services/src/img/icon-service-default-small.png?raw=true",
+    "icon-medium": "https://github.com/dcos/dcos-ui/blob/master/plugins/services/src/img/icon-service-default-medium.png?raw=true",
+    "icon-large": "https://github.com/dcos/dcos-ui/blob/master/plugins/services/src/img/icon-service-default-large.png?raw=true"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "b0dc012b0f344225148d9221c87ec93c629aec25c9e525c4257c62c1d883f3fb"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.0/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "e07545dc370855280f0701ece6c872befcb946e351c5778e953b0fbbb7173ccb"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.0/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "33e84a1ef1edd30f01c681b210068bf60c4e9b0c7c4ca3b6ef43b170f235bd6e"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.0/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/E/ethereum/1/resource.json
+++ b/repo/packages/E/ethereum/1/resource.json
@@ -8,9 +8,9 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u192-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz",
-      "bootstrap-zip": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.0/bootstrap.zip",
-      "scheduler-zip": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.0/ethereum-scheduler.zip",
-      "geth-scripts-zip": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.0/geth-scripts.zip"
+      "bootstrap-zip": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.1/bootstrap.zip",
+      "scheduler-zip": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.1/ethereum-scheduler.zip",
+      "geth-scripts-zip": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.1/geth-scripts.zip"
     }
   },
   "images": {
@@ -29,7 +29,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.0/dcos-service-cli-darwin"
+          "url": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.1/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -41,7 +41,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.0/dcos-service-cli-linux"
+          "url": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.1/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -53,7 +53,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.0/dcos-service-cli.exe"
+          "url": "https://github.com/iss-lab/dcos-ethereum/releases/download/v0.1.1/dcos-service-cli.exe"
         }
       }
     }


### PR DESCRIPTION
Notable changes:

* Fixed an issue preventing the sealer nodes from starting in EE DC/OS in Permissive mode.
* Reduced resource requirements for boot and ethstats nodes
* Improved usage documentation

Changes since v0.1.0:

```
$ git shortlog v0.1.0..HEAD
Drew Kerrigan (2):
      Use Scheduler VIP instead of master.mesos
      Reduce resource requirements, limit geth cache, improve documentation
```