### PR TITLE
Add beta-mesosphere-jupyter-service

### DIFF
--- a/repo/packages/B/beta-mesosphere-jupyter-service/0/config.json
+++ b/repo/packages/B/beta-mesosphere-jupyter-service/0/config.json
@@ -1,0 +1,643 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "id": "https://github.com/mesosphere/mesosphere-jupyter-service",
+      "title": "Mesosphere Jupyter Service Configuration",
+      "description": "Mesospere Jupyter Service Configuration Properties",
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$",
+          "title": "Service Name",
+          "description": "Unique name for this Mesosphere Jupyter Service instance consisting of a series of words separated by slashes. Each word must be at least 1 alphanumeric character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The word may not begin or end with a dash",
+          "default": "/jupyter"
+        },
+        "cpus": {
+          "type": "number",
+          "title": "CPU Allocation",
+          "description": "CPU shares to allocate to this service instance (e.g., 2.0)",
+          "minimum": 1.0,
+          "default": 2.0
+        },
+        "mem": {
+          "type": "integer",
+          "title": "Memory Allocation",
+          "description": "Memory to allocate to the service instance in MiB (e.g., 8192)",
+          "minimum": 4096,
+          "default": 8192
+        },
+        "gpu": {
+          "type": "object",
+          "title": "Nvidia GPU Configuration",
+          "description": "Nvidia GPU Allocation Configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable Nvidia GPU Support?",
+              "id": "https://www.nvidia.com/object/unix.html",
+              "description": "Enable Nvidia GPU Support? Note: This requires that CUDA 9.0-compatible Nvidia GPU Drivers (ideally the \"Latest Long Lived Branch Version\" - ref https://www.nvidia.com/object/unix.html) be installed on the DC/OS agents that have GPUs",
+              "default": false
+            },
+            "gpus": {
+              "type": "integer",
+              "title": "Nvidia GPU Allocation",
+              "description": "Number of Nvidia GPUs to allocate (e.g., 2) to this service (Jupyter Notebook) instance. Note: Nvidia GPU Support must be enabled for this to take effect.",
+              "minimum": 0,
+              "default": 0
+            }
+          }
+        },
+        "jupyter_password": {
+          "type": "string",
+          "title": "Jupyter Notebook Password",
+          "description": "Jupyter Notebook Password (JUPYTER_PASSWORD). Defaults to jupyter unless OpenID Connect has been configured.",
+          "default": "jupyter"
+        },
+        "jupyter_conf_urls": {
+          "type": "string",
+          "title": "Jupyter Configuration URLs",
+          "description": "Jupyter Configuration URLs as comma seperated list of URLs (JUPYTER_CONF_URLS) to download additional configuration artifacts (e.g., http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints,http://artifacts.contoso.com/jaas.conf)",
+          "default": ""
+        },
+        "service_account": {
+          "type": "string",
+          "title": "DC/OS Service Account",
+          "description": "The DC/OS Service Account to use for Mesosphere Jupyter Service for Mesos Framework (e.g., Apache Spark) Authentication or leave empty to use the default. Note: For Mesosphere DC/OS Enterprise clusters in strict mode, this must be explicitly set",
+          "default": ""
+        },
+        "service_account_secret": {
+          "type": "string",
+          "title": "DC/OS Service Account Credential Secret Name",
+          "description": "Path to the Secret to access the Service Account Credentials to use for DC/OS Service Authentication or leave empty to use the default. Note: For Mesosphere DC/OS Enterprise clusters in strict mode, this must be explicitly set",
+          "default": ""
+        },
+        "placement_constraints": {
+          "type": "string",
+          "title": "Mesosphere Jupyter Service Placement Constraints",
+          "description": "Placement constraints for the Mesosphere Jupyter Service. Note: It's best to deploy Mesosphere Jupyter Service in the Local Region - i.e., where the DC/OS Master Nodes reside",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          },
+          "default": "[]"
+        },
+        "user": {
+          "type": "string",
+          "title": "Linux User (Jupyter Notebook Process Execution Context)",
+          "description": "The Linux user account name under whom the Jupyter Notebook will run and own the Mesos Sandbox. Note: It is not recommended to set the Mesosphere Jupyter Service to run as root",
+          "default": "nobody"
+        },
+        "cmd": {
+          "type": "string",
+          "title": "Entrypoint",
+          "description": "The shell command to use to launch the Mesosphere Jupyter Service",
+          "default": "/usr/local/bin/start.sh ${CONDA_DIR}/bin/jupyter lab --notebook-dir=\"${MESOS_SANDBOX}\""
+        },
+        "log_level": {
+          "type": "string",
+          "title": "Log Level",
+          "description": "The default log level for the Mesosphere Jupyter Service",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        }
+      },
+      "required": [
+        "cpus",
+        "mem"
+      ]
+    },
+    "networking": {
+      "type": "object",
+      "title": "Mesosphere Jupyter Service Networking Configuration",
+      "description": "Mesosphere Jupyter Service Networking Configuration",
+      "properties": {
+        "cni_network_enabled": {
+          "type": "boolean",
+          "title": "Enable Virtual Networking (CNI)?",
+          "description": "Enable Virtual Networking (CNI)?",
+          "default": true
+        },
+        "cni_network_name": {
+          "type": "string",
+          "title": "(CNI) Virtual Network Name",
+          "description": "The name of the (CNI) Virtual Network to join",
+          "default": "dcos"
+        },
+        "cni_network_plugin_labels": {
+          "type": "string",
+          "title": "(CNI) Virtual Network Labels",
+          "description": "Labels to pass to the (CNI) Virtual Network plugin. Comma-separated key:value pairs (e.g., k_0:v_0,k_1:v_1,...,k_n:v_n)",
+          "default": ""
+        },
+        "ingress": {
+          "type": "object",
+          "title": "Ingress Loadbalancer Configuration",
+          "description": "Configure Mesosphere Jupyter Service to be advertized by Marathon-LB",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enable Ingress via Loadbalancer (Marathon-LB)?",
+              "description": "Enable external access through a public agent running Marathon-LB? Note: If enabled, you must set a hostname below for the service to be reachable",
+              "default": true
+            },
+            "hostname": {
+              "type": "string",
+              "title": "VHOST FQDN",
+              "description": "This is typically the (Elastic) Loadbalancer's Fully Qualified Domain Name (FQDN) that fronts the Public Agent(s) or a Virtual Hostname (VHOST) FQDN whose DNS record was specifically created for this Mesosphere Jupyter Service instance",
+              "default": ""
+            }
+          }
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "title": "Mesosphere Jupyter Service Storage Configuration",
+      "description": "Mesosphere Jupyter Service Storage Configuration",
+      "properties": {
+        "local_persistence": {
+          "type": "object",
+          "title": "Local Persistent Storage Configuration",
+          "description": "Local Persistent Storage Configuration",
+          "properties": {
+            "enabled": {
+              "title": "Enable Local Persistent Storage?",
+              "description": "Enable Local Persistent Storage?",
+              "type": "boolean",
+              "default": false
+            },
+            "volume_size": {
+              "title": "Local Persistent Volume Size",
+              "description": "Size of the local persistent volume in MiB",
+              "type": "integer",
+              "default": 4000
+            },
+            "volume_path": {
+              "title": "Local Persistent Volume Path",
+              "description": "Path at which to produce the volume (relative to the Mesos Sandbox) within the container",
+              "type": "string",
+              "default": "jupyter_data"
+            }
+          }
+        },
+        "s3": {
+          "type": "object",
+          "title": "S3 Object Store Configuration",
+          "description": "S3 Object Store Configuration",
+          "properties": {
+            "aws_region": {
+              "type": "string",
+              "title": "S3: Region",
+              "description": "S3 Region",
+              "default": "us-east-1"
+            },
+            "endpoint": {
+              "type": "string",
+              "title": "S3: Endpoint",
+              "description": "S3 Endpoint",
+              "default": "s3.us-east-1.amazonaws.com"
+            },
+            "use_https": {
+              "type": "boolean",
+              "title": "S3: Enable HTTPS?",
+              "description": "Enable connections to S3 over HTTPS?",
+              "default": true
+            },
+            "verify_ssl": {
+              "type": "boolean",
+              "title": "S3: Verify TLS?",
+              "description": "Verify TLS Certificate(s) for the S3 endpoint?",
+              "default": true
+            }
+          }
+        }
+      }
+    },
+    "oidc": {
+      "type": "object",
+      "title": "OpenID Connect (OIDC) Configuration",
+      "description": "OpenID Connect Configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enable OpenID Connect Authentication?",
+          "description": "Enable OpenID Connect Authentication (and optional Authorization)?",
+          "default": false
+        },
+        "discovery_uri": {
+          "type": "string",
+          "title": "OIDC Discovery URI",
+          "description": "OpenID Connect Discovery URI (e.g., https://keycloak.contoso.com/auth/realms/notebook/.well-known/openid-configuration)",
+          "default": "https://keycloak.contoso.com/auth/realms/notebook/.well-known/openid-configuration"
+        },
+        "client_id": {
+          "type": "string",
+          "title": "OIDC Client ID",
+          "description": "OpenID Connect Client ID (e.g., notebook)",
+          "default": "notebook"
+        },
+        "client_secret": {
+          "type": "string",
+          "title": "OIDC Client Secret",
+          "description": "OpenID Connect Client Secret (e.g., b874f6e9-8f3f-41a6-a206-53e928d24fb1). Note: This must not be set if using Windows Integrated Authentication (WIA) with Active Directory Federation Services (ADFS) on Windows Server 2016 or newer",
+          "default": ""
+        },
+        "scope": {
+          "type": "string",
+          "title": "OIDC Scope",
+          "description": "OpenID Scope (e.g., openid profile email). Note: This typically does not need to be modified",
+          "default": "openid profile email"
+        },
+        "authorization_params": {
+          "type": "string",
+          "title": "OIDC Authorization Parameters",
+          "description": "(Optional) Authorization Parameters (e.g., hd=\\\"zmartzone.eu\\\", resource=\\\"ABC:DEF:GH-12345-6789-foo-bar\\\"). Note: Windows Integrated Authentication requires that the resource parameter be set",
+          "default": ""
+        },
+        "authorized_email": {
+          "type": "string",
+          "title": "Email Address to Authorize",
+          "description": "(Optional) E-Mail Address to be authorized (e.g., user@contoso.com), once authenticated",
+          "default": ""
+        },
+        "authorized_upn": {
+          "type": "string",
+          "title": "User Principal Name (UPN) to Authorize",
+          "description": "(Optional) Windows Active Directory Federation Services (AD FS) UPN to be authorized (e.g., user007), once authenticated",
+          "default": ""
+        },
+        "redirect_after_logout_uri": {
+          "type": "string",
+          "title": "OIDC Redirect After Logout URI",
+          "description": "OpenID Connect Redirect After Redirect URI (e.g., https://notebooks.contoso.com/jupyter). Note: This typically does not need to be set",
+          "default": ""
+        },
+        "post_logout_redirect_uri": {
+          "type": "string",
+          "title": "OIDC Post Logout Redirect URI",
+          "description": "OpenID Post Logout Redirect URI (e.g., https://notebooks.contoso.com/jupyter). Note: This typically does not need to be set",
+          "default": ""
+        },
+        "tls_verify": {
+          "type": "boolean",
+          "title": "OIDC TLS Verify?",
+          "description": "Verify TLS Certificates presented by the OpenID Connect endpoint?",
+          "default": false
+        },
+        "redirect_uri": {
+          "type": "string",
+          "title": "OIDC Redirect URI",
+          "description": "OpenID Connect Redirect URI (e.g., /oidc-redirect-callback). Note: This typically does not need to be modified",
+          "default": "/oidc-redirect-callback"
+        },
+        "logout_path": {
+          "type": "string",
+          "title": "OIDC Logout Path",
+          "description": "OpenID Connect Logout Path (e.g., /logmeout). Note: This typically does not need to be modified",
+          "default": "/logmeout"
+        },
+        "token_endpoint_auth_method": {
+          "type": "string",
+          "title": "OIDC Token Endpoint Authentication Method",
+          "description": "OpenID Token Endpoint Authentication Method (e.g., client_secret_basic). Note: This typically does not need to be modified",
+          "default": "client_secret_basic"
+        },
+        "use_spartan_resolver": {
+          "type": "boolean",
+          "title": "Use DC/OS Highly Available DNS Dispatcher (Spartan)?",
+          "description": "Use the DC/OS DNS Dispatcher (Spartan) to resolve OpenID Connect endpoints. Note: This typically does not need to be modified",
+          "default": true
+        }
+      }
+    },
+    "spark": {
+      "type": "object",
+      "id": "https://spark.apache.org/docs/latest/configuration.html",
+      "title": "Apache Spark Configuration",
+      "description": "Apache Spark Configuration",
+      "properties": {
+        "spark_master_url": {
+          "type": "string",
+          "title": "spark.master",
+          "description": "The cluster manager (--master) to connect to",
+          "default": "mesos://zk://zk-1.zk:2181,zk-2.zk:2181,zk-3.zk:2181,zk-4.zk:2181,zk-5.zk:2181/mesos"
+        },
+        "spark_conf_cores_max": {
+          "title": "spark.cores.max",
+          "description": "The maximum amount of CPU cores to request for the application from across the cluster",
+          "type": "integer",
+          "minimum": 1,
+          "default": 5
+        },
+        "spark_driver_cores": {
+          "type": "integer",
+          "title": "spark.driver.cores",
+          "description": "Number of cores (--driver-cores) to use for the driver process",
+          "minimum": 1,
+          "default": 2
+        },
+        "spark_conf_executor_cores": {
+          "title": "spark.executor.cores",
+          "description": "The number of cores to use on each executor. Note: This MUST be set to 1 if using TensorFlowOnSpark",
+          "type": "integer",
+          "minimum": 1,
+          "default": 1
+        },
+        "spark_conf_mesos_gpus_max": {
+          "type": "integer",
+          "id": "https://spark.apache.org/docs/latest/running-on-mesos.html",
+          "title": "spark.mesos.gpus.max",
+          "description": "Set the maximum number GPU resources to acquire for this job. Warning: Executors will still launch when no GPU resources are found since this configuration is just a upper limit and not a guaranteed amount. Note: GPU Support must be enabled for this to take effect",
+          "minimum": 0,
+          "default": 0
+        },
+        "spark_conf_mesos_executor_gpus": {
+          "type": "integer",
+          "id": "https://spark.apache.org/docs/latest/running-on-mesos.html",
+          "title": "spark.mesos.executor.gpus",
+          "description": "Set the hard limit on the (integer) number of gpus to request for each executor. Note: GPU Support must be enabled for this to take effect",
+          "minimum": 0,
+          "default": 0
+        },
+        "spark_driver_memory": {
+          "type": "string",
+          "title": "spark.driver.memory",
+          "description": "Amount of memory (--driver-memory) to use for the driver process, i.e. where SparkContext is initialized, in MiB unless otherwise specified (e.g. 1g, 2g). Note: This must be less than 75% of the memory allocation for the Notebook",
+          "default": "6g"
+        },
+        "spark_conf_executor_memory": {
+          "type": "string",
+          "title": "spark.executor.memory",
+          "description": "spark.executor.memory: Amount of memory to use per executor process, in MiB unless otherwise specified. (e.g. 2g, 8g)",
+          "default": "6g"
+        },
+        "spark_conf_eventlog_enabled": {
+          "type": "boolean",
+          "title": "spark.eventLog.enabled",
+          "description": "Whether to log Spark events, useful for reconstructing the Web UI after the application has finished",
+          "default": true
+        },
+        "spark_conf_eventlog_dir": {
+          "type": "string",
+          "title": "spark.eventLog.dir",
+          "description": "Base directory to which Spark events are logged, if spark.eventLog.enabled is true (e.g., hdfs://hdfs/ or s3a://path/to/bucket). Note: You'd typically want to set this to point to distributed/HA storage",
+          "default": "/mnt/mesos/sandbox/"
+        },
+        "start_spark_history_server": {
+          "type": "boolean",
+          "title": "Start Spark History Server?",
+          "description": "Start Spark History Server",
+          "default": true
+        },
+        "spark_history_fs_logdirectory": {
+          "type": "string",
+          "title": "Spark EventLog Directory",
+          "description": "Spark EvenLog Directory from which to load events for prior Spark job runs (e.g., hdfs://hdfs/ or s3a://path/to/bucket). Note: You'd typically want to set this to point to distributed/HA storage",
+          "default": "/mnt/mesos/sandbox/"
+        },
+        "spark_conf_jars_packages": {
+          "type": "string",
+          "title": "spark.jars.packages",
+          "description": "Comma-separated list of Maven coordinates of jars to include on the driver and executor classpaths (e.g., org.apache.spark:spark-streaming-kafka-0-10_2.11:2.2.1,org.apache.kafka:kafka_2.11:0.10.2.1)",
+          "default": ""
+        },
+        "spark_conf_mesos_principal": {
+          "type": "string",
+          "title": "",
+          "description": "Spark Mesos Principal. Typically set to the Service Account Name provisioned for the Mesosphere Jupyter Service (e.g., dev_jupyter)",
+          "default": ""
+        },
+        "spark_conf_mesos_role": {
+          "type": "string",
+          "title": "",
+          "description": "Spark Mesos Role. Typically set to the Mesos Role to which the Service Account for the Mesosphere Jupyter Service has been provisioned (e.g., dev-jupyter-role)",
+          "default": ""
+        },
+        "spark_conf_mesos_driver_labels": {
+          "type": "string",
+          "title": "spark.mesos.driver.labels",
+          "description": "Mesos labels to add to the driver. Labels are free-form key-value pairs. Key-value pairs should be separated by a colon, and commas used to list more than one. If your label includes a colon or comma, you can escape it with a backslash (e.g., DCOS_SPACE:/jupyter,key:value,key2:a\\:b)",
+          "default": ""
+        },
+        "spark_conf_mesos_task_labels": {
+          "type": "string",
+          "title": "spark.mesos.task.labels",
+          "description": "Set the Mesos labels to add to each task. Labels are free-form key-value pairs. Key-value pairs should be separated by a colon, and commas used to list more than one. If your label includes a colon or comma, you can escape it with a backslash (e.g., DCOS_SPACE:/jupyter,key:value,key2:a\\:b)",
+          "default": ""
+        },
+        "spark_conf_executor_krb5_config": {
+          "type": "string",
+          "title": "spark.executorEnv.KRB5_CONFIG",
+          "description": "Location of the krb5.conf file passed via the KRB5_CONFIG environment variable to the Spark Executors",
+          "default": "/mnt/mesos/sandbox/krb5.conf"
+        },
+        "spark_conf_spark_scheduler_min_registered_resources_ratio": {
+          "title": "spark.scheduler.minRegisteredResourcesRatio",
+          "description": "The minimum ratio (range: 0.0 - 1.0) of registered resources before the Spark Driver will allocate work to the Spark Executors",
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "default": 1.0
+        },
+        "spark_conf_mesos_containerizer": {
+          "description": "Spark Mesos Containerizer.",
+          "type": "string",
+          "enum": [
+            "mesos",
+            "docker"
+          ],
+          "default": "mesos"
+        },
+        "spark_conf_hadoop_fs_s3a_aws_credentials_provider": {
+          "type": "string",
+          "title": "spark.hadoop.fs.s3a.aws.credentials.provider",
+          "description": "Hadoop FS S3A Client Credentials Provider",
+          "enum": [
+            "com.amazonaws.auth.InstanceProfileCredentialsProvider",
+            "com.amazonaws.auth.EnvironmentVariableCredentialsProvider"
+          ],
+          "default": "com.amazonaws.auth.InstanceProfileCredentialsProvider"
+        },
+        "spark_driver_java_options": {
+          "type": "string",
+          "title": "spark.driver.extraJavaOptions",
+          "description": "A string of extra JVM options (--driver-java-options) to pass to the driver",
+          "default": "-server -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/mnt/mesos/sandbox"
+        },
+        "spark_conf_executor_java_options": {
+          "type": "string",
+          "title": "spark.executor.extraJavaOptions",
+          "description": "A string of extra JVM options to pass to executors",
+          "default": "-server -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/mnt/mesos/sandbox"
+        },
+        "spark_conf_mesos_executor_home": {
+          "type": "string",
+          "title": "spark.mesos.executor.home",
+          "description": "Set the directory into which Spark is installed for the Executors when running on Apache Mesos",
+          "default": "/opt/spark"
+        },
+        "spark_conf_executor_java_home": {
+          "type": "string",
+          "title": "spark.executorEnv.JAVA_HOME",
+          "description": "Location of the Java runtime passed via the JAVA_HOME environment variable to the Spark Executors",
+          "default": "/opt/jdk"
+        },
+        "spark_conf_executor_hadoop_hdfs_home": {
+          "type": "string",
+          "title": "spark.executorEnv.HADOOP_HDFS_HOME",
+          "description": "Location of the Hadoop distribution passed via the HADOOP_HDFS_HOME environment variable to the Spark Executors",
+          "default": "/opt/hadoop"
+        },
+        "spark_conf_executor_hadoop_opts": {
+          "type": "string",
+          "title": "spark.executorEnv.HADOOP_OPTS",
+          "description": "JVM Options to pass to the Hadoop runtime via the HADOOP_OPTS environment variable to the Spark Executors",
+          "default": "-Djava.library.path=/opt/hadoop/lib/native -Djava.security.krb5.conf=/mnt/mesos/sandbox/krb5.conf"
+        },
+        "spark_conf_mesos_executor_docker_forcepullimage": {
+          "type": "boolean",
+          "title": "spark.mesos.executor.docker.forcePullImage",
+          "description": "Force Mesos agents to pull the image specified in spark.mesos.executor.docker.image",
+          "default": false
+        },
+        "spark_user": {
+          "type": "string",
+          "title": "Spark User (Process Execution Context)",
+          "description": "The Linux user under which the Spark Executors will run",
+          "default": "nobody"
+        }
+      }
+    },
+    "advanced": {
+      "type": "object",
+      "title": "Advanced",
+      "description": "Advanced Configuration Options",
+      "properties": {
+        "force_pull_jupyter_image": {
+          "type": "boolean",
+          "title": "Force-Pull Mesosphere Jupyter Service Docker Image?",
+          "description": "Always force a pull of the Mesosphere Jupyter Service Docker Image?",
+          "default": false
+        },
+        "force_pull_worker_image": {
+          "type": "boolean",
+          "title": "Force-Pull Mesosphere Data Toolkit (Worker) Docker Image?",
+          "description": "Always force a pull of the Mesosphere Data Toolkit (Worker) Docker Image?",
+          "default": false
+        },
+        "home": {
+          "type": "string",
+          "title": "Home Directory",
+          "description": "Your Home Directory (HOME)",
+          "default": "/mnt/mesos/sandbox"
+        },
+        "sandbox": {
+          "type": "string",
+          "title": "Sandbox Directory",
+          "description": "Your Sandbox Directory (MESOS_SANDBOX)",
+          "default": "/mnt/mesos/sandbox"
+        },
+        "hadoop_conf_dir": {
+          "type": "string",
+          "title": "Haddop Configuration Directory",
+          "description": "Hadoop Configuration Directory (HADOOP_CONF_DIR)",
+          "default": "/mnt/mesos/sandbox"
+        },
+        "jupyter_config_dir": {
+          "type": "string",
+          "title": "Jupyter Notebook Configuration Directory",
+          "description": "Jupyter Notebook Configuration Directory (JUPYTER_CONFIG_DIR)",
+          "default": "/mnt/mesos/sandbox/.jupyter"
+        },
+        "jupyter_runtime_dir": {
+          "type": "string",
+          "title": "Jupyter Notebook Runtime Directory",
+          "description": "Jupyter Notebook Runtime Directory (JUPYTER_RUNTIME_DIR)",
+          "default": "/mnt/mesos/sandbox/.local/share/jupyter/runtime"
+        },
+        "conda_envs_path": {
+          "type": "string",
+          "title": "Conda Environment Paths",
+          "description": "Conda Environment Paths (CONDA_ENVS_PATH)",
+          "default": "/mnt/mesos/sandbox/conda/envs:/opt/conda/envs"
+        },
+        "conda_pkgs_dir": {
+          "type": "string",
+          "title": "Conda Package Directory Paths",
+          "description": "Conda Package Directory Paths (CONDA_PKGS_DIRS)",
+          "default": "/mnt/mesos/sandbox/conda/pkgs:/opt/conda/pkgs"
+        },
+        "dcos_dir": {
+          "type": "string",
+          "title": "DC/OS CLI Configuration Directory",
+          "description": "DC/OS CLI Config Directory (DCOS_DIR)",
+          "default": "/mnt/mesos/sandbox/.dcos"
+        },
+        "java_opts": {
+          "type": "string",
+          "title": "JVM Options",
+          "description": "JVM Options (JAVA_OPTS)",
+          "default": "-server -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/mnt/mesos/sandbox"
+        },
+        "nginx_log_level": {
+          "type": "string",
+          "title": "NGINX Log Level",
+          "description": "NGINX Log Level (NGINX_LOG_LEVEL)",
+          "enum": [
+            "debug",
+            "warn",
+            "info"
+          ],
+          "default": "warn"
+        },
+        "spark_monitor_enabled": {
+          "type": "boolean",
+          "id": "https://github.com/krishnan-r/sparkmonitor",
+          "title": "Enable SparkMonitor?",
+          "description": "Enable the SparkMonitor Jupyter Notebook Server Extension to proxy the Spark Driver UI?",
+          "default": true
+        },
+        "start_dask_distributed": {
+          "type": "boolean",
+          "title": "Start Dask Distributed?",
+          "description": "Start Dask's Distributed Scheduler?",
+          "default": false
+        },
+        "start_ray_head_node": {
+          "type": "boolean",
+          "title": "Start Ray Head Node?",
+          "description": "Start Ray Head Node?",
+          "default": false
+        },
+        "start_tensorboard": {
+          "type": "boolean",
+          "title": "Start TensorBoard?",
+          "description": "Start TensorBoard?",
+          "default": true
+        },
+        "tensorboard_logdir": {
+          "type": "string",
+          "title": "TensorBoard Log Directory",
+          "description": "TensorBoard Log Directory - e.g., hdfs://hdfs/ or s3://path/to/bucket",
+          "default": "/mnt/mesos/sandbox"
+        },
+        "term": {
+          "type": "string",
+          "title": "Terminal (TTY) Type",
+          "description": "Unix Terminal Type",
+          "default": "xterm-256color"
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/B/beta-mesosphere-jupyter-service/0/marathon.json.mustache
+++ b/repo/packages/B/beta-mesosphere-jupyter-service/0/marathon.json.mustache
@@ -1,0 +1,454 @@
+{
+  "id": "{{service.name}}",
+  "instances": 1,
+  "cpus": {{service.cpus}},
+
+  {{#service.gpu.enabled}}
+  "gpus": {{service.gpu.gpus}},
+  {{/service.gpu.enabled}}
+
+  "mem": {{service.mem}},
+  "user": "{{service.user}}",
+  "cmd": "{{service.cmd}}",
+  "constraints": {{service.placement_constraints}},
+  "container": {
+    "type": "MESOS",
+    "volumes": [
+
+      {{#service.service_account_secret}}
+      {
+        "containerPath": "secrets/service-account.json",
+        "secret": "serviceCredential"
+
+      {{#storage.local_persistence.enabled}}
+      },
+      {{/storage.local_persistence.enabled}}
+      {{^storage.local_persistence.enabled}}
+      }
+      {{/storage.local_persistence.enabled}}
+
+      {{/service.service_account_secret}}
+
+      {{#storage.local_persistence.enabled}}
+      {
+        "containerPath": "{{storage.local_persistence.volume_path}}",
+        "mode": "RW",
+        "persistent": {
+          "type": "root",
+          "size": {{storage.local_persistence.volume_size}},
+          "constraints": []
+        }
+      },
+      {
+        "containerPath": "{{advanced.sandbox}}/{{storage.local_persistence.volume_path}}",
+        "hostPath": "{{storage.local_persistence.volume_path}}",
+        "mode": "RW"
+      }
+      {{/storage.local_persistence.enabled}}
+
+    ],
+    "docker": {
+
+      {{#service.gpu.enabled}}
+      "image": "{{resource.assets.container.docker.jupyter-docker-gpu}}",
+      {{/service.gpu.enabled}}
+      {{^service.gpu.enabled}}
+      "image": "{{resource.assets.container.docker.jupyter-docker}}",
+      {{/service.gpu.enabled}}
+
+      "forcePullImage": {{advanced.force_pull_jupyter_image}}
+    }
+
+    {{#networking.cni_network_enabled}}
+    ,
+    "portMappings": [
+        {
+          "containerPort": 8080,
+          "protocol": "tcp",
+          "name": "notebook",
+          "labels": {
+            "VIP_0": "{{service.name}}:8888"
+          }
+        },
+        {
+          "containerPort": 7077,
+          "protocol": "tcp",
+          "name": "sparkdriver",
+          "labels": {
+            "VIP_1": "{{service.name}}:7077"
+          }
+        },
+        {
+          "containerPort": 4040,
+          "protocol": "tcp",
+          "name": "sparkui",
+          "labels": {
+            "VIP_2": "{{service.name}}:4040"
+          }
+        },
+        {
+          "containerPort": 6046,
+          "protocol": "tcp",
+          "name": "tfdbg",
+          "labels": {
+            "VIP_3": "{{service.name}}:6046"
+          }
+        },
+        {
+          "containerPort": 8786,
+          "protocol": "tcp",
+          "name": "daskscheduler",
+          "labels": {
+            "VIP_4": "{{service.name}}:8786"
+          }
+        },
+        {
+          "containerPort": 8787,
+          "protocol": "tcp",
+          "name": "daskboard",
+          "labels": {
+            "VIP_5": "{{service.name}}:8787"
+          }
+        },
+        {
+          "containerPort": 6379,
+          "protocol": "tcp",
+          "name": "rayredis",
+          "labels": {
+            "VIP_6": "{{service.name}}:6379"
+          }
+        },
+        {
+          "containerPort": 8076,
+          "protocol": "tcp",
+          "name": "rayobjectmanager",
+          "labels": {
+            "VIP_7": "{{service.name}}:8076"
+          }
+        },
+        {
+          "containerPort": 18080,
+          "protocol": "tcp",
+          "name": "sparkhistory",
+          "labels": {
+            "VIP_8": "{{service.name}}:18080"
+          }
+        }
+    ]
+  {{/networking.cni_network_enabled}}
+
+  },
+
+  {{#networking.cni_network_enabled}}
+  "networks": [
+      {
+        "mode": "container",
+        "name": "dcos"
+
+        {{#networking.cni_network_plugin_labels}}
+        ,
+        "labels": "{{networking.cni_network_plugin_labels}}"
+        {{/networking.cni_network_plugin_labels}}
+
+      }
+  ],
+  {{/networking.cni_network_enabled}}
+  {{^networking.cni_network_enabled}}
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "notebook",
+      "labels": {
+        "VIP_0": "{{service.name}}:8888"
+      }
+    },
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "sparkdriver",
+      "labels": {
+        "VIP_1": "{{service.name}}:7077"
+      }
+    },
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "sparkui",
+      "labels": {
+        "VIP_2": "{{service.name}}:4040"
+      }
+    },
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "sparkblockmanager"
+    },
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "tfdbg",
+      "labels": {
+        "VIP_3": "{{service.name}}:6046"
+      }
+    },
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "daskscheduler",
+      "labels": {
+        "VIP_4": "{{service.name}}:8786"
+      }
+    },
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "daskboard",
+      "labels": {
+        "VIP_5": "{{service.name}}:8787"
+      }
+    },
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "rayredis",
+      "labels": {
+        "VIP_6": "{{service.name}}:6379"
+      }
+    },
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "rayobjectmanager",
+      "labels": {
+        "VIP_7": "{{service.name}}:8076"
+      }
+    },
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "sparkhistory",
+      "labels": {
+        "VIP_7": "{{service.name}}:18080"
+      }
+    }
+  ],
+  {{/networking.cni_network_enabled}}
+
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+
+  "env": {
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "file://secrets/service-account.json",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"\/opt\/mesosphere\/libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\",\"parameters\":[{\"key\":\"service_account_credential\",\"value\":\"file://secrets/service-account.json\"}]},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"service_account_credential\",\"value\":\"file://secrets/service-account.json\"},{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    {{/service.service_account_secret}}
+
+    {{#storage.local_persistence.enabled}}
+    "CONDA_ENVS_PATH": "{{advanced.sandbox}}/{{storage.local_persistence.volume_path}}/conda/envs:/opt/conda/envs",
+    "CONDA_PKGS_DIRS": "{{advanced.sandbox}}/{{storage.local_persistence.volume_path}}/conda/pkgs:/opt/conda/pkgs",
+    "DCOS_DIR": "{{advanced.sandbox}}/{{storage.local_persistence.volume_path}}/.dcos",
+    "HADOOP_CONF_DIR": "{{advanced.sandbox}}/{{storage.local_persistence.volume_path}}",
+    "HOME": "{{advanced.sandbox}}/{{storage.local_persistence.volume_path}}",
+    "JUPYTER_CONFIG_DIR": "{{advanced.sandbox}}/{{storage.local_persistence.volume_path}}/.jupyter",
+    "JUPYTER_RUNTIME_DIR": "{{advanced.sandbox}}/{{storage.local_persistence.volume_path}}/.local/share/jupyter/runtime",
+    {{/storage.local_persistence.enabled}}
+    {{^storage.local_persistence.enabled}}
+    "CONDA_ENVS_PATH": "{{advanced.conda_envs_path}}",
+    "CONDA_PKGS_DIRS": "{{advanced.conda_pkgs_dir}}",
+    "DCOS_DIR": "{{advanced.dcos_dir}}",
+    "HADOOP_CONF_DIR": "{{advanced.hadoop_conf_dir}}",
+    "HOME": "{{advanced.home}}",
+    "JUPYTER_CONFIG_DIR": "{{advanced.jupyter_config_dir}}",
+    "JUPYTER_RUNTIME_DIR": "{{advanced.jupyter_runtime_dir}}",
+    {{/storage.local_persistence.enabled}}
+    
+    "ENABLE_SPARK_MONITOR": "{{advanced.spark_monitor_enabled}}",
+    "JAVA_OPTS": "'{{advanced.java_opts}}'",
+    
+    {{#service.jupyter_conf_urls}}
+    "JUPYTER_CONF_URLS": "{{service.jupyter_conf_urls}}",
+    {{/service.jupyter_conf_urls}}
+
+    "JUPYTER_PASSWORD": "{{service.jupyter_password}}",
+    
+    "NGINX_LOG_LEVEL": "{{advanced.nginx_log_level}}",
+
+    {{#oidc.enabled}}
+    {{#oidc.authorization_params}}
+    "OIDC_AUTHORIZATION_PARAMS": "{{oidc.authorization_params}}",
+    {{/oidc.authorization_params}}
+    
+    "OIDC_CLIENT_ID": "{{oidc.client_id}}",
+    
+    {{#oidc.client_secret}}
+    "OIDC_CLIENT_SECRET": "{{oidc.client_secret}}",
+    {{/oidc.client_secret}}
+    
+    "OIDC_DISCOVERY_URI": "{{oidc.discovery_uri}}",
+    
+    {{#oidc.email}}
+    "OIDC_EMAIL": "{{oidc.email}}",
+    {{/oidc.email}}
+    
+    "OIDC_LOGOUT_PATH": "https://{{networking.ingress.hostname}}{{service.name}}{{oidc.logout_path}}",
+    
+    {{#oidc.post_logout_redirect_uri}}
+    "OIDC_POST_LOGOUT_REDIRECT_URI": "{{oidc.post_logout_redirect_uri}}",
+    {{/oidc.post_logout_redirect_uri}}
+    {{^oidc.post_logout_redirect_uri}}
+    "OIDC_POST_LOGOUT_REDIRECT_URI": "https://{{networking.ingress.hostname}}{{service.name}}",
+    {{/oidc.post_logout_redirect_uri}}
+    
+    "OIDC_REDIRECT_URI": "https://{{networking.ingress.hostname}}{{service.name}}{{oidc.redirect_uri}}",
+    
+    {{#oidc.redirect_after_logout_uri}}
+    "OIDC_REDIRECT_AFTER_LOGOUT_URI": "{{oidc.redirect_after_logout_uri}}",
+    {{/oidc.redirect_after_logout_uri}}
+    {{^oidc.redirect_after_logout_uri}}
+    "OIDC_REDIRECT_AFTER_LOGOUT_URI": "https://{{networking.ingress.hostname}}{{service.name}}",
+    {{/oidc.redirect_after_logout_uri}}
+   
+    "OIDC_SCOPE": "{{oidc.scope}}",
+    
+    {{#oidc.tls_verify}}
+    "OIDC_TLS_VERIFY": "yes",
+    {{/oidc.tls_verify}}
+    {{^oidc.tls_verify}}
+    "OIDC_TLS_VERIFY": "no",
+    {{/oidc.tls_verify}}
+    
+    "OIDC_TOKEN_ENDPOINT_AUTH_METHOD": "{{oidc.token_endpoint_auth_method}}",
+    
+    {{#oidc.upn}}
+    "OIDC_UPN": "{{oidc.upn}}",
+    {{/oidc.upn}}
+    
+    "OIDC_USE_SPARTAN_RESOLVER": "{{oidc.use_spartan_resolver}}",
+    {{/oidc.enabled}}
+
+    "AWS_REGION": "{{storage.s3.aws_region}}",
+    "S3_ENDPOINT": "{{storage.s3.endpoint}}",
+    "S3_USE_HTTPS": "{{storage.s3.use_https}}",
+    "S3_VERIFY_SSL": "{{storage.s3.verify_ssl}}",
+
+    "SPARK_MASTER_URL": "{{spark.spark_master_url}}",
+    "SPARK_USER": "{{spark.spark_user}}",
+    "SPARK_DRIVER_CORES": "{{spark.spark_driver_cores}}",
+    "SPARK_DRIVER_MEMORY": "{{spark.spark_driver_memory}}",
+    "SPARK_DRIVER_JAVA_OPTIONS": "'{{spark.spark_driver_java_options}}'",
+
+    "SPARK_HISTORY_FS_LOGDIRECTORY": "{{spark.spark_history_fs_logdirectory}}",
+
+    "SPARK_CONF_SPARK_SCHEDULER_MINREGISTEREDRESOURCESRATIO": "spark.scheduler.minRegisteredResourcesRatio={{spark.spark_conf_spark_scheduler_min_registered_resources_ratio}}",
+    "SPARK_CONF_CORES_MAX": "spark.cores.max={{spark.spark_conf_cores_max}}",
+    "SPARK_CONF_EXECUTOR_CORES": "spark.executor.cores={{spark.spark_conf_executor_cores}}",
+    "SPARK_CONF_EXECUTOR_MEMORY": "spark.executor.memory={{spark.spark_conf_executor_memory}}",
+    "SPARK_CONF_EXECUTOR_JAVA_OPTIONS": "spark.executor.extraJavaOptions='{{spark.spark_conf_executor_java_options}}'",
+
+    "SPARK_CONF_EVENTLOG_ENABLED": "spark.eventLog.enabled={{spark.spark_conf_eventlog_enabled}}",
+    "SPARK_CONF_EVENTLOG_DIR": "spark.eventLog.dir={{spark.spark_conf_eventlog_dir}}",
+
+    "SPARK_CONF_HADOOP_FS_S3A_AWS_CREDENTIALS_PROVIDER": "spark.hadoop.fs.s3a.aws.credentials.provider={{spark.spark_conf_hadoop_fs_s3a_aws_credentials_provider}}",
+
+    {{#service.gpu.enabled}}
+    "SPARK_CONF_MESOS_EXECUTOR_DOCKER_IMAGE":"spark.mesos.executor.docker.image={{resource.assets.container.docker.worker-docker-gpu}}",
+    {{/service.gpu.enabled}}
+    {{^service.gpu.enabled}}
+    "SPARK_CONF_MESOS_EXECUTOR_DOCKER_IMAGE":"spark.mesos.executor.docker.image={{resource.assets.container.docker.worker-docker}}",
+    {{/service.gpu.enabled}}
+
+    "SPARK_CONF_SPARK_MESOS_EXECUTOR_DOCKER_FORCEPULLIMAGE": "spark.mesos.executor.docker.forcePullImage={{spark.spark_conf_mesos_executor_docker_forcepullimage}}",
+    "SPARK_CONF_MESOS_EXECUTOR_HOME": "spark.mesos.executor.home={{spark.spark_conf_mesos_executor_home}}",
+    "SPARK_CONF_MESOS_CONTAINERIZER": "spark.mesos.containerizer={{spark.spark_conf_mesos_containerizer}}",
+
+    {{#spark.spark_conf_mesos_principal}}
+    "SPARK_CONF_MESOS_PRINCIPAL": "spark.mesos.principal={{spark.spark_conf_mesos_principal}}",
+    {{/spark.spark_conf_mesos_principal}}
+
+    {{#spark.spark_conf_mesos_role}}
+    "SPARK_CONF_MESOS_ROLE": "spark.mesos.role={{spark.spark_conf_mesos_role}}",
+    {{/spark.spark_conf_mesos_role}}
+
+    {{#spark.spark_conf_mesos_driver_labels}}
+    "SPARK_CONF_MESOS_DRIVER_LABELS": "spark.mesos.driver.labels={{spark.spark_conf_mesos_driver_labels}}",
+    {{/spark.spark_conf_mesos_driver_labels}}
+
+    {{#spark.spark_conf_mesos_task_labels}}
+    "SPARK_CONF_MESOS_TASK_LABELS": "spark.mesos.task.labels={{spark.spark_conf_mesos_task_labels}}",
+    {{/spark.spark_conf_mesos_task_labels}}
+
+    "SPARK_CONF_SPARK_EXECUTORENV_KRB5_CONFIG": "spark.executorEnv.KRB5_CONFIG={{spark.spark_conf_executor_krb5_config}}",
+    "SPARK_CONF_SPARK_EXECUTORENV_JAVA_HOME": "spark.executorEnv.JAVA_HOME={{spark.spark_conf_executor_java_home}}",
+    "SPARK_CONF_SPARK_EXECUTORENV_HADOOP_HDFS_HOME": "spark.executorEnv.HADOOP_HDFS_HOME={{spark.spark_conf_executor_hadoop_hdfs_home}}",
+    "SPARK_CONF_SPARK_EXECUTORENV_HADOOP_OPTS": "spark.executorEnv.HADOOP_OPTS='{{spark.spark_conf_executor_hadoop_opts}}'",
+
+    {{#spark.spark_conf_jars_packages}}
+    "SPARK_CONF_SPARK_JARS_PACKAGES": "spark.jars.packages={{spark.spark_conf_jars_packages}}",
+    {{/spark.spark_conf_jars_packages}}
+
+    {{#advanced.start_dask_distributed}}
+    "START_DASK_DISTRIBUTED": "{{advanced.start_dask_distributed}}",
+    {{/advanced.start_dask_distributed}}
+
+    {{#advanced.start_ray_head_node}}
+    "START_RAY_HEAD_NODE": "{{advanced.start_ray_head_node}}",
+    {{/advanced.start_ray_head_node}}
+
+    {{#advanced.start_spark_history_server}}
+    "START_SPARK_HISTORY": "{{advanced.start_spark_history_server}}",
+    {{/advanced.start_spark_history_server}}
+
+    {{#advanced.start_tensorboard}}
+    "START_TENSORBOARD": "{{advanced.start_tensorboard}}",
+    "TENSORBOARD_LOGDIR": "{{advanced.tensorboard_logdir}}",
+    {{/advanced.start_tensorboard}}
+
+    "TERM": "{{advanced.term}}",
+    "USER": "{{service.user}}"
+  },
+  "labels": {
+    "DCOS_PACKAGE_IS_FRAMEWORK": "true",
+
+    {{#networking.ingress.enabled}}
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_ENABLED": "true",
+    "HAPROXY_0_REDIRECT_TO_HTTPS": "true",
+    "HAPROXY_0_VHOST": "{{networking.ingress.hostname}}",
+    "HAPROXY_0_PATH": "{{service.name}}",
+    "HAPROXY_2_ENABLED": "true",
+    "HAPROXY_2_REDIRECT_TO_HTTPS": "true",
+    {{/networking.ingress.enabled}}
+
+    "MARATHON_SINGLE_INSTANCE_APP": "true"
+  },
+  "healthChecks": [
+    {
+      "portIndex": 0,
+      "protocol": "MESOS_HTTP",
+      "path": "/healthz",
+      "gracePeriodSeconds": 30,
+      "intervalSeconds": 20,
+      "timeoutSeconds": 10,
+      "maxConsecutiveFailures": 3
+    }
+  ],
+
+  {{^storage.local_persistence.enabled}}
+  "unreachableStrategy": {
+    "expungeAfterSeconds": 0,
+    "inactiveAfterSeconds": 0
+  },
+  {{/storage.local_persistence.enabled}}
+
+  "upgradeStrategy": {
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/B/beta-mesosphere-jupyter-service/0/package.json
+++ b/repo/packages/B/beta-mesosphere-jupyter-service/0/package.json
@@ -1,0 +1,44 @@
+{
+  "packagingVersion": "4.0",
+  "minDcosReleaseVersion": "1.11",
+  "name": "beta-mesosphere-jupyter-service",
+  "version": "1.3.0-0.35.4-beta",
+  "scm": "https://github.com/dcos-labs/dcos-jupyterlab-service",
+  "maintainer": "support+mesosphere-jupyter-service@mesosphere.com",
+  "website": "https://docs.mesosphere.com/services/beta-jupyter",
+  "description": "The Mesosphere Jupyter Service provisions Jupyter Notebooks, an open-source web application that allows you to create and share documents that contain live code, equations, visualizations and narrative text.\nUses include: data cleaning and transformation, numerical simulation, statistical modeling, data visualization, machine learning, and much more.",
+  "framework": true,
+  "selected": false,
+  "upgradesFrom": [
+    "1.3.0-0.35.4-beta"
+  ],
+  "downgradesTo": [
+    "1.3.0-0.35.4-beta"
+  ],
+  "tags": [
+    "beakerx",
+    "dask",
+    "hdfs",
+    "jupyter",
+    "jupyterlab",
+    "notebook",
+    "openid-connect",
+    "ray",
+    "s3",
+    "spark",
+    "tensorflow"
+  ],
+  "preInstallNotes": "The Mesosphere Jupyter Service is currently in Beta. There may be bugs, incomplete features, incorrect documentation, breaking changes, or other discrepancies.",
+  "postInstallNotes": "The Mesosphere Jupyter Service has been installed. Please refer to the Service Documentation at https://docs.mesosphere.com/services/beta-jupyter",
+  "postUninstallNotes": "The Mesosphere Jupyter Service has been uninstalled. Thanks for playing. Note: If applicable, any data on the persistent volume on the agent where this service was deployed will be automatically deleted and the volume will be removed.",
+  "licenses": [
+    {
+      "name": "Modified BSD License (also known as New or Revised or 3-Clause BSD)",
+      "url": "https://raw.githubusercontent.com/jupyter/notebook/master/COPYING.md"
+    },
+    {
+      "name": "APACHE LICENSE, VERSION 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ]
+}

--- a/repo/packages/B/beta-mesosphere-jupyter-service/0/resource.json
+++ b/repo/packages/B/beta-mesosphere-jupyter-service/0/resource.json
@@ -1,0 +1,20 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/jupyter/assets/jupyter-logo.svg",
+    "icon-medium": "https://downloads.mesosphere.com/jupyter/assets/jupyter-logo.svg",
+    "icon-large": "https://downloads.mesosphere.com/jupyter/assets/jupyter-logo.svg",
+    "screenshots": [
+      "https://downloads.mesosphere.com/jupyter/assets/jupyter-screenshot.png"
+    ]
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "jupyter-docker": "mesosphere/mesosphere-jupyter-service:1.3.0-0.35.4",
+        "jupyter-docker-gpu": "mesosphere/mesosphere-jupyter-service:1.3.0-0.35.4",
+        "worker-docker": "mesosphere/mesosphere-data-toolkit:1.0.0-1.0.0",
+        "worker-docker-gpu": "mesosphere/mesosphere-data-toolkit:1.0.0-1.0.0-gpu"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# (Beta) Mesosphere Jupyter Service - Release: 1.3.0-0.35.4

This release contains everything from [1.2.0-0.33.7](https://github.com/dcos-labs/dcos-jupyterlab-service/releases/tag/1.2.0-0.33.7) and includes and/or updates the following:

## Major Features and Improvements

* Based on Debian [9.6](https://github.com/docker-library/repo-info/blob/master/repos/debian/tag-details.md#debian96---linux-amd64)

### Package Additions

* boost
* conda-pack
* gensim
* h2oai::h2o
* ibis-framework
* ipyleaflet
* nbdime
* nbserverproxy
* numexpr
* openblas
* plotly
* pyomo
* pyomo.extras
* pyomo.solvers
* r-caret
* r-devtools
* r-forecast
* r-nycflights13
* r-plotly
* r-randomforest
* r-sqlite
* r-shiny
* r-sparklyr
* r-tidyverse
* s3cmd
* setproctitle
* typing
* pygdf
* quilt[img,pytorch,torchvision]

### Package Bumps

* dask 1.0.0
* distributed 1.25.1
* hadoop 2.9.2
* horovod 0.15.2
* jupyterlab 0.35.4
* mlflow 0.8.1
* pyarrow 0.11.0
* r-base 3.5.1
* ray[debug,rllib] 0.6.1
* setuptools 40.6.3
* tensorflow 1.11.0
* tensorflowonspark 1.4.1
* toree 0.3.0-incubating

### Jupyter Extensions Additions

* [@jupyterlab/celltags](https://github.com/jupyterlab/jupyterlab-celltags)
* [dask-labextension](https://github.com/dask/dask-labextension)
* [jupyterlab/git](https://github.com/jupyterlab/jupyterlab-git)
* [jupyterlab-drawio](https://github.com/QuantStack/jupyterlab-drawio)
* [jupyter-leaflet](https://github.com/jupyter-widgets/ipyleaflet)
* [jupyterlab-kernelspy](https://github.com/vidartf/jupyterlab-kernelspy)
* [jupyterlab_iframe](jupyterlab_iframe)
* [nbdime-jupyterlab](https://github.com/jupyter/nbdime)
* [nbserverproxy](https://github.com/jupyterhub/nbserverproxy)
* [qgrid](https://github.com/quantopian/qgrid)

### NVIDIA Library Bumps

* cuDNN 7.4.1.5-1+cuda9.0
* NCCL 2.3.7-1+cuda9.0

### Miscellaneous Bumps

* libmesos-bundle [1.12.0](https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.12.0.tar.gz)
* zmartzone/lua-resty-openidc [1.7.0](https://github.com/zmartzone/lua-resty-openidc/releases/tag/v1.7.0)

### OpenID Connect

* Added support for specifying:
  * Authorization Parameters
  * Redirect After Logout URI
  * Redirect After Logout With ID Token Hint (default: `true`)
  * Refresh Session Interval (default: `3300` seconds)
  * Whether to renew Access Token on Expiry (default: `true`)

## Breaking Changes

### Configuration

* The `OIDC_REDIRECT_URI` environment variable must now be specified as an absolute URI since [redirect_uri_path is deprecated](https://github.com/zmartzone/lua-resty-openidc/commit/0f2a68b82cf4849fc3efe4b25c389fc45377fc63)
* Rename the `OIDC_AUTH_METHOD` environment variable to `OIDC_TOKEN_ENDPOINT_AUTH_METHOD` to disambiguate from the Introspection Endpoint Authentication method

### Features

* Apache Toree, as of [0.3.0-incubating](https://github.com/apache/incubator-toree/releases/tag/v0.3.0-incubating) has [removed support for PySpark and SparkR](https://github.com/apache/incubator-toree/commit/276165ae2ac136a59d208058a031caf769bb312e), only the Scala and SQL interpreters will remain available. The [vanilla PySpark and SparkR kernels, however retain their ability to launch pre-configured Spark Jobs](https://github.com/mesosphere/mesosphere-jupyter-service/blob/master/jupyter_notebook_config.py#L231-L232)

## Docker Images
* [mesosphere/mesosphere-jupyter-service:1.3.0-0.35.4](https://hub.docker.com/r/mesosphere/mesosphere-jupyter-service/tags/)
* [mesosphere/mesosphere-jupyter-service:1.3.0-0.35.4-gpu](https://hub.docker.com/r/mesosphere/mesosphere-jupyter-service/tags/)
* [mesosphere/mesosphere-data-toolkit:1.0.0-1.0.0](https://hub.docker.com/r/mesosphere/mesosphere-data-toolkit/tags/)
* [mesosphere/mesosphere-data-toolkit:1.0.0-1.0.0-gpu](https://hub.docker.com/r/mesosphere/mesosphere-data-toolkit/tags/)