### PR TITLE
fix the binaries hash for elastic and hdfs

### DIFF
--- a/repo/packages/E/elastic/500/marathon.json.mustache
+++ b/repo/packages/E/elastic/500/marathon.json.mustache
@@ -33,8 +33,8 @@
   "env": {
     "PACKAGE_NAME": "elastic",
     "PACKAGE_VERSION": "2.5.0-6.3.2",
-    "PACKAGE_BUILD_TIME_EPOCH_MS": "1547823997602",
-    "PACKAGE_BUILD_TIME_STR": "Fri Jan 18 2019 15:06:37 +0000",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1549552224271",
+    "PACKAGE_BUILD_TIME_STR": "Thu Feb 07 2019 15:10:24 +0000",
     "ELASTIC_VERSION": "6.3.2",
     "ELASTIC_STATSD_VERSION": "6.3.2.0",
     "STATSD_URI": "{{resource.assets.uris.statsd-plugin-zip}}",

--- a/repo/packages/E/elastic/500/resource.json
+++ b/repo/packages/E/elastic/500/resource.json
@@ -35,7 +35,7 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "c2e0f3ecf36807ddc5587326dd3992f54563d1e0003ecec79abd19ccfd65f34d"
+              "value": "8085bc61b9ce596cf4b5b6053424ec732d237830b2f31acd419af2ea2ffd4668"
             }
           ],
           "kind": "executable",
@@ -47,7 +47,7 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "a0b4da5e3cbe1aecd2fb7ec2137c51aca4f14162bf95c83a16afc7681682cf97"
+              "value": "a8ce02a11b31c0f832416758b796b0c9ce11917117c39b59a53b3123e15def94"
             }
           ],
           "kind": "executable",

--- a/repo/packages/H/hdfs/500/marathon.json.mustache
+++ b/repo/packages/H/hdfs/500/marathon.json.mustache
@@ -33,8 +33,8 @@
   "env": {
     "PACKAGE_NAME": "hdfs",
     "PACKAGE_VERSION": "2.5.0-2.6.0-cdh5.11.0",
-    "PACKAGE_BUILD_TIME_EPOCH_MS": "1547077866096",
-    "PACKAGE_BUILD_TIME_STR": "Wed Jan 09 2019 23:51:06 +0000",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1549551717716",
+    "PACKAGE_BUILD_TIME_STR": "Thu Feb 07 2019 15:01:57 +0000",
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
     "TASKCFG_ALL_HDFS_VERSION": "hadoop-2.6.0-cdh5.11.0",

--- a/repo/packages/H/hdfs/500/resource.json
+++ b/repo/packages/H/hdfs/500/resource.json
@@ -35,7 +35,7 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "c2e0f3ecf36807ddc5587326dd3992f54563d1e0003ecec79abd19ccfd65f34d"
+              "value": "8085bc61b9ce596cf4b5b6053424ec732d237830b2f31acd419af2ea2ffd4668"
             }
           ],
           "kind": "executable",
@@ -47,7 +47,7 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "a0b4da5e3cbe1aecd2fb7ec2137c51aca4f14162bf95c83a16afc7681682cf97"
+              "value": "a8ce02a11b31c0f832416758b796b0c9ce11917117c39b59a53b3123e15def94"
             }
           ],
           "kind": "executable",


### PR DESCRIPTION
Description
--
This PR fixes the binaries for 

HDFS version: 2.5.0-2.6.0-cdh5.11.0
Elastic version: 2.5.0-6.3.2

JIRAs
--
https://jira.mesosphere.com/browse/DCOS-48139
https://jira.mesosphere.com/browse/DCOS-48141