### PR TITLE
Release percona-pxc-mysql 0.2.0-5.7.21 (automated commit)



### DIFF
--- a/repo/packages/P/percona-pxc-mysql/100/config.json
+++ b/repo/packages/P/percona-pxc-mysql/100/config.json
@@ -1,0 +1,553 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "percona-pxc-mysql",
+          "title": "Service name"
+        },
+        "check_for_nobody_leave_unchecked_for_root": {
+          "description": "The user that the service will run as. If checked, the service will run as nobody. If unchecked, the service will run as root.",
+          "type": "boolean",
+          "default": true,
+          "title": "User"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": "",
+          "title": "Credential secret name (optional)"
+        },
+        "enable_secrets": {
+          "description": "Enables Secrets based storage of passwords. Applicable and enable only in DC/OS Enterprise versions",
+          "type": "boolean",
+          "default": false
+        },
+        "ssl_enabled": {
+          "description": "Enables SSL support for Percona XtraDB Cluster",
+          "type": "boolean",
+          "default": false
+        },
+        "pam_enabled": {
+          "description": "Enables PAM support for Authn and Authz Percona XtraDB Cluster",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        }
+      },
+      "required": [
+        "name",
+        "enable_secrets"
+      ]
+    },
+    "pxc-advanced": {
+      "description": "PXC properties",
+      "type": "object",
+      "properties": {
+        "pxc_encrypt_cluster_traffic": {
+          "title": "Enables automatic configuration of SSL encryption",
+          "description": "Enables automatic configuration of SSL encryption. When disabled, you need to configure SSL manually to encrypt Percona XtraDB Cluster traffic",
+          "type": "string",
+          "default": "OFF"
+        },
+        "pxc_maint_mode": {
+          "description": "Specifies the maintenance mode for taking a node down without adjusting settings in ProxySQL",
+          "type": "string",
+          "enum": [
+            "DISABLED",
+            "SHUTDOWN",
+            "MAINTENANCE"
+          ],
+          "default": "DISABLED"
+        },
+        "pxc_maint_transition_period": {
+          "description": "Defines the transition period when you change pxc_maint_mode to SHUTDOWN or MAINTENANCE .",
+          "type": "number",
+          "default": 10
+        },
+        "pxc_strict_mode": {
+          "description": "Controls PXC Strict Mode , which runs validations to avoid the use of experimental and unsupported features in Percona XtraDB Cluster.",
+          "type": "string",
+          "enum": [
+            "DISABLED",
+            "PERMISSIVE",
+            "ENFORCING",
+            "MASTER"
+          ],
+          "default": "ENFORCING"
+        },
+        "wsrep_auto_increment_control": {
+          "description": "Enables automatic adjustment of auto-increment system variables depending on the size of the cluster",
+          "type": "string",
+          "default": "ON"
+        },
+        "wsrep_causal_reads": {
+          "description": "In some cases, the master may apply events faster than a slave, which can cause master and slave to become out of sync for a brief moment.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_certify_nonPK": {
+          "description": "Enables automatic generation of primary keys for rows that do not have them.  Write set replication requires primary keys on all tables to allow for parallel applying of transactions.",
+          "type": "string",
+          "default": "ON"
+        },
+        "wsrep_convert_lock_to_trx": {
+          "description": "Defines whether locking sessions should be converted into transactions. By default, this is disabled.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_debug": {
+          "description": "Enables additional debugging output for the database server error log. By default, it is disabled. This variable can be used when trying to diagnose problems or when submitting a bug.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_desync": {
+          "description": "Defines  whether  the  node  should  participate  in  Flow  Control. By  default,  this  variable  is  disabled,  meaning that  if  the  receive  queue  becomes  too  big,  the  node  engages  in  Flow  Control",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_dirty_reads": {
+          "description": "Defines whether the node accepts read queries when in a non-operational state, that is, when it loses connection to the Primary Component.  ",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_drupal_282555_workaround": {
+          "description": "Enables a workaround for MySQL InnoDB bug that affects Drupal",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_forced_binlog_format": {
+          "description": "Defines a binary log format that will always be effective, regardless of the client session binlog_format variable value",
+          "type": "string",
+          "enum": [
+            "ROW",
+            "STATEMENT",
+            "MIXED",
+            "NONE"
+          ],
+          "default": "NONE"
+        },
+        "wsrep_load_data_splitting": {
+          "description": "Defines whether the node should split large LOAD DATA transactions.  This variable is enabled by default, meaning that LOAD DATA commands are split into transactions of 10 000 rows or less.",
+          "type": "string",
+          "default": "ON"
+        },
+        "wsrep_log_conflicts": {
+          "description": "Defines whether the node should log additional information about conflicts.  By default, this variable is disabled and Percona XtraDB Cluster uses standard logging features in MySQL.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_max_ws_rows": {
+          "description": "Defines the maximum number of rows each write-set can contain",
+          "type": "number",
+          "default": 0
+        },
+        "wsrep_max_ws_size": {
+          "description": "Defines the maximum write-set size (in bytes). Anything bigger than the specified value will be rejected.",
+          "type": "number",
+          "default": 2147483647
+        },
+        "wsrep_on": {
+          "description": "Defines whether updates from the current session should be replicated. If disabled, it does not cause the node to leave the cluster and the node continues to communicate with other nodes.",
+          "type": "string",
+          "default": "ON"
+        },
+        "wsrep_OSU_method": {
+          "description": "Defines the method for Online Schema Upgrade that the node uses to replicate DDL statements",
+          "type": "string",
+          "enum": [
+            "TOI",
+            "RSU"
+          ],
+          "default": "TOI"
+        },
+        "wsrep_recover": {
+          "description": "Recovers database state after crash by parsing GTID from the log.  If the GTID is found, it will be assigned as the initial position for server.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_reject_queries": {
+          "description": "Defines whether the node should log additional information about conflicts.  By default, this variable is disabled and Percona XtraDB Cluster uses standard logging features in MySQL.",
+          "type": "string",
+          "enum": [
+            "ALL",
+            "ALL_KILL",
+            "NONE"
+          ],
+          "default": "NONE"
+        },
+        "wsrep_replicate_myisam": {
+          "description": "Defines whether DML statements for MyISAM tables should be replicated. It is disabled by default, because MyISAM replication is still experimental. On the global level, wsrep_replicate_myisam can be set only during startup. On session level, you can change it during runtime as well.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_restart_slave": {
+          "description": "Defines whether replication slave should be restarted when the node joins back to the cluster.  Enabling this can be useful because asynchronous replication slave thread is stopped when the node tries to apply the next replication event while the node is in non-primary state.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_retry_autocommit": {
+          "description": "Specifies the number of times autocommit transactions will be retried in the cluster if it encounters certification errors. In case there is a conflict, it should be safe for the cluster node to simply retry the statement without returning an error to the client, hoping that it will pass next time.",
+          "type": "number",
+          "default": 1
+        },
+        "wsrep_slave_FK_checks": {
+          "description": "Defines whether foreign key checking is done for applier threads. This is enabled by default.",
+          "type": "string",
+          "default": "ON"
+        },
+        "wsrep_slave_threads": {
+          "description": "Specifies the number of threads that can apply replication transactions in parallel. Galera supports true parallel repli-cation  that  applies  transactions  in  parallel  only  when  it  is  safe  to  do  so.   This  variable  is  dynamic.   You  can  in-crease/decrease it at any time.",
+          "type": "number",
+          "default": 2
+        },
+        "wsrep_slave_UK_checks": {
+          "description": "Defines whether unique key checking is done for applier threads. This is disabled by default.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_sst_receive_address": {
+          "description": "Specifies the network address where donor node should send state transfers.  By default, this variable is set to AUTO, meaning that the IP address from wsrep_node_address is used",
+          "type": "string",
+          "default": "AUTO"
+        },
+        "wsrep_sync_wait": {
+          "description": "Controls cluster-wide causality checks on certain statements.  Checks ensure that the statement is executed on a node that is fully synced with the cluster.",
+          "type": "number",
+          "default": 0
+        }
+      }
+    },
+    "pxc": {
+      "description": "Template pod configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of Template pods to run",
+          "type": "integer",
+          "default": 3
+        },
+        "pxc_port": {
+          "title": "PXC Port",
+          "description": "Port number at which Mysql Server will run",
+          "type": "integer",
+          "default": 3306
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Placement constraints for nodes. Example: [[\"hostname\", \"UNIQUE\"]]",
+          "type": "string",
+          "default": "[[\"hostname\", \"UNIQUE\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Template pod CPU requirements",
+          "type": "number",
+          "default": 1
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Template pod mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Template pod persistent disk requirements (in MB)",
+          "type": "integer",
+          "default": 250
+        },
+        "disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "key_disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "bkp_disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "psql_disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "backup_store_endpoint": {
+          "title": "Backup Store Endpoint",
+          "description": "Backup service requires an endpoint of a S3 compatible Storage system",
+          "type": "string",
+          "default": "https://s3.amazonaws.com"
+        },
+        "cluster_name": {
+          "description": "Specifies the name of the cluster and should be identical on all nodes.",
+          "type": "string",
+          "default": "cluster1"
+        },
+        "mysql_root_password": {
+          "description": "password for root user for mysqld process of PXC cluster",
+          "type": "string",
+          "default": "root"
+        },
+        "xtrabackup_password": {
+          "description": "Specifies the password for xtrabackup user",
+          "type": "string",
+          "default": "xtrabackup"
+        },
+        "application_user_name": {
+          "description": "Specifies the username for application user for external user access to PXC",
+          "type": "string",
+          "default": "proxymon"
+        },
+        "application_user_password": {
+          "description": "Specifies the password for application user for external user access to PXC",
+          "type": "string",
+          "default": "proxym0n"
+        },
+        "mysqldexporter_password": {
+          "description": "Specifies the password for mysqldexporter user for PXC metrics",
+          "type": "string",
+          "default": "pxcm0n"
+        },
+        "ldap_uri": {
+          "description": "URI for LDAP server",
+          "type": "string",
+          "default": "ldap://openldap.marathon.l4lb.thisdcos.directory:389"
+        },
+        "ldap_base": {
+          "description": "base for LDAP server configuration, for example : dc=example,dc=org",
+          "type": "string",
+          "default": "dc=example,dc=org"
+        },
+        "ldap_binddn": {
+          "description": "binddn for LDAP server configuration, for example : cn=admin,dc=example,dc=org",
+          "type": "string",
+          "default": "cn=admin,dc=example,dc=org"
+        },
+        "ldap_bindpw": {
+          "description": "bindpw for LDAP server configuration or password for the above binddn",
+          "type": "string",
+          "default": "password"
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "disk_type",
+        "cluster_name",
+        "application_user_name",
+        "mysql_root_password",
+        "xtrabackup_password",
+        "application_user_password",
+        "mysqldexporter_password",
+        "ldap_bindpw"
+      ]
+    },
+    "proxysql": {
+      "description": "Template pod configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Proxysql Node count",
+          "description": "Number of Template pods to run",
+          "type": "integer",
+          "default": 1
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Placement constraints for nodes. Example: [[\"hostname\", \"UNIQUE\"]]",
+          "type": "string",
+          "default": "[[\"hostname\", \"UNIQUE\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Template pod CPU requirements",
+          "type": "number",
+          "default": 0.1
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Template pod mem requirements (in MB)",
+          "type": "integer",
+          "default": 252
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Template pod persistent disk requirements (in MB)",
+          "type": "integer",
+          "default": 25
+        },
+        "disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "admin_user": {
+          "description": "admin_variables admin user",
+          "type": "string",
+          "default": "admin"
+        },
+        "admin_password": {
+          "description": "Specifies the password for admin user",
+          "type": "string",
+          "default": "admin"
+        },
+        "refresh_interval": {
+          "description": "admin_variables refresh interval",
+          "type": "integer",
+          "default": 2000
+        },
+        "threads": {
+          "description": "mysql_variables threads",
+          "type": "integer",
+          "default": 2
+        },
+        "max_connections": {
+          "description": "mysql_variables max_connections",
+          "type": "integer",
+          "default": 2048
+        },
+        "default_query_delay": {
+          "description": "mysql_variables default_query_delay",
+          "type": "integer",
+          "default": 0
+        },
+        "default_query_timeout": {
+          "description": "mysql_variables default_query_timeout",
+          "type": "integer",
+          "default": 10000
+        },
+        "poll_timeout": {
+          "description": "mysql_variables poll_timeout",
+          "type": "integer",
+          "default": 2000
+        },
+        "default_schema": {
+          "description": "mysql_variables default_schema",
+          "type": "string",
+          "default": "information_schema"
+        },
+        "stacksize": {
+          "description": "mysql_variables stacksize",
+          "type": "integer",
+          "default": 1048576
+        },
+        "connect_timeout_server": {
+          "description": "mysql_variables connect_timeout_server",
+          "type": "integer",
+          "default": 10000
+        },
+        "monitor_history": {
+          "description": "mysql_variables monitor_history",
+          "type": "integer",
+          "default": 60000
+        },
+        "monitor_connect_interval": {
+          "description": "mysql_variables monitor_connect_interval",
+          "type": "integer",
+          "default": 20000
+        },
+        "monitor_ping_interval": {
+          "description": "mysql_variables monitor_ping_interval",
+          "type": "integer",
+          "default": 10000
+        },
+        "ping_timeout_server": {
+          "description": "mysql_variables ping_timeout_server",
+          "type": "integer",
+          "default": 200
+        },
+        "commands_stats": {
+          "description": "mysql_variables commands_stats",
+          "type": "string",
+          "default": "true"
+        },
+        "sessions_sort": {
+          "description": "mysql_variables sessions_sort",
+          "type": "string",
+          "default": "true"
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "admin_user",
+        "admin_password"
+      ]
+    }
+  }
+}

--- a/repo/packages/P/percona-pxc-mysql/100/marathon.json.mustache
+++ b/repo/packages/P/percona-pxc-mysql/100/marathon.json.mustache
@@ -1,0 +1,210 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+
+  {{#service.check_for_nobody_leave_unchecked_for_root}}
+  "user": "nobody",
+  {{/service.check_for_nobody_leave_unchecked_for_root}}
+  {{^service.check_for_nobody_leave_unchecked_for_root}}
+  "user": "root",
+  {{/service.check_for_nobody_leave_unchecked_for_root}}
+
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./percona-pxc-mysql-scheduler/bin/percona-pxc-mysql ./percona-pxc-mysql-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "PACKAGE_NAME": "percona-pxc-mysql",
+    "PACKAGE_VERSION": "0.2.0-5.7.21",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1552562293172",
+    "PACKAGE_BUILD_TIME_STR": "Thu Mar 14 2019 11:18:13 +0000",
+    "FRAMEWORK_NAME": "{{service.name}}",
+
+    {{#service.check_for_nobody_leave_unchecked_for_root}}
+    "FRAMEWORK_USER": "nobody",
+    {{/service.check_for_nobody_leave_unchecked_for_root}}
+    {{^service.check_for_nobody_leave_unchecked_for_root}}
+    "FRAMEWORK_USER": "root",
+    {{/service.check_for_nobody_leave_unchecked_for_root}}
+
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    "MESOS_API_VERSION": "V1",
+    
+    "TASKCFG_ALL_PXC_CLUSTER_NAME": "{{pxc.cluster_name}}",
+    "TASKCFG_ALL_PXC_APP_USER_NAME": "{{pxc.application_user_name}}",
+
+
+    "PXC_MYSQL_ROOT_PASSWORD": "{{pxc.mysql_root_password}}",
+    "PXC_XTRABKP_PASSWORD": "{{pxc.xtrabackup_password}}",
+    "PXC_APP_USER_PASSWORD": "{{pxc.application_user_password}}",
+    "PXC_MSQLD_EXPORTER_PASSWORD": "{{pxc.mysqldexporter_password}}",
+
+    "PXC_COUNT": "{{pxc.count}}",
+    "TASKCFG_ALL_PXC_PORT": "{{pxc.pxc_port}}",
+    "PXC_PLACEMENT": "{{{pxc.placement_constraint}}}",
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+    "PXC_CPUS": "{{pxc.cpus}}",
+    "PXC_MEM": "{{pxc.mem}}",
+    "PXC_DISK": "{{pxc.disk}}",
+    "PXC_DISK_TYPE": "{{pxc.disk_type}}",
+    "KEY_DISK_TYPE": "{{pxc.key_disk_type}}",
+    "BKP_DISK_TYPE": "{{pxc.bkp_disk_type}}",
+    "PSQL_DISK_TYPE": "{{pxc.psql_disk_type}}",
+    "STHREE_COMPATIBLE_URI": "{{pxc.backup_store_endpoint}}",
+    "TASKCFG_ALL_PXC_LDAP_URI": "{{{pxc.ldap_uri}}}",
+    "TASKCFG_ALL_PXC_LDAP_BASE": "{{{pxc.ldap_base}}}",
+    "TASKCFG_ALL_PXC_LDAP_BINDDN": "{{{pxc.ldap_binddn}}}",
+    "TASKCFG_ALL_PXC_LDAP_BINDPW": "{{{pxc.ldap_bindpw}}}",
+
+    "PROXYSQL_COUNT": "{{proxysql.count}}",
+    "PROXYSQL_PLACEMENT": "{{{proxysql.placement_constraint}}}",
+    "PROXYSQL_CPUS": "{{proxysql.cpus}}",
+    "PROXYSQL_MEM": "{{proxysql.mem}}",
+    "PROXYSQL_DISK": "{{proxysql.disk}}",
+    "PROXYSQL_DISK_TYPE": "ROOT",
+    "TASKCFG_ALL_PROXYSQL_ADMIN_USER": "{{proxysql.admin_user}}",
+    "TASKCFG_ALL_PROXYSQL_REFRESH_INTERVAL": "{{proxysql.refresh_interval}}",
+    "TASKCFG_ALL_PROXYSQL_THREADS": "{{proxysql.threads}}",
+    "TASKCFG_ALL_PROXYSQL_MAX_CONNECTIONS": "{{proxysql.max_connections}}",
+    "TASKCFG_ALL_PROXYSQL_DEFAULT_QUERY_DELAY": "{{proxysql.default_query_delay}}",
+    "TASKCFG_ALL_PROXYSQL_DEFAULT_QUERY_TIMEOUT": "{{proxysql.default_query_timeout}}",
+    "TASKCFG_ALL_PROXYSQL_POLL_TIMEOUT": "{{proxysql.poll_timeout}}",
+    "TASKCFG_ALL_PROXYSQL_DEFAULT_SCHEMA": "{{proxysql.default_schema}}",
+    "TASKCFG_ALL_PROXYSQL_STACKSIZE": "{{proxysql.stacksize}}",
+    "TASKCFG_ALL_PROXYSQL_CONNECT_TIMEOUT_SERVER": "{{proxysql.connect_timeout_server}}",
+    "TASKCFG_ALL_PROXYSQL_MONITOR_HISTORY": "{{proxysql.monitor_history}}",
+    "TASKCFG_ALL_PROXYSQL_MONITOR_CONNECT_INTERVAL": "{{proxysql.monitor_connect_interval}}",
+    "TASKCFG_ALL_PROXYSQL_MONITOR_PING_INTERVAL": "{{proxysql.monitor_ping_interval}}",
+    "TASKCFG_ALL_PROXYSQL_PING_TIMEOUT_SERVER": "{{proxysql.ping_timeout_server}}",
+    "TASKCFG_ALL_PROXYSQL_COMMANDS_STATS": "{{proxysql.commands_stats}}",
+    "TASKCFG_ALL_PROXYSQL_SESSIONS_SORT": "{{proxysql.sessions_sort}}",
+
+    "TASKCFG_ALL_PROXYSQL_CLUSTER_NAME_PXC": "{{pxc.cluster_name}}",
+
+
+    {{#service.enable_secrets}}
+    "TASKCFG_ALL_PXC_ENABLE_SECRETS": "{{service.enable_secrets}}",
+    {{/service.enable_secrets}}
+
+    "PROXYSQL_ADMIN_PASSWORD": "{{proxysql.admin_password}}",
+
+    {{#service.ssl_enabled}}
+    "TASKCFG_ALL_PXC_NET_SSL_ENABLED": "{{service.ssl_enabled}}",
+    {{/service.ssl_enabled}}
+
+    {{#service.pam_enabled}}
+    "TASKCFG_ALL_PXC_PAM_ENABLED": "{{service.pam_enabled}}",
+    {{/service.pam_enabled}}
+
+
+    "TASKCFG_ALL_PXC_ENCRYPT_CLUSTER_TRAFFIC": "{{pxc-advanced.pxc_encrypt_cluster_traffic}}",
+    "TASKCFG_ALL_PXC_MAINT_MODE": "{{pxc-advanced.pxc_maint_mode}}",
+    "TASKCFG_ALL_PXC_MAINT_TRANSITION_PERIOD": "{{pxc-advanced.pxc_maint_transition_period}}",
+    "TASKCFG_ALL_PXC_STRICT_MODE": "{{pxc-advanced.pxc_strict_mode}}",
+    "TASKCFG_ALL_WSREP_AUTO_INCREMENT_CONTROL": "{{pxc-advanced.wsrep_auto_increment_control}}",
+    "TASKCFG_ALL_WSREP_CAUSAL_READS": "{{pxc-advanced.wsrep_causal_reads}}",
+    "TASKCFG_ALL_WSREP_CERTIFY_NONPK": "{{pxc-advanced.wsrep_certify_nonPK}}",
+    "TASKCFG_ALL_WSREP_CONVERT_LOCK_TO_TRX": "{{pxc-advanced.wsrep_convert_lock_to_trx}}",
+    "TASKCFG_ALL_WSREP_DEBUG": "{{pxc-advanced.wsrep_debug}}",
+    "TASKCFG_ALL_WSREP_DESYNC": "{{pxc-advanced.wsrep_desync}}",
+    "TASKCFG_ALL_WSREP_DIRTY_READS": "{{pxc-advanced.wsrep_dirty_reads}}",
+    "TASKCFG_ALL_WSREP_DRUPAL_282555_WORKAROUND": "{{pxc-advanced.wsrep_drupal_282555_workaround}}",
+    "TASKCFG_ALL_WSREP_FORCED_BINLOG_FORMAT": "{{pxc-advanced.wsrep_forced_binlog_format}}",
+    "TASKCFG_ALL_WSREP_LOAD_DATA_SPLITTING": "{{pxc-advanced.wsrep_load_data_splitting}}",
+    "TASKCFG_ALL_WSREP_LOG_CONFLICTS": "{{pxc-advanced.wsrep_log_conflicts}}",
+    "TASKCFG_ALL_WSREP_MAX_WS_ROWS": "{{pxc-advanced.wsrep_max_ws_rows}}",
+    "TASKCFG_ALL_WSREP_MAX_WS_SIZE": "{{pxc-advanced.wsrep_max_ws_size}}",
+    "TASKCFG_ALL_WSREP_ON": "{{pxc-advanced.wsrep_on}}",
+    "TASKCFG_ALL_WSREP_OSU_METHOD": "{{pxc-advanced.wsrep_OSU_method}}",
+    "TASKCFG_ALL_WSREP_RECOVER": "{{pxc-advanced.wsrep_recover}}",
+    "TASKCFG_ALL_WSREP_REJECT_QUERIES": "{{pxc-advanced.wsrep_reject_queries}}",
+    "TASKCFG_ALL_WSREP_REPLICATE_MYISAM": "{{pxc-advanced.wsrep_replicate_myisam}}",
+    "TASKCFG_ALL_WSREP_RESTART_SLAVE": "{{pxc-advanced.wsrep_restart_slave}}",
+    "TASKCFG_ALL_WSREP_RETRY_AUTOCOMMIT": "{{pxc-advanced.wsrep_retry_autocommit}}",
+    "TASKCFG_ALL_WSREP_SLAVE_FK_CHECKS": "{{pxc-advanced.wsrep_slave_FK_checks}}",
+    "TASKCFG_ALL_WSREP_SLAVE_THREADS": "{{pxc-advanced.wsrep_slave_threads}}",
+    "TASKCFG_ALL_WSREP_SLAVE_UK_CHECKS": "{{pxc-advanced.wsrep_slave_UK_checks}}",
+    "TASKCFG_ALL_WSREP_SST_RECEIVE_ADDRESS": "{{pxc-advanced.wsrep_sst_receive_address}}",
+    "TASKCFG_ALL_WSREP_SYNC_WAIT": "{{pxc-advanced.wsrep_sync_wait}}",
+
+    
+    "IMAGE_IS_NOBODY": "{{service.check_for_nobody_leave_unchecked_for_root}}",
+    "PXC_DOCKER_IMAGE_ROOT": "{{resource.assets.container.docker.percona-xtradb-cluster-root}}",
+    "PXC_DOCKER_IMAGE_NOBODY": "{{resource.assets.container.docker.percona-xtradb-cluster-nobody}}",
+    "PROXYSQL_DOCKER_IMAGE_ROOT": "{{resource.assets.container.docker.proxysql-root}}",
+    "PROXYSQL_DOCKER_IMAGE_NOBODY": "{{resource.assets.container.docker.proxysql-nobody}}",
+    "MYSQL_DOCKER_IMAGE": "{{resource.assets.container.docker.mysqlcli}}",
+    "PROM_MYSQLD_EXPORTER_DOCKER_IMAGE": "{{resource.assets.container.docker.prom-mysqld-exporter}}",
+
+    "SYNC_STATE": "Not-Synced",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "PIP_URI": "{{resource.assets.uris.pip-uri}}",
+    "ZK_URI": "{{resource.assets.uris.zk-uri}}",
+    "MYSQLD_EXPORTER_URI": "{{resource.assets.uris.mysqld-exporter-uri}}",
+    "MC_URI": "{{resource.assets.uris.mc-uri}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.service_account_secret}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+ 
+  },
+  "uris": [
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "{{resource.assets.uris.pip-uri}}",
+    "{{resource.assets.uris.zk-uri}}",
+    "{{resource.assets.uris.mysqld-exporter-uri}}",
+    "{{resource.assets.uris.mc-uri}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/percona-pxc-mysql/100/package.json
+++ b/repo/packages/P/percona-pxc-mysql/100/package.json
@@ -1,0 +1,23 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "*"
+  ],
+  "downgradesTo": [
+    "*"
+  ],
+  "minDcosReleaseVersion": "1.9",
+  "name": "percona-pxc-mysql",
+  "version": "0.2.0-5.7.21",
+  "maintainer": "https://dcos.io/community",
+  "description": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production!",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "pxc",
+    "percona-pxc-mysql"
+  ],
+  "preInstallNotes": "Default configuration requires 3 agent nodes each with: 0.1 CPU | 252 MB MEM | 1 25 MB Disk.",
+  "postInstallNotes": "DC/OS Percona XtraDB CLuster is being installed!\n\n\tDocumentation: https://github.com/dcos/examples\n\tIssues: https://dcos.io/community",
+  "postUninstallNotes": "DC/OS Percona XtraDB CLuster is being uninstalled."
+}

--- a/repo/packages/P/percona-pxc-mysql/100/resource.json
+++ b/repo/packages/P/percona-pxc-mysql/100/resource.json
@@ -1,0 +1,70 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz",
+      "bootstrap-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip",
+      "scheduler-zip": "https://pxc-bucket.s3.amazonaws.com/pxc/assets/0.2.0-5.7.21/percona-pxc-mysql-scheduler.zip",
+      "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip",
+      "pip-uri": "https://bootstrap.pypa.io/get-pip.py",
+      "zk-uri": "https://s3-ap-northeast-1.amazonaws.com/pxc-utils/zookeepercli-linux-amd64-binary.tar.gz",
+      "mysqld-exporter-uri": "https://s3-ap-northeast-1.amazonaws.com/pxc-utils/mysqld_exporter-0.7.1.linux-amd64.tar.gz",
+      "mc-uri": "https://dl.minio.io/client/mc/release/linux-amd64/mc"
+    },
+    "container": {
+      "docker": {
+        "percona-xtradb-cluster-root": "mesostcs/pxc:5.7-DCOS-root",
+        "percona-xtradb-cluster-nobody": "mesostcs/pxc:5.7-DCOS-nobody",
+        "proxysql-root": "mesostcs/proxysql:1.4.12-DCOS-root",
+        "proxysql-nobody": "mesostcs/proxysql:1.4.12-DCOS-nobody",
+        "mysqlcli": "mysql:5.7",
+        "prom-mysqld-exporter": "mesostcs/mysqld-exporter:0.11.0"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://s3.amazonaws.com/pxc-icons/pxc-icon-small.png",
+    "icon-medium": "https://s3.amazonaws.com/pxc-icons/pxc-icon-medium.png",
+    "icon-large": "https://s3.amazonaws.com/pxc-icons/pxc-icon-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "c459d2109b31fc0b423f8cacd49df855ef898e63609f7050957f4a0e044d5432"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "e580ee8b71c0c26b1a1a605ca09cbd3528a2c031a8de11519024ccbbce862339"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "9135f9456a40cd53e27e73e44fc94c1d4cbf27d9b59f2b47d82bad3ae0f8c714"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release percona-pxc-mysql 0.2.0-5.7.21 (automated commit)

Description:
dc/os pxc release 0.2.0

Source URL: https://lcmdev.s3.amazonaws.com/autodelete7d/percona-pxc-mysql/20190314-111810-K8gnzQpWjSN7bqIL/stub-universe-percona-pxc-mysql.json

Changes between revisions 0 => 100:
0 files added: []
0 files removed: []
4 files changed:

```
--- 0/config.json
+++ 100/config.json
@@ -11,20 +11,10 @@
           "default": "percona-pxc-mysql",
           "title": "Service name"
         },
-        "cluster_name": {
-          "description": "Specifies the name of the cluster and should be identical on all nodes.",
-          "type": "string",
-          "default": "cluster1"
-        },
-        "mysql_root_password": {
-          "description": "Specifies the password for mysql cluster",
-          "type": "string",
-          "default": "root"
-        },
-        "user": {
-          "description": "The user that the service will run as.",
-          "type": "string",
-          "default": "root",
+        "check_for_nobody_leave_unchecked_for_root": {
+          "description": "The user that the service will run as. If checked, the service will run as nobody. If unchecked, the service will run as root.",
+          "type": "boolean",
+          "default": true,
           "title": "User"
         },
         "service_account": {
@@ -37,12 +27,22 @@
           "type": "string",
           "default": "",
           "title": "Credential secret name (optional)"
+        },
+        "enable_secrets": {
+          "description": "Enables Secrets based storage of passwords. Applicable and enable only in DC/OS Enterprise versions",
+          "type": "boolean",
+          "default": false
         },
         "ssl_enabled": {
           "description": "Enables SSL support for Percona XtraDB Cluster",
           "type": "boolean",
           "default": false
         },
+        "pam_enabled": {
+          "description": "Enables PAM support for Authn and Authz Percona XtraDB Cluster",
+          "type": "boolean",
+          "default": false
+        },
         "virtual_network_enabled": {
           "description": "Enable virtual networking",
           "type": "boolean",
@@ -57,15 +57,6 @@
           "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
           "type": "string",
           "default": ""
-        },
-        "mesos_api_version": {
-          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
-          "type": "string",
-          "enum": [
-            "V0",
-            "V1"
-          ],
-          "default": "V1"
         },
         "log_level": {
           "description": "The log level for the DC/OS service.",
@@ -85,8 +76,186 @@
       },
       "required": [
         "name",
-        "user"
+        "enable_secrets"
       ]
+    },
+    "pxc-advanced": {
+      "description": "PXC properties",
+      "type": "object",
+      "properties": {
+        "pxc_encrypt_cluster_traffic": {
+          "title": "Enables automatic configuration of SSL encryption",
+          "description": "Enables automatic configuration of SSL encryption. When disabled, you need to configure SSL manually to encrypt Percona XtraDB Cluster traffic",
+          "type": "string",
+          "default": "OFF"
+        },
+        "pxc_maint_mode": {
+          "description": "Specifies the maintenance mode for taking a node down without adjusting settings in ProxySQL",
+          "type": "string",
+          "enum": [
+            "DISABLED",
+            "SHUTDOWN",
+            "MAINTENANCE"
+          ],
+          "default": "DISABLED"
+        },
+        "pxc_maint_transition_period": {
+          "description": "Defines the transition period when you change pxc_maint_mode to SHUTDOWN or MAINTENANCE .",
+          "type": "number",
+          "default": 10
+        },
+        "pxc_strict_mode": {
+          "description": "Controls PXC Strict Mode , which runs validations to avoid the use of experimental and unsupported features in Percona XtraDB Cluster.",
+          "type": "string",
+          "enum": [
+            "DISABLED",
+            "PERMISSIVE",
+            "ENFORCING",
+            "MASTER"
+          ],
+          "default": "ENFORCING"
+        },
+        "wsrep_auto_increment_control": {
+          "description": "Enables automatic adjustment of auto-increment system variables depending on the size of the cluster",
+          "type": "string",
+          "default": "ON"
+        },
+        "wsrep_causal_reads": {
+          "description": "In some cases, the master may apply events faster than a slave, which can cause master and slave to become out of sync for a brief moment.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_certify_nonPK": {
+          "description": "Enables automatic generation of primary keys for rows that do not have them.  Write set replication requires primary keys on all tables to allow for parallel applying of transactions.",
+          "type": "string",
+          "default": "ON"
+        },
+        "wsrep_convert_lock_to_trx": {
+          "description": "Defines whether locking sessions should be converted into transactions. By default, this is disabled.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_debug": {
+          "description": "Enables additional debugging output for the database server error log. By default, it is disabled. This variable can be used when trying to diagnose problems or when submitting a bug.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_desync": {
+          "description": "Defines  whether  the  node  should  participate  in  Flow  Control. By  default,  this  variable  is  disabled,  meaning that  if  the  receive  queue  becomes  too  big,  the  node  engages  in  Flow  Control",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_dirty_reads": {
+          "description": "Defines whether the node accepts read queries when in a non-operational state, that is, when it loses connection to the Primary Component.  ",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_drupal_282555_workaround": {
+          "description": "Enables a workaround for MySQL InnoDB bug that affects Drupal",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_forced_binlog_format": {
+          "description": "Defines a binary log format that will always be effective, regardless of the client session binlog_format variable value",
+          "type": "string",
+          "enum": [
+            "ROW",
+            "STATEMENT",
+            "MIXED",
+            "NONE"
+          ],
+          "default": "NONE"
+        },
+        "wsrep_load_data_splitting": {
+          "description": "Defines whether the node should split large LOAD DATA transactions.  This variable is enabled by default, meaning that LOAD DATA commands are split into transactions of 10 000 rows or less.",
+          "type": "string",
+          "default": "ON"
+        },
+        "wsrep_log_conflicts": {
+          "description": "Defines whether the node should log additional information about conflicts.  By default, this variable is disabled and Percona XtraDB Cluster uses standard logging features in MySQL.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_max_ws_rows": {
+          "description": "Defines the maximum number of rows each write-set can contain",
+          "type": "number",
+          "default": 0
+        },
+        "wsrep_max_ws_size": {
+          "description": "Defines the maximum write-set size (in bytes). Anything bigger than the specified value will be rejected.",
+          "type": "number",
+          "default": 2147483647
+        },
+        "wsrep_on": {
+          "description": "Defines whether updates from the current session should be replicated. If disabled, it does not cause the node to leave the cluster and the node continues to communicate with other nodes.",
+          "type": "string",
+          "default": "ON"
+        },
+        "wsrep_OSU_method": {
+          "description": "Defines the method for Online Schema Upgrade that the node uses to replicate DDL statements",
+          "type": "string",
+          "enum": [
+            "TOI",
+            "RSU"
+          ],
+          "default": "TOI"
+        },
+        "wsrep_recover": {
+          "description": "Recovers database state after crash by parsing GTID from the log.  If the GTID is found, it will be assigned as the initial position for server.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_reject_queries": {
+          "description": "Defines whether the node should log additional information about conflicts.  By default, this variable is disabled and Percona XtraDB Cluster uses standard logging features in MySQL.",
+          "type": "string",
+          "enum": [
+            "ALL",
+            "ALL_KILL",
+            "NONE"
+          ],
+          "default": "NONE"
+        },
+        "wsrep_replicate_myisam": {
+          "description": "Defines whether DML statements for MyISAM tables should be replicated. It is disabled by default, because MyISAM replication is still experimental. On the global level, wsrep_replicate_myisam can be set only during startup. On session level, you can change it during runtime as well.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_restart_slave": {
+          "description": "Defines whether replication slave should be restarted when the node joins back to the cluster.  Enabling this can be useful because asynchronous replication slave thread is stopped when the node tries to apply the next replication event while the node is in non-primary state.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_retry_autocommit": {
+          "description": "Specifies the number of times autocommit transactions will be retried in the cluster if it encounters certification errors. In case there is a conflict, it should be safe for the cluster node to simply retry the statement without returning an error to the client, hoping that it will pass next time.",
+          "type": "number",
+          "default": 1
+        },
+        "wsrep_slave_FK_checks": {
+          "description": "Defines whether foreign key checking is done for applier threads. This is enabled by default.",
+          "type": "string",
+          "default": "ON"
+        },
+        "wsrep_slave_threads": {
+          "description": "Specifies the number of threads that can apply replication transactions in parallel. Galera supports true parallel repli-cation  that  applies  transactions  in  parallel  only  when  it  is  safe  to  do  so.   This  variable  is  dynamic.   You  can  in-crease/decrease it at any time.",
+          "type": "number",
+          "default": 2
+        },
+        "wsrep_slave_UK_checks": {
+          "description": "Defines whether unique key checking is done for applier threads. This is disabled by default.",
+          "type": "string",
+          "default": "OFF"
+        },
+        "wsrep_sst_receive_address": {
+          "description": "Specifies the network address where donor node should send state transfers.  By default, this variable is set to AUTO, meaning that the IP address from wsrep_node_address is used",
+          "type": "string",
+          "default": "AUTO"
+        },
+        "wsrep_sync_wait": {
+          "description": "Controls cluster-wide causality checks on certain statements.  Checks ensure that the statement is executed on a node that is fully synced with the cluster.",
+          "type": "number",
+          "default": 0
+        }
+      }
     },
     "pxc": {
       "description": "Template pod configuration properties",
@@ -98,6 +267,12 @@
           "type": "integer",
           "default": 3
         },
+        "pxc_port": {
+          "title": "PXC Port",
+          "description": "Port number at which Mysql Server will run",
+          "type": "integer",
+          "default": 3306
+        },
         "placement_constraint": {
           "title": "Placement constraint",
           "description": "Placement constraints for nodes. Example: [[\"hostname\", \"UNIQUE\"]]",
@@ -111,19 +286,19 @@
           "title": "CPU count",
           "description": "Template pod CPU requirements",
           "type": "number",
-          "default": 0.1
+          "default": 1
         },
         "mem": {
           "title": "Memory size (MB)",
           "description": "Template pod mem requirements (in MB)",
           "type": "integer",
-          "default": 252
+          "default": 1024
         },
         "disk": {
           "title": "Disk size (MB)",
           "description": "Template pod persistent disk requirements (in MB)",
           "type": "integer",
-          "default": 25
+          "default": 250
         },
         "disk_type": {
           "title": "Disk type [ROOT, MOUNT]",
@@ -134,10 +309,88 @@
           ],
           "default": "ROOT"
         },
-        "port": {
-          "description": "Port for broker to listen on",
-          "type": "integer",
-          "default": 3306
+        "key_disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "bkp_disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "psql_disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "backup_store_endpoint": {
+          "title": "Backup Store Endpoint",
+          "description": "Backup service requires an endpoint of a S3 compatible Storage system",
+          "type": "string",
+          "default": "https://s3.amazonaws.com"
+        },
+        "cluster_name": {
+          "description": "Specifies the name of the cluster and should be identical on all nodes.",
+          "type": "string",
+          "default": "cluster1"
+        },
+        "mysql_root_password": {
+          "description": "password for root user for mysqld process of PXC cluster",
+          "type": "string",
+          "default": "root"
+        },
+        "xtrabackup_password": {
+          "description": "Specifies the password for xtrabackup user",
+          "type": "string",
+          "default": "xtrabackup"
+        },
+        "application_user_name": {
+          "description": "Specifies the username for application user for external user access to PXC",
+          "type": "string",
+          "default": "proxymon"
+        },
+        "application_user_password": {
+          "description": "Specifies the password for application user for external user access to PXC",
+          "type": "string",
+          "default": "proxym0n"
+        },
+        "mysqldexporter_password": {
+          "description": "Specifies the password for mysqldexporter user for PXC metrics",
+          "type": "string",
+          "default": "pxcm0n"
+        },
+        "ldap_uri": {
+          "description": "URI for LDAP server",
+          "type": "string",
+          "default": "ldap://openldap.marathon.l4lb.thisdcos.directory:389"
+        },
+        "ldap_base": {
+          "description": "base for LDAP server configuration, for example : dc=example,dc=org",
+          "type": "string",
+          "default": "dc=example,dc=org"
+        },
+        "ldap_binddn": {
+          "description": "binddn for LDAP server configuration, for example : cn=admin,dc=example,dc=org",
+          "type": "string",
+          "default": "cn=admin,dc=example,dc=org"
+        },
+        "ldap_bindpw": {
+          "description": "bindpw for LDAP server configuration or password for the above binddn",
+          "type": "string",
+          "default": "password"
         }
       },
       "required": [
@@ -145,7 +398,14 @@
         "cpus",
         "mem",
         "disk",
-        "disk_type"
+        "disk_type",
+        "cluster_name",
+        "application_user_name",
+        "mysql_root_password",
+        "xtrabackup_password",
+        "application_user_password",
+        "mysqldexporter_password",
+        "ldap_bindpw"
       ]
     },
     "proxysql": {
@@ -193,6 +453,91 @@
             "MOUNT"
           ],
           "default": "ROOT"
+        },
+        "admin_user": {
+          "description": "admin_variables admin user",
+          "type": "string",
+          "default": "admin"
+        },
+        "admin_password": {
+          "description": "Specifies the password for admin user",
+          "type": "string",
+          "default": "admin"
+        },
+        "refresh_interval": {
+          "description": "admin_variables refresh interval",
+          "type": "integer",
+          "default": 2000
+        },
+        "threads": {
+          "description": "mysql_variables threads",
+          "type": "integer",
+          "default": 2
+        },
+        "max_connections": {
+          "description": "mysql_variables max_connections",
+          "type": "integer",
+          "default": 2048
+        },
+        "default_query_delay": {
+          "description": "mysql_variables default_query_delay",
+          "type": "integer",
+          "default": 0
+        },
+        "default_query_timeout": {
+          "description": "mysql_variables default_query_timeout",
+          "type": "integer",
+          "default": 10000
+        },
+        "poll_timeout": {
+          "description": "mysql_variables poll_timeout",
+          "type": "integer",
+          "default": 2000
+        },
+        "default_schema": {
+          "description": "mysql_variables default_schema",
+          "type": "string",
+          "default": "information_schema"
+        },
+        "stacksize": {
+          "description": "mysql_variables stacksize",
+          "type": "integer",
+          "default": 1048576
+        },
+        "connect_timeout_server": {
+          "description": "mysql_variables connect_timeout_server",
+          "type": "integer",
+          "default": 10000
+        },
+        "monitor_history": {
+          "description": "mysql_variables monitor_history",
+          "type": "integer",
+          "default": 60000
+        },
+        "monitor_connect_interval": {
+          "description": "mysql_variables monitor_connect_interval",
+          "type": "integer",
+          "default": 20000
+        },
+        "monitor_ping_interval": {
+          "description": "mysql_variables monitor_ping_interval",
+          "type": "integer",
+          "default": 10000
+        },
+        "ping_timeout_server": {
+          "description": "mysql_variables ping_timeout_server",
+          "type": "integer",
+          "default": 200
+        },
+        "commands_stats": {
+          "description": "mysql_variables commands_stats",
+          "type": "string",
+          "default": "true"
+        },
+        "sessions_sort": {
+          "description": "mysql_variables sessions_sort",
+          "type": "string",
+          "default": "true"
         }
       },
       "required": [
@@ -200,7 +545,8 @@
         "cpus",
         "mem",
         "disk",
-        "disk_type"
+        "admin_user",
+        "admin_password"
       ]
     }
   }
--- 0/marathon.json.mustache
+++ 100/marathon.json.mustache
@@ -3,7 +3,14 @@
   "cpus": 1.0,
   "mem": 1024,
   "instances": 1,
-  "user": "{{service.user}}",
+
+  {{#service.check_for_nobody_leave_unchecked_for_root}}
+  "user": "nobody",
+  {{/service.check_for_nobody_leave_unchecked_for_root}}
+  {{^service.check_for_nobody_leave_unchecked_for_root}}
+  "user": "root",
+  {{/service.check_for_nobody_leave_unchecked_for_root}}
+
   "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./percona-pxc-mysql-scheduler/bin/percona-pxc-mysql ./percona-pxc-mysql-scheduler/svc.yml",
   "labels": {
     "DCOS_COMMONS_API_VERSION": "v1",
@@ -23,19 +30,33 @@
   {{/service.service_account_secret}}
   "env": {
     "PACKAGE_NAME": "percona-pxc-mysql",
-    "PACKAGE_VERSION": "0.1.0-5.7.21-29.26",
-    "PACKAGE_BUILD_TIME_EPOCH_MS": "1532963653379",
-    "PACKAGE_BUILD_TIME_STR": "Mon Jul 30 2018 15:14:13 +0000",
+    "PACKAGE_VERSION": "0.2.0-5.7.21",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1552562293172",
+    "PACKAGE_BUILD_TIME_STR": "Thu Mar 14 2019 11:18:13 +0000",
     "FRAMEWORK_NAME": "{{service.name}}",
-    "FRAMEWORK_USER": "{{service.user}}",
+
+    {{#service.check_for_nobody_leave_unchecked_for_root}}
+    "FRAMEWORK_USER": "nobody",
+    {{/service.check_for_nobody_leave_unchecked_for_root}}
+    {{^service.check_for_nobody_leave_unchecked_for_root}}
+    "FRAMEWORK_USER": "root",
+    {{/service.check_for_nobody_leave_unchecked_for_root}}
+
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
-    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    "MESOS_API_VERSION": "V1",
     
-    "CLUSTER_NAME": "{{service.cluster_name}}",
-    "MYSQL_ROOT_PASSWORD": "{{service.mysql_root_password}}",
+    "TASKCFG_ALL_PXC_CLUSTER_NAME": "{{pxc.cluster_name}}",
+    "TASKCFG_ALL_PXC_APP_USER_NAME": "{{pxc.application_user_name}}",
+
+
+    "PXC_MYSQL_ROOT_PASSWORD": "{{pxc.mysql_root_password}}",
+    "PXC_XTRABKP_PASSWORD": "{{pxc.xtrabackup_password}}",
+    "PXC_APP_USER_PASSWORD": "{{pxc.application_user_password}}",
+    "PXC_MSQLD_EXPORTER_PASSWORD": "{{pxc.mysqldexporter_password}}",
 
     "PXC_COUNT": "{{pxc.count}}",
+    "TASKCFG_ALL_PXC_PORT": "{{pxc.pxc_port}}",
     "PXC_PLACEMENT": "{{{pxc.placement_constraint}}}",
     {{#service.virtual_network_enabled}}
     "ENABLE_VIRTUAL_NETWORK": "yes",
@@ -46,30 +67,103 @@
     "PXC_MEM": "{{pxc.mem}}",
     "PXC_DISK": "{{pxc.disk}}",
     "PXC_DISK_TYPE": "{{pxc.disk_type}}",
-    "PXC_PORT": "{{pxc.port}}",
+    "KEY_DISK_TYPE": "{{pxc.key_disk_type}}",
+    "BKP_DISK_TYPE": "{{pxc.bkp_disk_type}}",
+    "PSQL_DISK_TYPE": "{{pxc.psql_disk_type}}",
+    "STHREE_COMPATIBLE_URI": "{{pxc.backup_store_endpoint}}",
+    "TASKCFG_ALL_PXC_LDAP_URI": "{{{pxc.ldap_uri}}}",
+    "TASKCFG_ALL_PXC_LDAP_BASE": "{{{pxc.ldap_base}}}",
+    "TASKCFG_ALL_PXC_LDAP_BINDDN": "{{{pxc.ldap_binddn}}}",
+    "TASKCFG_ALL_PXC_LDAP_BINDPW": "{{{pxc.ldap_bindpw}}}",
 
     "PROXYSQL_COUNT": "{{proxysql.count}}",
     "PROXYSQL_PLACEMENT": "{{{proxysql.placement_constraint}}}",
     "PROXYSQL_CPUS": "{{proxysql.cpus}}",
     "PROXYSQL_MEM": "{{proxysql.mem}}",
     "PROXYSQL_DISK": "{{proxysql.disk}}",
-    "PROXYSQL_DISK_TYPE": "{{proxysql.disk_type}}",
+    "PROXYSQL_DISK_TYPE": "ROOT",
+    "TASKCFG_ALL_PROXYSQL_ADMIN_USER": "{{proxysql.admin_user}}",
+    "TASKCFG_ALL_PROXYSQL_REFRESH_INTERVAL": "{{proxysql.refresh_interval}}",
+    "TASKCFG_ALL_PROXYSQL_THREADS": "{{proxysql.threads}}",
+    "TASKCFG_ALL_PROXYSQL_MAX_CONNECTIONS": "{{proxysql.max_connections}}",
+    "TASKCFG_ALL_PROXYSQL_DEFAULT_QUERY_DELAY": "{{proxysql.default_query_delay}}",
+    "TASKCFG_ALL_PROXYSQL_DEFAULT_QUERY_TIMEOUT": "{{proxysql.default_query_timeout}}",
+    "TASKCFG_ALL_PROXYSQL_POLL_TIMEOUT": "{{proxysql.poll_timeout}}",
+    "TASKCFG_ALL_PROXYSQL_DEFAULT_SCHEMA": "{{proxysql.default_schema}}",
+    "TASKCFG_ALL_PROXYSQL_STACKSIZE": "{{proxysql.stacksize}}",
+    "TASKCFG_ALL_PROXYSQL_CONNECT_TIMEOUT_SERVER": "{{proxysql.connect_timeout_server}}",
+    "TASKCFG_ALL_PROXYSQL_MONITOR_HISTORY": "{{proxysql.monitor_history}}",
+    "TASKCFG_ALL_PROXYSQL_MONITOR_CONNECT_INTERVAL": "{{proxysql.monitor_connect_interval}}",
+    "TASKCFG_ALL_PROXYSQL_MONITOR_PING_INTERVAL": "{{proxysql.monitor_ping_interval}}",
+    "TASKCFG_ALL_PROXYSQL_PING_TIMEOUT_SERVER": "{{proxysql.ping_timeout_server}}",
+    "TASKCFG_ALL_PROXYSQL_COMMANDS_STATS": "{{proxysql.commands_stats}}",
+    "TASKCFG_ALL_PROXYSQL_SESSIONS_SORT": "{{proxysql.sessions_sort}}",
+
+    "TASKCFG_ALL_PROXYSQL_CLUSTER_NAME_PXC": "{{pxc.cluster_name}}",
+
+
+    {{#service.enable_secrets}}
+    "TASKCFG_ALL_PXC_ENABLE_SECRETS": "{{service.enable_secrets}}",
+    {{/service.enable_secrets}}
+
+    "PROXYSQL_ADMIN_PASSWORD": "{{proxysql.admin_password}}",
 
     {{#service.ssl_enabled}}
-    "PXC_NET_SSL_ENABLED": "{{service.ssl_enabled}}",
+    "TASKCFG_ALL_PXC_NET_SSL_ENABLED": "{{service.ssl_enabled}}",
     {{/service.ssl_enabled}}
 
-    "PXC_DOCKER_IMAGE": "{{resource.assets.container.docker.percona-xtradb-cluster}}",
-    "PROXYSQL_DOCKER_IMAGE": "{{resource.assets.container.docker.proxysql}}",
+    {{#service.pam_enabled}}
+    "TASKCFG_ALL_PXC_PAM_ENABLED": "{{service.pam_enabled}}",
+    {{/service.pam_enabled}}
+
+
+    "TASKCFG_ALL_PXC_ENCRYPT_CLUSTER_TRAFFIC": "{{pxc-advanced.pxc_encrypt_cluster_traffic}}",
+    "TASKCFG_ALL_PXC_MAINT_MODE": "{{pxc-advanced.pxc_maint_mode}}",
+    "TASKCFG_ALL_PXC_MAINT_TRANSITION_PERIOD": "{{pxc-advanced.pxc_maint_transition_period}}",
+    "TASKCFG_ALL_PXC_STRICT_MODE": "{{pxc-advanced.pxc_strict_mode}}",
+    "TASKCFG_ALL_WSREP_AUTO_INCREMENT_CONTROL": "{{pxc-advanced.wsrep_auto_increment_control}}",
+    "TASKCFG_ALL_WSREP_CAUSAL_READS": "{{pxc-advanced.wsrep_causal_reads}}",
+    "TASKCFG_ALL_WSREP_CERTIFY_NONPK": "{{pxc-advanced.wsrep_certify_nonPK}}",
+    "TASKCFG_ALL_WSREP_CONVERT_LOCK_TO_TRX": "{{pxc-advanced.wsrep_convert_lock_to_trx}}",
+    "TASKCFG_ALL_WSREP_DEBUG": "{{pxc-advanced.wsrep_debug}}",
+    "TASKCFG_ALL_WSREP_DESYNC": "{{pxc-advanced.wsrep_desync}}",
+    "TASKCFG_ALL_WSREP_DIRTY_READS": "{{pxc-advanced.wsrep_dirty_reads}}",
+    "TASKCFG_ALL_WSREP_DRUPAL_282555_WORKAROUND": "{{pxc-advanced.wsrep_drupal_282555_workaround}}",
+    "TASKCFG_ALL_WSREP_FORCED_BINLOG_FORMAT": "{{pxc-advanced.wsrep_forced_binlog_format}}",
+    "TASKCFG_ALL_WSREP_LOAD_DATA_SPLITTING": "{{pxc-advanced.wsrep_load_data_splitting}}",
+    "TASKCFG_ALL_WSREP_LOG_CONFLICTS": "{{pxc-advanced.wsrep_log_conflicts}}",
+    "TASKCFG_ALL_WSREP_MAX_WS_ROWS": "{{pxc-advanced.wsrep_max_ws_rows}}",
+    "TASKCFG_ALL_WSREP_MAX_WS_SIZE": "{{pxc-advanced.wsrep_max_ws_size}}",
+    "TASKCFG_ALL_WSREP_ON": "{{pxc-advanced.wsrep_on}}",
+    "TASKCFG_ALL_WSREP_OSU_METHOD": "{{pxc-advanced.wsrep_OSU_method}}",
+    "TASKCFG_ALL_WSREP_RECOVER": "{{pxc-advanced.wsrep_recover}}",
+    "TASKCFG_ALL_WSREP_REJECT_QUERIES": "{{pxc-advanced.wsrep_reject_queries}}",
+    "TASKCFG_ALL_WSREP_REPLICATE_MYISAM": "{{pxc-advanced.wsrep_replicate_myisam}}",
+    "TASKCFG_ALL_WSREP_RESTART_SLAVE": "{{pxc-advanced.wsrep_restart_slave}}",
+    "TASKCFG_ALL_WSREP_RETRY_AUTOCOMMIT": "{{pxc-advanced.wsrep_retry_autocommit}}",
+    "TASKCFG_ALL_WSREP_SLAVE_FK_CHECKS": "{{pxc-advanced.wsrep_slave_FK_checks}}",
+    "TASKCFG_ALL_WSREP_SLAVE_THREADS": "{{pxc-advanced.wsrep_slave_threads}}",
+    "TASKCFG_ALL_WSREP_SLAVE_UK_CHECKS": "{{pxc-advanced.wsrep_slave_UK_checks}}",
+    "TASKCFG_ALL_WSREP_SST_RECEIVE_ADDRESS": "{{pxc-advanced.wsrep_sst_receive_address}}",
+    "TASKCFG_ALL_WSREP_SYNC_WAIT": "{{pxc-advanced.wsrep_sync_wait}}",
+
+    
+    "IMAGE_IS_NOBODY": "{{service.check_for_nobody_leave_unchecked_for_root}}",
+    "PXC_DOCKER_IMAGE_ROOT": "{{resource.assets.container.docker.percona-xtradb-cluster-root}}",
+    "PXC_DOCKER_IMAGE_NOBODY": "{{resource.assets.container.docker.percona-xtradb-cluster-nobody}}",
+    "PROXYSQL_DOCKER_IMAGE_ROOT": "{{resource.assets.container.docker.proxysql-root}}",
+    "PROXYSQL_DOCKER_IMAGE_NOBODY": "{{resource.assets.container.docker.proxysql-nobody}}",
     "MYSQL_DOCKER_IMAGE": "{{resource.assets.container.docker.mysqlcli}}",
-
-    "ZK_SERVER": "zookeeper-0-server.kafka-zookeeper.autoip.dcos.thisdcos.directory:1140,zookeeper-1-server.kafka-zookeeper.autoip.dcos.thisdcos.directory:1140,zookeeper-2-server.kafka-zookeeper.autoip.dcos.thisdcos.directory:1140",
+    "PROM_MYSQLD_EXPORTER_DOCKER_IMAGE": "{{resource.assets.container.docker.prom-mysqld-exporter}}",
+
     "SYNC_STATE": "Not-Synced",
     "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
     "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
     "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
     "PIP_URI": "{{resource.assets.uris.pip-uri}}",
     "ZK_URI": "{{resource.assets.uris.zk-uri}}",
+    "MYSQLD_EXPORTER_URI": "{{resource.assets.uris.mysqld-exporter-uri}}",
+    "MC_URI": "{{resource.assets.uris.mc-uri}}",
 
     {{#service.service_account_secret}}
     "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
@@ -86,7 +180,9 @@
     "{{resource.assets.uris.scheduler-zip}}",
     "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
     "{{resource.assets.uris.pip-uri}}",
-    "{{resource.assets.uris.zk-uri}}"
+    "{{resource.assets.uris.zk-uri}}",
+    "{{resource.assets.uris.mysqld-exporter-uri}}",
+    "{{resource.assets.uris.mc-uri}}"
   ],
   "upgradeStrategy":{
     "minimumHealthCapacity": 0,
--- 0/package.json
+++ 100/package.json
@@ -8,7 +8,7 @@
   ],
   "minDcosReleaseVersion": "1.9",
   "name": "percona-pxc-mysql",
-  "version": "0.1.0-5.7.21-29.26",
+  "version": "0.2.0-5.7.21",
   "maintainer": "https://dcos.io/community",
   "description": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production!",
   "selected": false,
@@ -19,23 +19,5 @@
   ],
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: 0.1 CPU | 252 MB MEM | 1 25 MB Disk.",
   "postInstallNotes": "DC/OS Percona XtraDB CLuster is being installed!\n\n\tDocumentation: https://github.com/dcos/examples\n\tIssues: https://dcos.io/community",
-  "postUninstallNotes": "DC/OS Percona XtraDB CLuster is being uninstalled.",
-  "licenses": [
-    {
-      "name": "GNU General Public License Version 2.0",
-      "url": "https://raw.githubusercontent.com/mysql/mysql-server/8.0/LICENSE"
-    },
-    {
-      "name": "Universal FOSS Exception",
-      "url": "https://raw.githubusercontent.com/mysql/mysql-server/8.0/LICENSE"
-    },
-    {
-      "name": "BSD-like License",
-      "url": "https://raw.githubusercontent.com/percona/percona-server/5.7/COPYING.show_temp_51"
-    },
-    {
-      "name": "BSD-like License",
-      "url": "https://raw.githubusercontent.com/percona/percona-server/5.7/COPYING.innodb-deadlock-count-patch"
-    }
-  ]
-}
+  "postUninstallNotes": "DC/OS Percona XtraDB CLuster is being uninstalled."
+}--- 0/resource.json
+++ 100/resource.json
@@ -4,16 +4,21 @@
       "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz",
       "bootstrap-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip",
-      "scheduler-zip": "https://pxc-bucket.s3.amazonaws.com/pxc/assets/0.1.0-5.7.21-29.26/percona-pxc-mysql-scheduler.zip",
+      "scheduler-zip": "https://pxc-bucket.s3.amazonaws.com/pxc/assets/0.2.0-5.7.21/percona-pxc-mysql-scheduler.zip",
       "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip",
       "pip-uri": "https://bootstrap.pypa.io/get-pip.py",
-      "zk-uri": "https://s3-ap-northeast-1.amazonaws.com/pxc-utils/zookeepercli-linux-amd64-binary.tar.gz"
+      "zk-uri": "https://s3-ap-northeast-1.amazonaws.com/pxc-utils/zookeepercli-linux-amd64-binary.tar.gz",
+      "mysqld-exporter-uri": "https://s3-ap-northeast-1.amazonaws.com/pxc-utils/mysqld_exporter-0.7.1.linux-amd64.tar.gz",
+      "mc-uri": "https://dl.minio.io/client/mc/release/linux-amd64/mc"
     },
     "container": {
       "docker": {
-        "percona-xtradb-cluster": "percona/percona-xtradb-cluster:5.7.21",
-        "proxysql": "percona/proxysql:1.4.9",
-        "mysqlcli": "mysql:5.7"
+        "percona-xtradb-cluster-root": "mesostcs/pxc:5.7-DCOS-root",
+        "percona-xtradb-cluster-nobody": "mesostcs/pxc:5.7-DCOS-nobody",
+        "proxysql-root": "mesostcs/proxysql:1.4.12-DCOS-root",
+        "proxysql-nobody": "mesostcs/proxysql:1.4.12-DCOS-nobody",
+        "mysqlcli": "mysql:5.7",
+        "prom-mysqld-exporter": "mesostcs/mysqld-exporter:0.11.0"
       }
     }
   },
```
