### PR TITLE
Remove jessie-updates main from apt sources

### DIFF
--- a/docker/local-universe/Dockerfile.base
+++ b/docker/local-universe/Dockerfile.base
@@ -6,9 +6,13 @@ RUN apt-key adv --keyserver hkp://zimmermann.mayfirst.org --recv-keys "$GPG_KEY"
   || apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
   || apt-key adv --keyserver pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
   || apt-key adv --keyserver keyserver.pgp.com --recv-keys "$GPG_KEY" \
-  || apt-key adv --keyserver pgp.mit.edu --recv-keys "$GPG_KEY" \
-  && echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list \
-  && apt-get update \
+  || apt-key adv --keyserver pgp.mit.edu --recv-keys "$GPG_KEY"
+
+RUN echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list
+# Explicitly remove `jessie-updates`
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list
+
+RUN apt-get update \
   && apt-get install --no-install-recommends --no-install-suggests -y \
             ca-certificates \
             nginx \


### PR DESCRIPTION
Remove the following line
```
deb http://httpredir.debian.org/debian jessie-updates main
```
from `/etc/apt/sources.list` to account for changes in http://cdn-fastly.deb.debian.org/debian/dists/ 