### PR TITLE
Update zeppelin package to 1.1-0.8.1-2.4.0

### DIFF
--- a/repo/packages/Z/zeppelin/9/config.json
+++ b/repo/packages/Z/zeppelin/9/config.json
@@ -1,0 +1,126 @@
+{
+    "type": "object",
+    "properties": {
+        "service": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "default": "zeppelin"
+                },
+                "cores": {
+                    "type": "integer",
+                    "description": "Nuber of cores to allocate for the zeppelin instance",
+                    "default": 2
+                },
+                "memory": {
+                    "type": "integer",
+                    "description": "Memory to allocate for the zeppelin instance, in MB",
+                    "default": 4096
+                },
+                "external_persistent_volume": {
+                  "type": "string",
+                  "description": "Name of an external persistent volume to store notebook data on (rexray needs to be configured). Mutually exclusive with local_persistent_volume"
+                },
+                "local_persistent_volume": {
+                  "type": "boolean",
+                  "description": "Whether to use a local persistent volume to store notebook data. Mutually exclusive to external_persistent_volume",
+                  "default": false
+                },
+                "marathon_lb": {
+                  "type": "boolean",
+                  "description": "Whether to enable marathon-lb config for the service, if set requires marathon_lb_vhost",
+                  "default": false
+                },
+                "marathon_lb_group": {
+                  "type": "string",
+                  "description": "The group name for marathon-lb, used for HAPROXY_GROUP",
+                  "default": "external"
+                },
+                "marathon_lb_vhost": {
+                  "type": "string",
+                  "description": "The domain name to use for marathon-lb, used for HAPROXY_0_VHOST",
+                  "default": ""
+                },
+                "virtual_network_enabled": {
+                  "description": "Enable virtual networking. Otherwise host networking will be used. With virtual network enabled you need marathon-lb to access your instance as the dcos-adminrouter does not work with cni.",
+                  "type": "boolean",
+                  "default": false
+                },
+                "virtual_network_name": {
+                  "description": "The name of the virtual network to join",
+                  "type": "string",
+                  "default": "dcos"
+                }
+            }
+        },
+        "spark": {
+            "type": "object",
+            "properties": {
+                "cores_max": {
+                    "type": "string",
+                    "description": "Sets spark.cores.max",
+                    "default": "4"
+                },
+                "executor_cores": {
+                    "type": "string",
+                    "description": "Sets spark.executor.cores",
+                    "default": "1"
+                },
+                "executor_memory": {
+                    "type": "string",
+                    "description": "Sets spark.executor.memory",
+                    "default": "1g"
+                },
+                "use_hdfs": {
+                  "type": "boolean",
+                  "description": "Whether to configure hdfs access for spark",
+                  "default": false
+                },
+                "hdfs_config_url": {
+                  "type": "string",
+                  "description": "URL for hdfs config endpoint (hdfs-site.xml and core-site.xml), only used if use_hdfs is set",
+                  "default": "http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints"
+                },
+                "java_opts": {
+                    "type": "string",
+                    "description": "Sets ZEPPELIN_JAVA_OPTS and ZEPPELIN_INTP_JAVA_OPTS.  You can use this to set arbitrary spark configuration properties (e.g. spark.mesos.uris)",
+                    "default": ""
+                }
+            }
+        },
+        "zeppelin": {
+          "type": "object",
+          "properties": {
+            "shiro_conf_secret": {
+              "type": "string",
+              "description": "Path to a secret to use as content for shiro.ini (to configure users and permissions), mutually exclusive with shiro_conf_url"
+            },
+            "shiro_conf_url": {
+              "type": "string",
+              "description": "URL to a file to use as shiro.ini (to configure users and permissions), mutually exclusive with shiro_conf_secret"
+            },
+            "python_packages": {
+                "type": "string",
+                "description": "Space-separated list of python packages to install on startup, will be passed to pip. Needs internet connection. Example: \"tensorflow requests\"",
+                "default": ""
+            },
+            "r_packages": {
+                "type": "string",
+                "description": "List of r packages to install on startup, will be passed to the R command install.packages(). Needs internet connection. Example: \"c('glmnet', 'caret')\"",
+                "default": ""
+            },
+            "timezone": {
+              "type": "string",
+              "description": "Timezone to set in the container. Needed if you want to run the cron scheduler for notebooks. Example: \"Europe/Berlin\"",
+              "default": ""
+            },
+            "cacerts_url": {
+              "type": "string",
+              "description": "URL for a custom cacerts file that should be used for the zeppelin jvm. Must be fetchable by the mesos agents.",
+              "default": ""
+            }
+          }
+        }
+    }
+}

--- a/repo/packages/Z/zeppelin/9/marathon.json.mustache
+++ b/repo/packages/Z/zeppelin/9/marathon.json.mustache
@@ -1,0 +1,145 @@
+{
+  "id": "/{{service.name}}",
+  "instances": 1,
+  "cpus": {{service.cores}},
+  "mem": {{service.memory}},
+  "env": {
+    {{#zeppelin.shiro_conf_secret}}
+    "ZEPPELIN_SHIRO_CONF": {
+      "secret": "shiroconf"
+    },
+    {{/zeppelin.shiro_conf_secret}}
+    {{#service.external_persistent_volume}}
+    "ZEPPELIN_DATA_VOLUME": "/zeppelin-data",
+    "ZEPPELIN_NOTEBOOK_DIR": "/zeppelin-data/notebook",
+    {{/service.external_persistent_volume}}
+    {{#service.local_persistent_volume}}
+    "ZEPPELIN_DATA_VOLUME": "/zeppelin-data",
+    "ZEPPELIN_NOTEBOOK_DIR": "/zeppelin-data/notebook",
+    {{/service.local_persistent_volume}}
+    {{#zeppelin.python_packages}}
+    "PYTHON_PACKAGES": "{{zeppelin.python_packages}}",
+    {{/zeppelin.python_packages}}
+    {{#zeppelin.r_packages}}
+    "R_PACKAGES": "{{zeppelin.r_packages}}",
+    {{/zeppelin.r_packages}}
+    {{#spark.cores_max}}
+    "SPARK_CORES_MAX": "{{spark.cores_max}}",
+    {{/spark.cores_max}}
+    {{#spark.executor_memory}}
+    "SPARK_EXECUTOR_MEMORY": "{{spark.executor_memory}}",
+    {{/spark.executor_memory}}
+    {{#spark.executor_cores}}
+    "SPARK_EXECUTOR_CORES": "{{spark.executor_cores}}",
+    {{/spark.executor_cores}}
+    {{#zeppelin.timezone}}
+    "TZ": "{{zeppelin.timezone}}",
+    {{/zeppelin.timezone}}
+    "ZEPPELIN_JAVA_OPTS": "{{spark.java_opts}}",
+    "ZEPPELIN_INTP_JAVA_OPTS": "{{spark.java_opts}}"
+  },
+  "container": {
+    "type": "MESOS",
+    "docker": {
+      "image": "{{resource.assets.container.docker.zeppelin}}",
+      "forcePullImage": false
+    },
+    {{#service.virtual_network_enabled}}
+    "portMappings": [
+      {
+        "containerPort": 8080,
+        "name": "web",
+        "protocol": "tcp"
+      }
+    ],
+    {{/service.virtual_network_enabled}}
+    "volumes": [
+      {{#service.external_persistent_volume}}
+      {
+        "containerPath": "/zeppelin-data",
+        "external": {
+          "name": "{{service.external_persistent_volume}}",
+          "provider": "dvdi",
+          "options": {
+            "dvdi/driver": "rexray"
+          }
+        },
+        "mode": "RW"
+      }
+      {{/service.external_persistent_volume}}
+      {{#service.local_persistent_volume}}
+      {
+        "containerPath": "/zeppelin-data",
+        "hostPath": "zeppelindata",
+        "mode": "RW"
+      },
+      {
+        "containerPath": "zeppelindata",
+        "mode": "RW",
+        "persistent": {
+          "type": "root",
+          "size": 10240,
+          "constraints": []
+        }
+      }
+      {{/service.local_persistent_volume}}
+    ]
+  },
+  "networks": [
+    {{#service.virtual_network_enabled}}
+    {
+      "name": "{{service.virtual_network_name}}",
+      "mode": "container"
+    }
+    {{/service.virtual_network_enabled}}
+    {{^service.virtual_network_enabled}}
+    {
+      "mode": "host"
+    }
+    {{/service.virtual_network_enabled}}
+  ],
+  "upgradeStrategy": {
+    "maximumOverCapacity": 0,
+    "minimumHealthCapacity": 0
+  },
+  "labels": {
+    {{#service.marathon_lb}}
+    "HAPROXY_GROUP": "{{service.marathon_lb_group}}",
+    "HAPROXY_0_VHOST": "{{service.marathon_lb_vhost}}",
+    {{/service.marathon_lb}}
+    "DCOS_SERVICE_SCHEME": "http",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0"
+  },
+  "healthChecks": [
+    {
+      "protocol": "TCP",
+      "portIndex": 0,
+      "gracePeriodSeconds": 300,
+      "intervalSeconds": 30,
+      "timeoutSeconds": 15,
+      "maxConsecutiveFailures": 5
+    }
+  ],
+  "fetch": [
+    {{#zeppelin.cacerts_url}}
+    { "uri": "{{zeppelin.cacerts_url}}", "extract": false, "executable": false, "cache": false }
+    {{/zeppelin.cacerts_url}}
+    {{#spark.use_hdfs}}
+    {{#zeppelin.cacerts_url}},{{/zeppelin.cacerts_url}}
+    { "uri": "{{spark.hdfs_config_url}}/hdfs-site.xml", "extract": false, "executable": false, "cache": false },
+    { "uri": "{{spark.hdfs_config_url}}/core-site.xml", "extract": false, "executable": false, "cache": false }
+    {{/spark.use_hdfs}}
+    {{#zeppelin.shiro_conf_url}}
+    {{#spark.use_hdfs}},{{/spark.use_hdfs}}{{^spark.use_hdfs}}{{#zeppelin.cacerts_url}},{{/zeppelin.cacerts_url}}{{/spark.use_hdfs}}
+    { "uri": "{{zeppelin.shiro_conf_url}}", "extract": false, "executable": false, "cache": false }
+    {{/zeppelin.shiro_conf_url}}
+  ],
+  "secrets": {
+    {{#zeppelin.shiro_conf_secret}}
+    "shiroconf": {
+      "source": "{{zeppelin.shiro_conf_secret}}"
+    }
+    {{/zeppelin.shiro_conf_secret}}
+  }
+}

--- a/repo/packages/Z/zeppelin/9/package.json
+++ b/repo/packages/Z/zeppelin/9/package.json
@@ -1,0 +1,22 @@
+{
+    "packagingVersion": "4.0",
+    "name": "zeppelin",
+    "version": "1.1-0.8.1-2.4.0",
+    "minDcosReleaseVersion": "1.10",
+    "scm": "https://github.com/MaibornWolff/dcos-zeppelin",
+    "maintainer": "https://dcos.io/community/",
+    "description": "Zeppelin is a web-based notebook that enables interactive data analytics using spark",
+    "framework": true,
+    "tags": [
+        "framework",
+        "bigdata",
+        "spark",
+        "notebook",
+        "interactive",
+        "python"
+    ],
+    "website": "https://zeppelin.apache.org/",
+    "preInstallNotes": "This DC/OS Service is currently in preview.",
+    "postInstallNotes": "DC/OS Zeppelin is being installed!\n\n\tDocumentation: https://github.com/dcos/examples/tree/master/zeppelin/1.11\n\tIssues: https://dcos.io/community or\n\t\t https://github.com/MaibornWolff/dcos-zeppelin",
+    "postUninstallNotes": "If you installed Zeppelin with an external persistent volume make sure to delete the volume manually."
+}

--- a/repo/packages/Z/zeppelin/9/resource.json
+++ b/repo/packages/Z/zeppelin/9/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/zeppelin-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/zeppelin-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/zeppelin-icon-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "zeppelin": "mesosphere/zeppelin:1.1-0.8.1-all-2.4.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
New version of the zeppelin package (source: https://github.com/MaibornWolff/dcos-zeppelin)
Changes:
* Updated Zeppelin to 0.8.1
* Updated Spark to 2.4.0
* Added python-dev packages to image (allows for installation of python libraries like numpy that require compilation of c extensions)
* Added config option to set a timezone for the container (useful for running the notebook cron scheduler)
* Added config option to provide a custom cacerts file for the zeppelin/spark jvm
* Support for CNI / Overlay networking
* Switch containerizer from Docker to UCR

Please pull the docker image `maibornwolff/zeppelin:1.1-0.8.1-all-2.4.0` into the `mesosphere` organization (like done with the previous versions). The asset reference is already pointing to it. 