### PR TITLE
Add etcd 0.1.0-3.3.12

### DIFF
--- a/repo/packages/E/etcd/2/config.json
+++ b/repo/packages/E/etcd/2/config.json
@@ -1,0 +1,192 @@
+{
+    "type": "object", 
+    "properties": {
+        "service": {
+            "type": "object", 
+            "description": "DC/OS service configuration properties", 
+            "properties": {
+                "name": {
+                    "description": "The name of the service instance", 
+                    "type": "string", 
+                    "default": "etcd", 
+                    "title": "Service name"
+                }, 
+                "user": {
+                    "description": "The user that the service will run as.", 
+                    "type": "string", 
+                    "default": "root", 
+                    "title": "User"
+                }, 
+                "service_account": {
+                    "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.", 
+                    "type": "string", 
+                    "default": ""
+                }, 
+                "service_account_secret": {
+                    "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.", 
+                    "type": "string", 
+                    "default": "", 
+                    "title": "Credential secret name (optional)"
+                }, 
+                "virtual_network_enabled": {
+                    "description": "Enable virtual networking", 
+                    "type": "boolean", 
+                    "default": false
+                }, 
+                "virtual_network_name": {
+                    "description": "The name of the virtual network to join", 
+                    "type": "string", 
+                    "default": "dcos"
+                }, 
+                "virtual_network_plugin_labels": {
+                    "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n", 
+                    "type": "string", 
+                    "default": ""
+                }, 
+                "log_level": {
+                    "description": "The log level for the DC/OS service.", 
+                    "type": "string", 
+                    "enum": [
+                        "OFF", 
+                        "FATAL", 
+                        "ERROR", 
+                        "WARN", 
+                        "INFO", 
+                        "DEBUG", 
+                        "TRACE", 
+                        "ALL"
+                    ], 
+                    "default": "INFO"
+                }, 
+                "deploy_strategy": {
+                    "description": "etcd deploy strategy. [parallel, serial]", 
+                    "type": "string", 
+                    "enum": [
+                        "parallel", 
+                        "serial"
+                    ], 
+                    "default": "parallel"
+                }, 
+                "update_strategy": {
+                    "description": "etcd update strategy. [parallel, serial]", 
+                    "type": "string", 
+                    "enum": [
+                        "parallel", 
+                        "serial"
+                    ], 
+                    "default": "serial"
+                }
+            }, 
+            "required": [
+                "name", 
+                "user"
+            ]
+        }, 
+        "node": {
+            "description": "etcd pod configuration properties", 
+            "type": "object", 
+            "properties": {
+                "count": {
+                    "title": "Node count", 
+                    "description": "Number of etcd pods to run", 
+                    "type": "integer", 
+                    "default": 3, 
+                    "minimum": 3
+                }, 
+                "placement_constraint": {
+                    "title": "Placement constraint", 
+                    "description": "Placement constraints for nodes. Example: [[\"hostname\", \"UNIQUE\"]]", 
+                    "type": "string", 
+                    "default": "[[\"hostname\", \"UNIQUE\"]]", 
+                    "media": {
+                        "type": "application/x-zone-constraints+json"
+                    }
+                }, 
+                "cpus": {
+                    "title": "CPU count", 
+                    "description": "etcd pod CPU requirements", 
+                    "type": "number", 
+                    "default": 1.0
+                }, 
+                "mem": {
+                    "title": "Memory size (MB)", 
+                    "description": "etcd pod mem requirements (in MB)", 
+                    "type": "integer", 
+                    "default": 256
+                }, 
+                "disk": {
+                    "title": "Disk size (MB)", 
+                    "description": "etcd pod persistent disk requirements (in MB)", 
+                    "type": "integer", 
+                    "default": 100
+                }, 
+                "disk_type": {
+                    "title": "Disk type [ROOT, MOUNT]", 
+                    "description": "Mount volumes require preconfiguration in DC/OS", 
+                    "enum": [
+                        "ROOT", 
+                        "MOUNT"
+                    ], 
+                    "default": "ROOT"
+                }
+            }, 
+            "required": [
+                "count", 
+                "cpus", 
+                "mem", 
+                "disk", 
+                "disk_type"
+            ]
+        }, 
+        "etcd": {
+            "description": "consul pod configuration properties", 
+            "type": "object", 
+            "properties": {
+                "client_port": {
+                    "description": "Port for client communication", 
+                    "type": "integer", 
+                    "default": 2379
+                }, 
+                "peer_port": {
+                    "description": "Port for communication between etcd peers", 
+                    "type": "integer", 
+                    "default": 2380
+                }, 
+                "tls_enabled": {
+                    "description": "Enable TLS for client and peer connections. Requires DC/OS EE and configured serviceaccount unless use_auto_tls is set to true.", 
+                    "type": "boolean", 
+                    "default": false
+                }, 
+                "use_auto_tls": {
+                    "description": "Let etcd generate its own self-signed certificates instead of using ones provided by DC/OS. Only takes effect when tls_enabled is set to true.", 
+                    "type": "boolean", 
+                    "default": false
+                }, 
+                "initial_cluster_token": {
+                    "description": "Initial cluster token for the etcd cluster during bootstrap. Default is \"dcos\". Make this unique if you have multiple etcd clusters.", 
+                    "type": "string", 
+                    "default": "dcos"
+                }, 
+                "heartbeat_interval": {
+                    "description": "Time (in milliseconds) of a heartbeat interval", 
+                    "type": "integer", 
+                    "default": 100
+                }, 
+                "election_timeout": {
+                    "description": "Time (in milliseconds) for an election to timeout", 
+                    "type": "integer", 
+                    "default": 1000
+                }, 
+                "snapshot_count": {
+                    "description": "Number of committed transactions to trigger a snapshot to disk.", 
+                    "type": "integer", 
+                    "default": 100000
+                }
+            }, 
+            "required": [
+                "client_port", 
+                "peer_port"
+            ]
+        }
+    }
+}

--- a/repo/packages/E/etcd/2/marathon.json.mustache
+++ b/repo/packages/E/etcd/2/marathon.json.mustache
@@ -1,0 +1,101 @@
+
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "user": "{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./operator-scheduler/bin/operator svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "PACKAGE_NAME": "etcd",
+    "PACKAGE_VERSION": "0.1.0-3.3.12",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1556089164666",
+    "PACKAGE_BUILD_TIME_STR": "2019-04-24T06:59:24.666978",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    "MESOS_API_VERSION": "V1",
+
+    "NODE_COUNT": "{{node.count}}",
+    "NODE_PLACEMENT": "{{{node.placement_constraint}}}",
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+    "NODE_CPUS": "{{node.cpus}}",
+    "NODE_MEM": "{{node.mem}}",
+    "NODE_DISK": "{{node.disk}}",
+    "NODE_DISK_TYPE": "{{node.disk_type}}",
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "ETCD_URI": "{{resource.assets.uris.etcd-tar-gz}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.service_account_secret}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+
+    "DEPLOY_STRATEGY": "{{service.deploy_strategy}}",
+    "UPDATE_STRATEGY": "{{service.update_strategy}}",
+
+    "PORT_CLIENT": "{{etcd.client_port}}",
+    "PORT_PEER": "{{etcd.peer_port}}",
+    "TLS_ENABLED": "{{etcd.tls_enabled}}",
+    "USE_AUTO_TLS": "{{etcd.use_auto_tls}}",
+    "INITIAL_CLUSTER_TOKEN": "{{etcd.initial_cluster_token}}",
+    "HEARTBEAT_INTERVAL": "{{etcd.heartbeat_interval}}",
+    "ELECTION_TIMEOUT": "{{etcd.election_timeout}}",
+    "SNAPSHOT_COUNT": "{{etcd.snapshot_count}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "{{resource.assets.uris.svc}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/E/etcd/2/package.json
+++ b/repo/packages/E/etcd/2/package.json
@@ -1,0 +1,23 @@
+{
+    "packagingVersion": "4.0", 
+    "upgradesFrom": [
+        "0.1.0-3.3.12"
+    ], 
+    "downgradesTo": [
+        "0.1.0-3.3.12"
+    ], 
+    "minDcosReleaseVersion": "1.11", 
+    "name": "etcd", 
+    "version": "0.1.0-3.3.12", 
+    "maintainer": "https://github.com/maibornwolff/dcos-etcd", 
+    "description": "etcd cluster in HA mode on DC/OS", 
+    "selected": false, 
+    "framework": true, 
+    "tags": [
+        "etcd", 
+        "keyvalue", 
+        "ha"
+    ], 
+    "postInstallNotes": "DC/OS etcd is being installed!\n\n\tDocumentation: https://github.com/maibornwolff/dcos-etcd\n\tIssues: https://github.com/maibornwolff/dcos-etcd", 
+    "postUninstallNotes": "DC/OS etcd is being uninstalled."
+}

--- a/repo/packages/E/etcd/2/package.json
+++ b/repo/packages/E/etcd/2/package.json
@@ -1,5 +1,5 @@
 {
-    "packagingVersion": "4.0", 
+    "packagingVersion": "4.0",
     "upgradesFrom": [
         "0.1.0-3.3.12"
     ], 
@@ -17,7 +17,13 @@
         "etcd", 
         "keyvalue", 
         "ha"
-    ], 
+    ],
+    "licenses": [
+        {
+            "name": "Apache License Version 2.0",
+            "url": "https://github.com/etcd-io/etcd/blob/master/LICENSE"
+        }
+    ],
     "postInstallNotes": "DC/OS etcd is being installed!\n\n\tDocumentation: https://github.com/maibornwolff/dcos-etcd\n\tIssues: https://github.com/maibornwolff/dcos-etcd", 
     "postUninstallNotes": "DC/OS etcd is being uninstalled."
 }

--- a/repo/packages/E/etcd/2/package.json
+++ b/repo/packages/E/etcd/2/package.json
@@ -21,7 +21,7 @@
     "licenses": [
         {
             "name": "Apache License Version 2.0",
-            "url": "https://github.com/etcd-io/etcd/blob/master/LICENSE"
+            "url": "https://raw.githubusercontent.com/etcd-io/etcd/master/LICENSE"
         }
     ],
     "postInstallNotes": "DC/OS etcd is being installed!\n\n\tDocumentation: https://github.com/maibornwolff/dcos-etcd\n\tIssues: https://github.com/maibornwolff/dcos-etcd", 

--- a/repo/packages/E/etcd/2/resource.json
+++ b/repo/packages/E/etcd/2/resource.json
@@ -1,0 +1,57 @@
+{
+    "assets": {
+        "uris": {
+            "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz", 
+            "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz", 
+            "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.55.2/bootstrap.zip", 
+            "scheduler-zip": "https://ecosystem-repo.s3.amazonaws.com/sdk/artifacts/0.55.2/operator-scheduler.zip", 
+            "etcd-tar-gz": "https://github.com/etcd-io/etcd/releases/download/v3.3.12/etcd-v3.3.12-linux-amd64.tar.gz", 
+            "svc": "https://github.com/MaibornWolff/dcos-etcd/releases/download/v0.1.0-3.3.12/svc.yml"
+        }
+    }, 
+    "images": {
+        "icon-small": "https://github.com/dcos/dcos-ui/blob/master/plugins/services/src/img/icon-service-default-small.png?raw=true", 
+        "icon-medium": "https://github.com/dcos/dcos-ui/blob/master/plugins/services/src/img/icon-service-default-medium.png?raw=true", 
+        "icon-large": "https://github.com/dcos/dcos-ui/blob/master/plugins/services/src/img/icon-service-default-large.png?raw=true"
+    }, 
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256", 
+                            "value": "c329d60aa5fea372115c371814a141f6615819db51935bd09a8265c8978115ac"
+                        }
+                    ], 
+                    "kind": "executable", 
+                    "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.55.2/dcos-service-cli-darwin"
+                }
+            }, 
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256", 
+                            "value": "9690330cd5d7017ab7d747e31b28d30f817cf35cb8db700a5ceebaf628d0d299"
+                        }
+                    ], 
+                    "kind": "executable", 
+                    "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.55.2/dcos-service-cli-linux"
+                }
+            }, 
+            "windows": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256", 
+                            "value": "75a6d593848f18b6fc5050f7dde18fb91c659b5b62825ba0eca0e8a5286d46bf"
+                        }
+                    ], 
+                    "kind": "executable", 
+                    "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.55.2/dcos-service-cli.exe"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
New framework for installing etcd on DC/OS. Based on etcd 3.3.12 and developed using https://github.com/mesosphere/dcosdev

Main features:
* distributed / HA mode
* TLS support
* Reconfiguration using rolling restart

Source: https://github.com/MaibornWolff/dcos-etcd