### PR TITLE
Add airfield 0.2.0

### DIFF
--- a/repo/packages/A/airfield/1/config.json
+++ b/repo/packages/A/airfield/1/config.json
@@ -1,0 +1,114 @@
+{
+    "type": "object", 
+    "properties": {
+        "service": {
+            "type": "object", 
+            "description": "DC/OS service configuration properties", 
+            "properties": {
+                "name": {
+                    "description": "The name of the service instance", 
+                    "type": "string", 
+                    "default": "airfield", 
+                    "title": "Service name"
+                }, 
+                "user": {
+                    "description": "The user that the service will run as.", 
+                    "type": "string", 
+                    "default": "root", 
+                    "title": "User"
+                }, 
+                "service_account_secret": {
+                    "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.", 
+                    "type": "string", 
+                    "default": "", 
+                    "title": "Credential secret name (optional)"
+                }, 
+                "virtual_network_enabled": {
+                    "description": "Enable virtual networking", 
+                    "type": "boolean", 
+                    "default": false
+                }, 
+                "virtual_network_name": {
+                    "description": "The name of the virtual network to join", 
+                    "type": "string", 
+                    "default": "dcos"
+                }, 
+                "marathon_lb_vhost": {
+                    "description": "The domain name to make airfield available under, must be pointing to your marathon-lb", 
+                    "type": "string"
+                }
+            }, 
+            "required": [
+                "name", 
+                "user"
+            ]
+        }, 
+        "node": {
+            "description": "airfield pod configuration properties", 
+            "type": "object", 
+            "properties": {
+                "cpus": {
+                    "title": "CPU count", 
+                    "description": "airfield pod CPU requirements", 
+                    "type": "number", 
+                    "default": 0.5
+                }, 
+                "mem": {
+                    "title": "Memory size (MB)", 
+                    "description": "airfield pod mem requirements (in MB)", 
+                    "type": "integer", 
+                    "default": 512
+                }
+            }, 
+            "required": [
+                "cpus", 
+                "mem"
+            ]
+        }, 
+        "airfield": {
+            "description": "Airfield specific configuration", 
+            "type": "object", 
+            "properties": {
+                "marathon_lb_base_host": {
+                    "title": "Base host to expose zeppelin instances under", 
+                    "description": "Hostnames will be construced as <instance-name><marathon_lb_base_host>, e.g. marathon_lb_base_host=\".zeppelin.mycorp\" results in hosts of the form someinstance.zeppelin.mycorp.", 
+                    "type": "string"
+                }, 
+                "consul_endpoint": {
+                    "title": "Endpoint for consul", 
+                    "description": "HTTP Endpoint for consul, e.g. \"http://api.consul.l4lb.thisdcos.directory:8500/v1\" if you use the consul package. Either this or etcd_endpoint must be set", 
+                    "type": "string"
+                }, 
+                "etcd_endpoint": {
+                    "title": "Endpoint for etcd", 
+                    "description": "Endpoint for etcd, e.g. \"http://api.etcd.l4lb.thisdcos.directory:2379\" if you use the etcd package. Either this or consul_endpoint must be set", 
+                    "type": "string"
+                }, 
+                "app_group": {
+                    "title": "Marathon App group for zeppelin instances", 
+                    "description": "app group to start zeppelin instances under. If not set \"airfield-zeppelin\" is used.", 
+                    "type": "string"
+                }, 
+                "config_base_key": {
+                    "title": "Key prefix in consul/etcd", 
+                    "description": "Key prefix in consul/etcd to use for storing airfield config. If not set \"airfield\" is used.", 
+                    "type": "string"
+                }, 
+                "dcos_base_url": {
+                    "title": "Base URL of the DC/OS adminrouter", 
+                    "description": "URL of the DC/OS adminrouter. Default works under EE clusters in permissive/strict mode. Set this to \"http://leader.mesos\" if running on OpenSource DC/OS", 
+                    "type": "string"
+                },
+                "oidc_config": {
+                    "title": "Base64-encoded oidc config",
+                    "description": "OIDC client configuration. See https://github.com/MaibornWolff/dcos-airfield/blob/master/airfield-microservice/airfield/resources/keycloak_example.json for an example. Encode the file with 'base64 -wc 0 oidc.json' and use the result as value for this config.",
+                    "type": "string",
+                    "default": ""
+                }
+            }, 
+            "required": [
+                "marathon_lb_base_host"
+            ]
+        }
+    }
+}

--- a/repo/packages/A/airfield/1/marathon.json.mustache
+++ b/repo/packages/A/airfield/1/marathon.json.mustache
@@ -1,0 +1,93 @@
+
+{
+  "id": "{{service.name}}",
+  "user": "{{service.user}}",
+  "instances": 1,
+  "cpus": {{node.cpus}},
+  "mem": {{node.mem}},
+  "container": {
+    "type": "MESOS",
+    "portMappings": [
+      {
+        "containerPort": 5000
+      }
+    ],
+    "docker": {
+      "image": "{{resource.assets.container.docker.airfield}}",
+      "forcePullImage": false
+    }
+  },
+  "networks": [
+    {{#service.virtual_network_enabled}}
+    {
+      "name": "{{service.virtual_network_name}}",
+      "mode": "container"
+    }
+    {{/service.virtual_network_enabled}}
+    {{^service.virtual_network_enabled}}
+    {
+      "mode": "container/bridge"
+    }
+    {{/service.virtual_network_enabled}}
+  ],
+  "labels": {
+    {{#service.marathon_lb_vhost}}
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_VHOST": "{{service.marathon_lb_vhost}}",
+    {{/service.marathon_lb_vhost}}
+    "DCOS_SERVICE_NAME": "{{service.name}}"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": {
+      "secret": "serviceCredential"
+    },
+    {{/service.service_account_secret}}
+    "PACKAGE_NAME": "airfield",
+    "PACKAGE_VERSION": "0.2.0",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1556101126847",
+    "PACKAGE_BUILD_TIME_STR": "2019-04-24T10:18:46.847522",
+    {{#airfield.dcos_base_url}}
+    "DCOS_BASE_URL": "{{airfield.dcos_base_url}}",
+    {{/airfield.dcos_base_url}}
+    {{#airfield.consul_endpoint}}
+    "AIRFIELD_CONSUL_ENDPOINT": "{{airfield.consul_endpoint}}",
+    {{/airfield.consul_endpoint}}
+    {{#airfield.etcd_endpoint}}
+    "AIRFIELD_ETCD_ENDPOINT": "{{airfield.etcd_endpoint}}",
+    {{/airfield.etcd_endpoint}}
+    {{#airfield.app_group}}
+    "AIRFIELD_MARATHON_APP_GROUP": "{{airfield.app_group}}",
+    {{/airfield.app_group}}
+    {{#airfield.config_base_key}}
+    "AIRFIELD_CONFIG_BASE_KEY": "{{airfield.config_base_key}}",
+    {{/airfield.config_base_key}}
+    {{#airfield.oidc_config}}
+    "AIRFIELD_OIDC_ACTIVATED": "1",
+    "AIRFIELD_OIDC_SECRET_FILE": "{{airfield.oidc_config}}",
+    {{/airfield.oidc_config}}
+    "AIRFIELD_BASE_HOST" : "{{airfield.marathon_lb_base_host}}"
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/",
+      "portIndex": 0,
+      "timeoutSeconds": 10,
+      "gracePeriodSeconds": 20,
+      "intervalSeconds": 20,
+      "maxConsecutiveFailures": 6
+    }
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/A/airfield/1/package.json
+++ b/repo/packages/A/airfield/1/package.json
@@ -1,0 +1,23 @@
+{
+    "packagingVersion": "4.0", 
+    "upgradesFrom": [
+        "0.1.0"
+    ], 
+    "downgradesTo": [
+        "0.1.0"
+    ], 
+    "minDcosReleaseVersion": "1.10", 
+    "name": "airfield", 
+    "version": "0.2.0", 
+    "maintainer": "https://github.com/MaibornWolff/dcos-airfield", 
+    "description": "Airfield - easily start and manage zeppelin instances on DC/OS", 
+    "selected": false, 
+    "framework": false, 
+    "tags": [
+        "airfield", 
+        "zeppelin", 
+        "spark"
+    ], 
+    "postInstallNotes": "Airfield is being installed!\n\n\tDocumentation: https://github.com/MaibornWolff/dcos-airfield\n\tIssues: https://github.com/MaibornWolff/dcos-airfield", 
+    "postUninstallNotes": "Airfield is being uninstalled."
+}

--- a/repo/packages/A/airfield/1/package.json
+++ b/repo/packages/A/airfield/1/package.json
@@ -18,6 +18,12 @@
         "zeppelin", 
         "spark"
     ], 
+    "licenses": [
+        {
+          "name": "Apache License Version 2.0",
+          "url": "https://github.com/MaibornWolff/dcos-airfield/blob/master/LICENSE"
+        }
+    ],
     "postInstallNotes": "Airfield is being installed!\n\n\tDocumentation: https://github.com/MaibornWolff/dcos-airfield\n\tIssues: https://github.com/MaibornWolff/dcos-airfield", 
     "postUninstallNotes": "Airfield is being uninstalled."
 }

--- a/repo/packages/A/airfield/1/package.json
+++ b/repo/packages/A/airfield/1/package.json
@@ -21,7 +21,7 @@
     "licenses": [
         {
           "name": "Apache License Version 2.0",
-          "url": "https://github.com/MaibornWolff/dcos-airfield/blob/master/LICENSE"
+          "url": "https://raw.githubusercontent.com/MaibornWolff/dcos-airfield/master/LICENSE"
         }
     ],
     "postInstallNotes": "Airfield is being installed!\n\n\tDocumentation: https://github.com/MaibornWolff/dcos-airfield\n\tIssues: https://github.com/MaibornWolff/dcos-airfield", 

--- a/repo/packages/A/airfield/1/resource.json
+++ b/repo/packages/A/airfield/1/resource.json
@@ -1,0 +1,14 @@
+{
+    "assets": {
+        "container": {
+            "docker": {
+                "airfield": "maibornwolff/airfield:0.2.0"
+            }
+        }
+    }, 
+    "images": {
+        "icon-small": "https://github.com/MaibornWolff/dcos-airfield/raw/master/img/icon-service-default-small.png", 
+        "icon-medium": "https://github.com/MaibornWolff/dcos-airfield/raw/master/img/icon-service-default-medium.png", 
+        "icon-large": "https://github.com/MaibornWolff/dcos-airfield/raw/master/img/icon-service-default-large.png"
+    }
+}


### PR DESCRIPTION
New features:
* Secure airfield login with OpenID Connect (e.g. using keycloak)
* Preprovision new zeppelin instances with notebook templates
* Import and export notebooks
* Reconfigure notebooks after creation (with automatic export/import of notebooks)

Source: https://github.com/MaibornWolff/dcos-airfield/