### PR TITLE
New Docker Registry package

### DIFF
--- a/repo/packages/R/registry/2/config.json
+++ b/repo/packages/R/registry/2/config.json
@@ -1,0 +1,172 @@
+{
+	"properties": {
+		"service": {
+			"type": "object",
+			"description": "DC/OS service configuration properties",
+			"properties": {
+				"name": {
+					"description": "Name of this service instance",
+					"type": "string",
+					"default": "registry"
+				},
+				"cpus": {
+					"description": "CPU shares to allocate to each service instance.",
+					"type": "number",
+					"default": 0.2,
+					"minimum": 0.2
+				},
+				"mem": {
+					"description":  "Memory to allocate to each service instance.",
+					"type": "number",
+					"default": 256.0,
+					"minimum": 256.0
+				},
+				"proxy": {
+					"type": "object",
+					"description": "Configure this registry as a remote proxy for another registry.",
+					"properties": {    
+						"enable": {
+							"description": "Enable or disable proxy mode.",
+							"type": "boolean",
+							"default": false                    
+						},
+						"remote_url": {
+							"description": "URL of the remote proxy to connect to.",
+							"type": "string",
+							"default": "https://registry-1.docker.io"
+						},
+						"username": {
+							"description": "Username to use in the remote proxy.",
+							"type": "string",
+							"default": "username"
+						},						
+						"password": {
+							"description": "Password to use in the remote proxy.",
+							"type": "string",
+							"default": "password"
+						}
+					}
+				}
+			},
+			"required": [
+				"cpus",
+				"mem"
+			]
+		},
+		"security": {
+			"type": "object",
+			"description": "registry security configuration properties",
+			"properties":{
+				"enable": {
+					"description":  "Enable TLS secure registry.",
+					"type": "boolean",
+					"default": false
+				},
+				"http_tls_download_ip": {
+					"description":  "IP address of the host to download the HTTP TLS certificate and key from. Files need to be in the root subdirectory of the server.",
+					"type": "string"
+				},
+				"http_tls_download_port": {
+					"description":  "TCP port of the host to download the HTTP TLS certificate and key from (i.e. the port where the server is listening on). Files need to be in the root subdirectory of the server.",
+					"type": "string",
+					"default": "80"
+				},					
+				"http_tls_certificate_filename": {
+					"description":  "Name of the file holding the HTTP TLS certificate to download from the host with the IP address configured in http_tls_download_ip.",
+					"type": "string",
+					"default": "domain.crt"
+				},
+				"http_tls_key_filename": {
+					"description":  "Name of the file holding the HTTP TLS key to download from the host with the IP address configured in http_tls_download_ip.",
+					"type": "string",
+					"default": "domain.key"
+				}
+			}
+		},
+		"storage": {
+			"type": "object",
+			"description": "registry storage configuration properties",
+			"properties":{
+				"storage_path": {
+					"description": "Storage path to be used inside the registry container.",
+					"type": "string",
+					"default": "/var/lib/registry"
+				}, 
+				"host_volume_registry": {
+					"description": "If using non-persistent volumes (local volumes), this sets the location of a volume on the host to be used for the registry service to store the contents of the registry. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/service_name`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents. NOTE: if you don't change the default /tmp value, YOUR DATA WILL NOT BE SAVED IN ANY WAY.",
+					"type": "string",
+					"default": "/tmp"
+				},     
+				"persistence": {
+					"type": "object",
+					"description": "Enable persistent storage.",
+					"properties": {    
+						"enable": {
+							"description": "Enable or disable persistent storage.",
+							"type": "boolean",
+							"default": false                    
+						},
+						"volume_size_registry": {
+							"description": "If a new volume is to be created, this controls its size in MBs.",
+							"type": "number",
+							"default": 1024
+						},
+						"external": {
+							"type": "object",
+							"description": "External persistent storage properties",
+								"properties":{   
+									"enable": {
+										"description": "Enable or disable external persistent storage. The `persistence` option must also be selected. Please note that for these to work, your DC/OS cluster MUST have been installed with the right options in `config.yaml`. Also, please note this requires a working  configuration file for the driver (e.g. `rexray.yaml`).",
+										"type": "boolean",
+										"default": false                    
+									},
+									"volume_name_registry": {
+										"description": "Name that your volume driver uses to look up your external volume. When your task is staged on an agent, the volume driver queries the storage service for a volume with this name. If one does not exist, it is created implicitly. Otherwise, the existing volume is reused.",
+										"type": "string",
+										"default": "registry"
+									},
+									"provider": {
+										"description": "Provider of the external persistent volume. The default value should be correct for most use cases.",
+										"type": "string",
+										"default": "dvdi"
+									},
+									"driver": {
+										"description": "Volume driver to use for storage. The default value should be correct for most use cases.",
+										"type": "string",
+										"default": "rexray"
+									}
+								}
+						}
+					}
+				}
+			}
+		},
+		"networking": {
+			"type": "object",
+			"description": "registry networking configuration properties",
+			"properties": {    
+				"port": {
+					"description": "Port number to be used for clear communication internally to the cluster.",
+					"type": "number",
+					"default": 5000
+				},  
+				"external_access": {
+					"type": "object",
+					"description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+						"properties": {    
+							"enable": {
+								"description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+								"type": "boolean",
+								"default": false                    
+							},
+							"external_access_port": {
+								"description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+								"type": "number",
+								"default": 15000
+							}
+						}
+					}
+			}      
+		}
+	}
+}

--- a/repo/packages/R/registry/2/marathon.json.mustache
+++ b/repo/packages/R/registry/2/marathon.json.mustache
@@ -1,0 +1,94 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{service.cpus}},
+  "mem": {{service.mem}},
+  "instances": 1,
+  "env": {
+    {{#service.proxy.enable}}
+    "REGISTRY_PROXY_REMOTEURL": "{{service.proxy.remote_url}}",
+    "REGISTRY_PROXY_USERNAME": "{{service.proxy.username}}",
+    "REGISTRY_PROXY_PASSWORD": "{{service.proxy.password}}",        
+    {{/service.proxy.enable}} 
+    {{#security.enable}}
+    "REGISTRY_HTTP_TLS_CERTIFICATE": "/mnt/mesos/sandbox/{{security.http_tls_certificate_filename}}",
+    "REGISTRY_HTTP_TLS_KEY": "/mnt/mesos/sandbox/{{security.http_tls_key_filename}}",
+    {{/security.enable}}
+    {{#storage.persistence.external.enable}}          
+    "STORAGE_PATH": "{{storage.storage_path}}",
+    {{/storage.persistence.external.enable}}  
+    {{^storage.persistence.external.enable}}    
+    "REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY": "/mnt/mesos/sandbox/var/registry",
+    {{/storage.persistence.external.enable}}  
+    "FOO": "bar"
+  },
+  {{#security.enable}}
+  "uris": [
+      "http://{{security.http_tls_download_ip}}:{{security.http_tls_download_port}}/{{security.http_tls_certificate_filename}}",
+      "http://{{security.http_tls_download_ip}}:{{security.http_tls_download_port}}/{{security.http_tls_key_filename}}"
+  ],
+  {{/security.enable}}
+  "container": {
+    "type": "DOCKER",
+    "volumes": [{
+      {{^storage.persistence.enable}}
+      "containerPath": "{{storage.storage_path}}",
+      "hostPath": "{{storage.host_volume_registry}}/{{service.name}}",
+      {{/storage.persistence.enable}}
+      {{#storage.persistence.enable}}
+      {{^storage.persistence.external.enable}}
+      "containerPath": "var",
+      "persistent": {
+        "size": {{storage.persistence.volume_size_registry}}
+      },
+      {{/storage.persistence.external.enable}}
+      {{#storage.persistence.external.enable}}
+      "containerPath": "/var/lib/registry",
+      "external": {
+        "name": "{{storage.persistence.external.volume_name_registry}}",
+        "provider": "{{storage.persistence.external.provider}}",
+        "options": { "dvdi/driver": "{{storage.persistence.external.driver}}" }
+      },
+      {{/storage.persistence.external.enable}}
+      {{/storage.persistence.enable}} 
+      "mode": "RW"
+    }],
+    "docker": {
+      "image": "{{resource.assets.container.docker.registry-docker}}",
+      "network": "BRIDGE",
+      "portMappings": [{
+        "containerPort": 5000,
+        "hostPort": 0,
+        {{#networking.external_access.enable}}
+        "servicePort": {{networking.external_access.external_access_port}},
+        {{/networking.external_access.enable}}
+        "protocol": "tcp",
+        "name": "registry",
+        "labels": {
+          "VIP_0": "/{{service.name}}:{{networking.port}}"
+        }
+      }],
+      "forcePullImage": false
+    }
+  },
+  "healthChecks": [{
+    "protocol": "TCP",
+    "portIndex": 0, 
+    "gracePeriodSeconds": 300,
+    "intervalSeconds": 60,
+    "timeoutSeconds": 20,
+    "maxConsecutiveFailures": 3
+  }],
+  "labels": {
+    "DCOS_PACKAGE_VERSION": "5.7.12-0.2",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    {{#networking.external_access.enable}}
+    "HAPROXY_GROUP": "external",
+    {{/networking.external_access.enable}}
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/R/registry/2/package.json
+++ b/repo/packages/R/registry/2/package.json
@@ -1,0 +1,20 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.7",
+  "name": "registry",
+  "version": "2.7.1",
+  "scm": "https://github.com/docker/distribution",
+  "maintainer": "https://dcos.io/community/",
+  "website": "https://docs.docker.com/registry/",
+  "description": "The docker Registry is a stateless, highly scalable server side application that stores and lets you distribute Docker images. This DC/OS package provides a private registry that can be made available to any other component in the system through a virtual IP (default: registry.marathon.l4lb.thisdcos.directory:5000).\n\nNOTE: This package requires additional configuration in order to run either in secure or insecure mode. Check the package documentation at https://github.com/dcos/examples/tree/master/registry for details.",
+  "tags": ["docker", "registry"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\nAdvanced Installation options notes\n\nregistry / http_tls_download_ip: For secure communication, IP address of the host to download the HTTP TLS certificate and key from. This will be used to form the URI location of a valid HTTP TLS certificate and key to be used in the authentication process between the docker registry and the agents running the docker engine.\n\nregistry / http_tls_certificate_filename: For secure communication, name of the file holding the HTTP TLS certificate to download from the host with the IP address configured in http_tls_download_ip.\n\nregistry / http_tls_key_filename: For secure communication, name of the file holding the HTTP TLS key to download from the host with the IP address configured in http_tls_download_ip.\n\nstorage / persistence: create local persistent volumes for internal storage files to survive across restarts or failures.\n\nstorage / persistence / *external*: create external persistent volumes. This allows to use an external storage system such as Amazon EBS, OpenStack Cinder, EMC Isilon, EMC ScaleIO, EMC XtremIO, EMC VMAX and Google Compute Engine persistent storage. NOTE: To use external volumes with DC/OS, you MUST enable them during CLI or Advanced installation.\n\nstorage / host_volume:  if persistence is not selected, this package can use a local volume in the host for storage, like a local directory or an NFS mount. The parameter host_volume controls the path in the host in which these volumes will be created, which MUST be the same on all nodes of the cluster.\n\nNOTE: If you didn't select persistence in the storage section, or provided a valid value for host_volume on installation,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n\nnetworking / port: This DC/OS service can be accessed from any other application through a NAMED VIP in the format service_name.marathon.l4lb.thisdcos.directory:port. Check status of the VIP in the Network tab of the DC/OS Dashboard (Enterprise DC/OS only).\n\nnetworking / external_access: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / external_access_port: port to be used in Marathon-LB for accessing the service. This registry version was tested against docker version 18.09",
+ "postInstallNotes": "Service installed.\n\nNOTE: This package REQUIRES post-install configuration in your cluster in order to work correctly. Please check the package documentation at https://github.com/dcos/examples/tree/master/registry for details.",
+ "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed for the agent where the service was deployed.",
+  "licenses": [
+    {
+      "name": "Apache License",
+      "url": "http://en.wikipedia.org/wiki/Apache_License"
+    }
+  ]
+}

--- a/repo/packages/R/registry/2/resource.json
+++ b/repo/packages/R/registry/2/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/registry-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/registry-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/registry-icon-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "registry-docker": "registry:2.7.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added newer docker registry package, tested with existing instructions from https://github.com/dcos/examples/tree/master/registry/1.9 for insecure and secure in DCOS 1.12.3 and Docker-ce 18.09