### PR TITLE
Update Universe Support for DC/OS 1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,3 +500,8 @@ Currently Universe Server provides support for the following versions of DC/OS
 | 1.10                  | Full Support  |
 | 1.11                  | Full Support  |
 | 1.12                  | Full Support  |
+| 1.13                  | Full Support  |
+| 1.14                  | Full Support  |
+
+
+

--- a/docker/local-universe/default.conf
+++ b/docker/local-universe/default.conf
@@ -48,6 +48,10 @@ server {
     set $dcos_release_version 1.13;
   }
 
+  if ($http_user_agent ~ ".*dcos\/1\.14.*") {
+    set $dcos_release_version 1.14;
+  }
+
   location = /repo-1.7 {
     types {
       "application/vnd.dcos.universe.repo+json;charset=utf-8;version=v3" json;

--- a/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
+++ b/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
@@ -31,7 +31,7 @@ server {
   # We assume a user is running the latest DC/OS if their User-Agent is unknown
   # Historically, we assumed 1.6.1 until its deprecation.
   # User-Agent was added to cosmos in DC/OS Release 1.8
-  set $dcos_release_version 1.13;
+  set $dcos_release_version 1.14;
 
   if ($http_user_agent ~ ".*dcos\/1\.8.*") {
     set $dcos_release_version 1.8;
@@ -56,6 +56,11 @@ server {
   if ($http_user_agent ~ ".*dcos\/1\.13.*") {
     set $dcos_release_version 1.13;
   }
+
+  if ($http_user_agent ~ ".*dcos\/1\.14.*") {
+    set $dcos_release_version 1.14;
+  }
+
 
   location = /repo-1.7 {
     types {

--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -77,7 +77,7 @@ def main():
     create_content_type_file(ct_empty_path, "v3")
 
     zip_file_dcos_versions = ["1.6.1", "1.7"]
-    json_file_dcos_versions = ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13"]
+    json_file_dcos_versions = ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13", "1.14"]
     # create universe-by-version files for `dcos_versions`
     dcos_versions = zip_file_dcos_versions + json_file_dcos_versions
     [render_universe_by_version(


### PR DESCRIPTION
This PR updates  the Universe Support for DC/OS 1.14.

Related JIRA:

* DCOS-53681 - Update DC/OS Version in master branch to 1.14-dev

