### PR TITLE
Added Tags as an option to package

### DIFF
--- a/repo/packages/D/datadog/7/config.json
+++ b/repo/packages/D/datadog/7/config.json
@@ -1,0 +1,70 @@
+{
+    "properties": {
+        "datadog": {
+            "description": "Datadog Agent configuration",
+            "properties": {
+                "use_agent_5": {
+                    "description": "Install version 5.21 of the Agent",
+                    "type": "boolean",
+                    "default": false
+                },
+                "api_key": {
+                    "description": "Your Datadog API key.",
+                    "type": "string"
+                },
+                "app_id": {
+                    "default": "datadog-agent",
+                    "description": "Marathon Application ID",
+                    "type": "string"
+                },
+                "app_tags": {
+                    "default": "",
+                    "description": "Tags to add to Datadog Agent",
+                    "type": "string"
+                },
+                "instances": {
+                    "default": 1,
+                    "description": "Number of Marathon instances to run.",
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "cpus": {
+                    "default": 0.05,
+                    "description": "CPU shares to allocate to each Marathon instance.",
+                    "minimum": 0.0,
+                    "type": "number"
+                },
+                "mem": {
+                    "default": 256.0,
+                    "description": "Memory (MB) to allocate to each Marathon task.",
+                    "minimum": 256.0,
+                    "type": "number"
+                },
+                "dogstatsd": {
+                  "description": "Dogstatsd (custom metrics) options",
+                  "type": "object",
+                  "properties": {
+                    "non_local_traffic": {
+                        "default": false,
+                        "description": "Allow statsD non-local traffic",
+                        "type": "boolean"
+                    },
+                    "port": {
+                        "default": 8125,
+                        "description": "UDP port to listen to",
+                        "type": "integer"
+                    }
+                  }
+                }
+            },
+            "required": [
+                "api_key"
+            ],
+            "type": "object"
+        }
+    },
+    "required": [
+        "datadog"
+    ],
+    "type": "object"
+}

--- a/repo/packages/D/datadog/7/marathon.json.mustache
+++ b/repo/packages/D/datadog/7/marathon.json.mustache
@@ -1,0 +1,77 @@
+{
+    "id": "{{datadog.app_id}}",
+    "container": {
+        "type": "DOCKER",
+        "docker": {
+            {{#datadog.use_agent_5}}
+            "image": "{{resource.assets.container.docker.agent5}}",
+            {{/datadog.use_agent_5}}
+            {{^datadog.use_agent_5}}
+            "image": "{{resource.assets.container.docker.agent6}}",
+            "forcePullImage": true,
+            {{/datadog.use_agent_5}}
+            "parameters": [
+                {
+                    "key": "env", "value": "DD_API_KEY={{datadog.api_key}}"
+                },
+                {
+                    "key": "env", "value": "DD_TAGS={{datadog.app_tags}}"
+                },
+                {{#datadog.use_agent_5}}
+                {
+                    "key": "env", "value": "SD_BACKEND=docker"
+                },
+                {{/datadog.use_agent_5}}
+                {{#datadog.dogstatsd.non_local_traffic}}
+                {
+                    "key": "env", "value": "DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true"
+                },
+                {{/datadog.dogstatsd.non_local_traffic}}
+                {
+                    "key": "env", "value": "MESOS_SLAVE=true"
+                }
+            ],
+            "portMappings": [
+                {{#datadog.dogstatsd.non_local_traffic}}
+                { "hostPort": {{datadog.dogstatsd.port}}, "containerPort": 8125, "protocol": "udp" }
+                {{/datadog.dogstatsd.non_local_traffic}}
+            ],
+            "network": "BRIDGE"
+        },
+        "volumes": [
+            {
+                "containerPath": "/var/run/docker.sock",
+                "hostPath": "/var/run/docker.sock",
+                "mode": "RO"
+            },
+            {
+                "containerPath": "/host/proc",
+                "hostPath": "/proc",
+                "mode": "RO"
+            },
+            {
+                "containerPath": "/host/sys/fs/cgroup",
+                "hostPath": "/sys/fs/cgroup",
+                "mode": "RO"
+            }
+        ]
+    },
+    "cpus": {{datadog.cpus}},
+    "mem": {{datadog.mem}},
+    "instances": {{datadog.instances}},
+    "acceptedResourceRoles": ["slave_public", "*"],
+    "constraints": [
+        ["hostname", "UNIQUE"],
+        ["hostname", "GROUP_BY"]
+    ],
+    "healthChecks": [
+        {
+            "protocol": "COMMAND",
+            "command": { "value": "/probe.sh" },
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "timeoutSeconds": 20,
+            "maxConsecutiveFailures": 3
+        }
+    ]
+}

--- a/repo/packages/D/datadog/7/package.json
+++ b/repo/packages/D/datadog/7/package.json
@@ -1,0 +1,24 @@
+{
+    "packagingVersion": "3.0",
+    "minDcosReleaseVersion" : "1.8",
+    "description": "Datadog is a hosted monitoring service for cloud-scale infrastructure and applications",
+    "framework": false,
+    "licenses": [
+        {
+            "name": "Apache License 2.0",
+            "url": "https://github.com/DataDog/datadog-agent/blob/master/LICENSE"
+        }
+    ],
+    "maintainer": "package@datadoghq.com",
+    "name": "datadog",
+    "postInstallNotes": "Datadog on DCOS successfully installed.\nHead over to https://app.datadoghq.com to monitor your DCOS cluster.",
+    "postUninstallNotes": "Datadog on DCOS successfully uninstalled.\n.",
+    "preInstallNotes": "This package installs the new Agent 6 by default. You can revert to Agent 5 by enabling datadog.use_agent_5.\n\nPass your API key as a package option (datadog.api_key), which you can find at https://app.datadoghq.com/account/settings#api\n\nAlso pass the number of Mesos slaves as an option (datadog.instances), Marathon will make sure that the Datadog Agent runs only once per slave.\n\nSee https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md for available options.",
+    "scm": "https://github.com/datadog/datadog-agent.git",
+    "tags": [
+        "datadog",
+        "monitoring"
+    ],
+    "version": "1.0.7-6.0.0rc1",
+    "website": "https://www.datadoghq.com/"
+}

--- a/repo/packages/D/datadog/7/resource.json
+++ b/repo/packages/D/datadog/7/resource.json
@@ -1,0 +1,15 @@
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "agent5": "datadog/docker-dd-agent:12.5.5212",
+        "agent6": "datadog/agent:latest"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/datadog-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/datadog-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/datadog-icon-large.png"
+  }
+}


### PR DESCRIPTION
Added Tagging as an option to support customers with multiple clusters feeding one datadog account.
Updated version to reflect packaging and datadog agent version
