### PR TITLE
Fix broken URLs for (confluent-)kafka

### DIFF
--- a/repo/packages/C/confluent-kafka/500/package.json
+++ b/repo/packages/C/confluent-kafka/500/package.json
@@ -10,7 +10,7 @@
   "name": "confluent-kafka",
   "version": "2.5.0-4.1.2",
   "maintainer": "partner-support@confluent.io",
-  "description": "Apache Kafka by Confluent\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/confluent-kafka/v2.5.0-4.1.2/",
+  "description": "Apache Kafka by Confluent\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/confluent-kafka/2.5.0-4.1.2/",
   "selected": true,
   "framework": true,
   "tags": [
@@ -21,8 +21,8 @@
     "kafka"
   ],
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: 1.0 CPU | 4096 MB MEM | 1 5000 MB Disk",
-  "postInstallNotes": "Apache Kafka by Confluent is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/confluent-kafka/v2.5.0-4.1.2/\n\tCommunity Support: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "Apache Kafka by Confluent is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/confluent-kafka/v2.5.0-4.1.2/uninstall to remove any persistent state if required.",
+  "postInstallNotes": "Apache Kafka by Confluent is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/confluent-kafka/2.5.0-4.1.2/\n\tCommunity Support: https://docs.mesosphere.com/support/",
+  "postUninstallNotes": "Apache Kafka by Confluent is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/confluent-kafka/2.5.0-4.1.2/uninstall to remove any persistent state if required.",
   "licenses": [
     {
       "name": "Apache License v2",

--- a/repo/packages/C/confluent-kafka/600/package.json
+++ b/repo/packages/C/confluent-kafka/600/package.json
@@ -10,7 +10,7 @@
   "name": "confluent-kafka",
   "version": "2.6.0-5.1.2",
   "maintainer": "partner-support@confluent.io",
-  "description": "Apache Kafka by Confluent\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/confluent-kafka/v2.6.0-5.1.2/",
+  "description": "Apache Kafka by Confluent\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/confluent-kafka/2.6.0-5.1.2/",
   "selected": true,
   "framework": true,
   "tags": [
@@ -21,8 +21,8 @@
     "kafka"
   ],
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: 1.0 CPU | 4096 MB MEM | 1 5000 MB Disk",
-  "postInstallNotes": "Apache Kafka by Confluent is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/confluent-kafka/v2.6.0-5.1.2/\n\tCommunity Support: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "Apache Kafka by Confluent is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/confluent-kafka/v2.6.0-5.1.2/uninstall to remove any persistent state if required.",
+  "postInstallNotes": "Apache Kafka by Confluent is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/confluent-kafka/2.6.0-5.1.2/\n\tCommunity Support: https://docs.mesosphere.com/support/",
+  "postUninstallNotes": "Apache Kafka by Confluent is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/confluent-kafka/2.6.0-5.1.2/uninstall to remove any persistent state if required.",
   "licenses": [
     {
       "name": "Apache License v2",

--- a/repo/packages/K/kafka/500/package.json
+++ b/repo/packages/K/kafka/500/package.json
@@ -20,8 +20,8 @@
     "kafka"
   ],
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: 1.0 CPU, 2048 MB MEM and 1,5000 MB Disk.\n\nNote that Kafka requires a Zookeeper instance to be available before starting. It is a good practice to deploy a dedicated Zookeeper service, but you can always fall-back into using the DC/OS core Zookeeper instance instead.",
-  "postInstallNotes": "The DC/OS Apache Kafka service is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/kafka/v2.4.0-1.1.1/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Apache Kafka service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/kafka/v2.4.0-1.1.1/uninstall to remove any persistent state if required.",
+  "postInstallNotes": "The DC/OS Apache Kafka service is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/kafka/2.4.0-1.1.1/\n\tIssues: https://docs.mesosphere.com/support/",
+  "postUninstallNotes": "The DC/OS Apache Kafka service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/kafka/2.4.0-1.1.1/uninstall to remove any persistent state if required.",
   "scm": "https://github.com/mesosphere/dcos-kafka-service",
   "website": "https://docs.mesosphere.com/services/kafka/2.4.0-1.1.1",
   "licenses": [

--- a/repo/packages/K/kafka/600/package.json
+++ b/repo/packages/K/kafka/600/package.json
@@ -20,8 +20,8 @@
     "kafka"
   ],
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: 1.0 CPU, 2048 MB MEM and 1,5000 MB Disk.\n\nNote that Kafka requires a Zookeeper instance to be available before starting. It is a good practice to deploy a dedicated Zookeeper service, but you can always fall-back into using the DC/OS core Zookeeper instance instead.",
-  "postInstallNotes": "The DC/OS Apache Kafka service is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/kafka/v2.5.0-2.1.0/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Apache Kafka service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/kafka/v2.5.0-2.1.0/uninstall to remove any persistent state if required.",
+  "postInstallNotes": "The DC/OS Apache Kafka service is being installed.\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/kafka/2.5.0-2.1.0/\n\tIssues: https://docs.mesosphere.com/support/",
+  "postUninstallNotes": "The DC/OS Apache Kafka service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/kafka/2.5.0-2.1.0/uninstall to remove any persistent state if required.",
   "scm": "https://github.com/mesosphere/dcos-kafka-service",
   "website": "https://docs.mesosphere.com/services/kafka/2.5.0-2.1.0",
   "licenses": [


### PR DESCRIPTION
The `v` was throwing it off