### PR TITLE
[DCOS-54580] Updated universe packages catalogue icons for DSE and OPS package

### DIFF
--- a/repo/packages/D/datastax-dse/400/resource.json
+++ b/repo/packages/D/datastax-dse/400/resource.json
@@ -15,9 +15,9 @@
     }
   },
   "images": {
-    "icon-small": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Small.jpg",
-    "icon-medium": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Medium.jpg",
-    "icon-large": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Big.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/dse/icons/datastax-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/dse/icons/datastax-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/dse/icons/datastax-icon-large.png"
   },
   "cli": {
     "binaries": {

--- a/repo/packages/D/datastax-dse/500/resource.json
+++ b/repo/packages/D/datastax-dse/500/resource.json
@@ -14,9 +14,9 @@
     }
   },
   "images": {
-    "icon-small": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Small.jpg",
-    "icon-medium": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Medium.jpg",
-    "icon-large": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Big.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/dse/icons/datastax-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/dse/icons/datastax-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/dse/icons/datastax-icon-large.png"
   },
   "cli": {
     "binaries": {

--- a/repo/packages/D/datastax-ops/400/resource.json
+++ b/repo/packages/D/datastax-ops/400/resource.json
@@ -15,9 +15,9 @@
     }
   },
   "images": {
-    "icon-small": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Small.jpg",
-    "icon-medium": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Medium.jpg",
-    "icon-large": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Big.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/dse/icons/datastax-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/dse/icons/datastax-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/dse/icons/datastax-icon-large.png"
   },
   "cli": {
     "binaries": {

--- a/repo/packages/D/datastax-ops/500/resource.json
+++ b/repo/packages/D/datastax-ops/500/resource.json
@@ -14,9 +14,9 @@
     }
   },
   "images": {
-    "icon-small": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Small.jpg",
-    "icon-medium": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Medium.jpg",
-    "icon-large": "https://s3-us-west-1.amazonaws.com/dcos-dse-pkg/image/DS_Big.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/dse/icons/datastax-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/dse/icons/datastax-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/dse/icons/datastax-icon-large.png"
   },
   "cli": {
     "binaries": {


### PR DESCRIPTION
## What changes are proposed in this PR?

Resolves [DCOS-54580](https://jira.mesosphere.com/browse/DCOS-54580)
Made changes by uploading icon assets for Datastax DSE and OPS universe packages for fetching correct icons in packages (catalog).

## How were these changes tested?
The assets URL were manually checked by uploading them, browsing their URL to get icon images, and then deploying changes by adding them in resource.json and adding stub over a cluster to check output.