### PR TITLE
chore: add new dcos-ui package version

### DIFF
--- a/repo/packages/D/dcos-ui/2/package.json
+++ b/repo/packages/D/dcos-ui/2/package.json
@@ -1,0 +1,22 @@
+{
+  "packagingVersion": "4.0",
+  "name": "dcos-ui",
+  "version": "2.82.6",
+  "tags": [
+    "dcos-ui",
+    "dcos",
+    "ui"
+  ],
+  "maintainer": "frontend-dev@mesosphere.io",
+  "description": "DC/OS UI",
+  "scm": "https://github.com/dcos/dcos-ui",
+  "website": "https://dcos.io/",
+  "framework": false,
+  "minDcosReleaseVersion": "1.12",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/dcos/dcos-ui/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/D/dcos-ui/2/resource.json
+++ b/repo/packages/D/dcos-ui/2/resource.json
@@ -1,0 +1,7 @@
+{
+  "assets": {
+    "uris": {
+      "dcos-ui-bundle": "https://downloads.mesosphere.io/dcos-ui/1.13%2Bdcos-ui-enterprise-v2.82.6%2B0e5782c0.tar.gz"
+    }
+  }
+}


### PR DESCRIPTION
This updates ui packages devliered for ui-update-service to version that we shipped with 1.13.2 for customers running 1.13.1 or 1.13.0.