### PR TITLE
use mesosphere images in confluent packages

### DIFF
--- a/repo/packages/C/confluent-connect/100/config.json
+++ b/repo/packages/C/confluent-connect/100/config.json
@@ -39,7 +39,7 @@
         "user": {
           "description": "The user that the service will run as.",
           "type": "string",
-          "default": "root",
+          "default": "nobody",
           "title": "User"
         },
         "instances": {

--- a/repo/packages/C/confluent-connect/100/resource.json
+++ b/repo/packages/C/confluent-connect/100/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "image": "confluentinc/cp-kafka-connect:5.1.2"
+        "image": "mesosphere/cp-kafka-connect:5.1.2"
       }
     }
   },

--- a/repo/packages/C/confluent-connect/200/config.json
+++ b/repo/packages/C/confluent-connect/200/config.json
@@ -39,7 +39,7 @@
         "user": {
           "description": "The user that the service will run as.",
           "type": "string",
-          "default": "root",
+          "default": "nobody",
           "title": "User"
         },
         "instances": {

--- a/repo/packages/C/confluent-connect/200/resource.json
+++ b/repo/packages/C/confluent-connect/200/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "image": "confluentinc/cp-kafka-connect:5.1.2"
+        "image": "mesosphere/cp-kafka-connect:5.1.2"
       }
     }
   },

--- a/repo/packages/C/confluent-control-center/100/config.json
+++ b/repo/packages/C/confluent-control-center/100/config.json
@@ -51,7 +51,7 @@
         "user": {
           "description": "The user that the service will run as.",
           "type": "string",
-          "default": "root",
+          "default": "nobody",
           "title": "User"
         },
         "instances": {

--- a/repo/packages/C/confluent-control-center/100/resource.json
+++ b/repo/packages/C/confluent-control-center/100/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "image": "confluentinc/cp-enterprise-control-center:5.1.2"
+        "image": "mesosphere/cp-enterprise-control-center:5.1.2"
       }
     }
   },

--- a/repo/packages/C/confluent-replicator/100/config.json
+++ b/repo/packages/C/confluent-replicator/100/config.json
@@ -38,7 +38,7 @@
         "user": {
           "description": "The user that the service will run as.",
           "type": "string",
-          "default": "root",
+          "default": "nobody",
           "title": "User"
         },
         "instances": {

--- a/repo/packages/C/confluent-replicator/100/resource.json
+++ b/repo/packages/C/confluent-replicator/100/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "image": "confluentinc/cp-enterprise-replicator:5.1.2"
+        "image": "mesosphere/cp-enterprise-replicator:5.1.2"
       }
     }
   },

--- a/repo/packages/C/confluent-rest-proxy/100/config.json
+++ b/repo/packages/C/confluent-rest-proxy/100/config.json
@@ -59,7 +59,7 @@
         "user": {
           "description": "The user that the service will run as.",
           "type": "string",
-          "default": "root",
+          "default": "nobody",
           "title": "User"
         },
         "instances": {

--- a/repo/packages/C/confluent-rest-proxy/100/resource.json
+++ b/repo/packages/C/confluent-rest-proxy/100/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "image": "confluentinc/cp-kafka-rest:5.1.2"
+        "image": "mesosphere/cp-kafka-rest:5.1.2"
       }
     }
   },

--- a/repo/packages/C/confluent-rest-proxy/200/config.json
+++ b/repo/packages/C/confluent-rest-proxy/200/config.json
@@ -59,7 +59,7 @@
         "user": {
           "description": "The user that the service will run as.",
           "type": "string",
-          "default": "root",
+          "default": "nobody",
           "title": "User"
         },
         "instances": {

--- a/repo/packages/C/confluent-rest-proxy/200/resource.json
+++ b/repo/packages/C/confluent-rest-proxy/200/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "image": "confluentinc/cp-kafka-rest:5.1.2"
+        "image": "mesosphere/cp-kafka-rest:5.1.2"
       }
     }
   },

--- a/repo/packages/C/confluent-schema-registry/100/config.json
+++ b/repo/packages/C/confluent-schema-registry/100/config.json
@@ -61,7 +61,7 @@
         "user": {
           "description": "The user that the service will run as.",
           "type": "string",
-          "default": "root",
+          "default": "nobody",
           "title": "User"
         },
         "instances": {

--- a/repo/packages/C/confluent-schema-registry/100/resource.json
+++ b/repo/packages/C/confluent-schema-registry/100/resource.json
@@ -2,7 +2,7 @@
   "assets": {
     "container": {
       "docker": {
-        "image": "confluentinc/cp-schema-registry:5.1.2"
+        "image": "mesosphere/cp-schema-registry:5.1.2"
       }
     }
   },


### PR DESCRIPTION
This PR provides a fix for [confluent packages running with user nobody](https://support.mesosphere.com/s/article/confluent-2-6-0-5-1-2-on-strict-mode-centos)

And also changes the default user to `nobody`