### PR TITLE
add configuration option in schema registry to bootstrap servers

### DIFF
--- a/repo/packages/C/confluent-schema-registry/100/config.json
+++ b/repo/packages/C/confluent-schema-registry/100/config.json
@@ -134,6 +134,12 @@
           "type": "string",
           "default": "PLAINTEXT"
         },
+        "kafkastore-bootstrap-servers": {
+          "title": "Kafka bootstrap servers",
+          "default": "",
+          "description": "A list of Kafka brokers to connect to. For example, PLAINTEXT://kafka-0-broker.confluent-kafka.autoip.dcos.thisdcos.directory:9092,SSL://kafka-0-broker.confluent-kafka.autoip.dcos.thisdcos.directory:9092",
+          "type": "string"
+        },
         "kerberos_enabled": {
           "description": "Enable kerberos",
           "type": "boolean",

--- a/repo/packages/C/confluent-schema-registry/100/marathon.json.mustache
+++ b/repo/packages/C/confluent-schema-registry/100/marathon.json.mustache
@@ -116,6 +116,7 @@
     "SCHEMA_REGISTRY_SSL_KEY_PASSWORD": "changeit",
     "SCHEMA_REGISTRY_SSL_CLIENT_AUTH": "{{registry.ssl_client_auth}}",
     "SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL": "{{kafka.client_security_protocol}}",
+    "SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS":"{{kafka.kafkastore-bootstrap-servers}},"
     "SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_LOCATION": "/tmp/kafka-truststore.jks",
     "SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD": "changeit",
     "SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_LOCATION": "/tmp/kafka-keystore.jks",


### PR DESCRIPTION
`SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS` is not optional for schema registry when configured TLS/SSL.

This PR adds the configuration option `kafka.kafkastore-bootstrap-servers` to let users configure it correctly.