### PR TITLE
fix the parsing error in confluent schema registry

### DIFF
--- a/repo/packages/C/confluent-schema-registry/100/marathon.json.mustache
+++ b/repo/packages/C/confluent-schema-registry/100/marathon.json.mustache
@@ -116,7 +116,7 @@
     "SCHEMA_REGISTRY_SSL_KEY_PASSWORD": "changeit",
     "SCHEMA_REGISTRY_SSL_CLIENT_AUTH": "{{registry.ssl_client_auth}}",
     "SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL": "{{kafka.client_security_protocol}}",
-    "SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS":"{{kafka.kafkastore-bootstrap-servers}},"
+    "SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS":"{{kafka.kafkastore-bootstrap-servers}}",
     "SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_LOCATION": "/tmp/kafka-truststore.jks",
     "SCHEMA_REGISTRY_KAFKASTORE_SSL_TRUSTSTORE_PASSWORD": "changeit",
     "SCHEMA_REGISTRY_KAFKASTORE_SSL_KEYSTORE_LOCATION": "/tmp/kafka-keystore.jks",


### PR DESCRIPTION
fixing the wrong addition of the config option `kafka.kafkastore-bootstrap-servers` 
