### PR TITLE
Release elastic 2.7.0-6.8.1 (automated commit)



### DIFF
--- a/repo/packages/E/elastic/700/config.json
+++ b/repo/packages/E/elastic/700/config.json
@@ -1062,7 +1062,7 @@
           "default": ""
         },
         "script_painless_regex_enabled": {
-          "description": "Regexes are disabled by default because they circumvent Painless\u2019s protection against long running and memory hungry scripts. Set true to enable.",
+          "description": "Regexes are disabled by default because they circumvent Painless's protection against long running and memory hungry scripts. Set true to enable.",
           "type": "boolean",
           "default": false
         },
@@ -1262,7 +1262,7 @@
           "default": 0
         },
         "xpack_ml_max_machine_memory_percent": {
-          "description": "The maximum percentage of the machine\u2019s memory that machine learning may use for running analytics processes. (These processes are separate to the Elasticsearch JVM.) Defaults to 30 percent.",
+          "description": "The maximum percentage of the machine's memory that machine learning may use for running analytics processes. (These processes are separate to the Elasticsearch JVM.) Defaults to 30 percent.",
           "type": "integer",
           "default": 30
         },

--- a/repo/packages/E/elastic/700/config.json
+++ b/repo/packages/E/elastic/700/config.json
@@ -1,0 +1,1317 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "Unique name for the Elasticsearch service instance consisting of a series of words separated by slashes. Each word must be at least 1 alphanumeric character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The word may not begin or end with a dash",
+          "type": "string",
+          "default": "elastic",
+          "pattern": "^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$"
+        },
+        "user": {
+          "description": "The user that runs the Elasticsearch services and owns the Mesos sandbox.",
+          "type": "string",
+          "default": "nobody"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": "",
+          "media": {
+            "type": "application/x-service-account+string"
+          }
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": "",
+          "media": {
+            "type": "application/x-secret+string"
+          }
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        },
+        "check": {
+          "description": "Health check used to determine the scheduler health based on the status of the scheduler plans.",
+          "type": "object",
+          "properties": {
+            "intervalSeconds": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last check has completed to start the next check.",
+              "default": 30,
+              "minimum": 30
+            },
+            "timeoutSeconds": {
+              "type": "integer",
+              "description": " An amount of time in seconds to wait for check to succeed.",
+              "default": 20,
+              "minimum": 20
+            },
+            "delaySeconds": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the check attempts.",
+              "default": 15,
+              "minimum": 15
+            }
+          }
+        },
+        "deploy_strategy": {
+          "description": "Elasticsearch deploy strategy. [parallel, serial]",
+          "type": "string",
+          "enum": [
+            "parallel",
+            "serial"
+          ],
+          "default": "parallel"
+        },
+        "region": {
+          "description": "All Elastic nodes will run in this region.  When no region is specified the nodes are constrained to the local region.",
+          "type": "string",
+          "default": "",
+          "media": {
+            "type": "application/x-region+string"
+          }
+        },
+        "update_strategy": {
+          "description": "Elasticsearch update strategy. [parallel, serial]",
+          "type": "string",
+          "enum": [
+            "parallel",
+            "serial"
+          ],
+          "default": "serial"
+        },
+        "security": {
+          "description": "Elastic security settings",
+          "type": "object",
+          "properties": {
+            "transport_encryption": {
+              "type": "object",
+              "description": "Transport encryption settings",
+              "properties": {
+                "enabled": {
+                  "description": "Enable transport encryption (TLS)",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            },
+            "custom_domain": {
+              "type": "string",
+              "description": "A custom domain to be used in place of autoip.dcos.thisdcos.directory. This can be used to expose the service securely outside of the cluster, but requires setting up external DNS. See the service documentation for details."
+            }
+          }
+        }
+      },
+      "required": [
+        "name",
+        "user",
+        "deploy_strategy",
+        "update_strategy"
+      ]
+    },
+    "master_nodes": {
+      "description": "Configuration properties for the three (3) Elasticsearch master nodes",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "description": "Node cpu requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "mem": {
+          "description": "Node mem requirements",
+          "type": "integer",
+          "default": 2048
+        },
+        "heap": {
+          "description": "The Elasticsearch process JVM heap configuration object",
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "integer",
+              "description": "The amount of JVM heap, in MB, allocated to the Elasticsearch node process.",
+              "default": 1024
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "size"
+          ]
+        },
+        "disk": {
+          "description": "Node disk requirements (only respected with persistent volumes)",
+          "type": "integer",
+          "default": 2000
+        },
+        "disk_type": {
+          "type": "string",
+          "description": "Disk type to be used for storing data. [ROOT, MOUNT]",
+          "default": "ROOT"
+        },
+        "volume_profile": {
+          "type": "string",
+          "description": "Volume profile to be used for storing Master Node data."
+        },
+        "transport_port": {
+          "description": "Transport port for master nodes to listen on.",
+          "type": "integer",
+          "default": 9300
+        },
+        "placement": {
+          "description": "Placement constraints for master nodes (e.g., [[\"hostname\", \"UNIQUE\"]]).",
+          "type": "string",
+          "default": "[[\"hostname\", \"UNIQUE\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "readiness_check": {
+          "description": "Readiness check settings. Exercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 5,
+              "minimum": 5
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0,
+              "minimum": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 10,
+              "minimum": 10
+            }
+          }
+        },
+        "rlimits": {
+          "description": "POSIX resource limits applied to the pod. Exercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft": {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard": {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "transport_port"
+      ]
+    },
+    "data_nodes": {
+      "description": "Elasticsearch data node configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "description": "Number of data nodes to run",
+          "type": "integer",
+          "default": 2,
+          "minimum": 1
+        },
+        "cpus": {
+          "description": "Node cpu requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "mem": {
+          "description": "Node mem requirements",
+          "type": "integer",
+          "default": 4096
+        },
+        "heap": {
+          "description": "The Elasticsearch process JVM heap configuration object",
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "integer",
+              "description": "The amount of JVM heap, in MB, allocated to the Elasticsearch node process.",
+              "default": 2048
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "size"
+          ]
+        },
+        "disk": {
+          "description": "Node disk requirements (only respected with persistent volumes)",
+          "type": "integer",
+          "default": 10000
+        },
+        "disk_type": {
+          "type": "string",
+          "description": "Disk type to be used for storing data. [ROOT, MOUNT]",
+          "default": "ROOT"
+        },
+        "volume_profile": {
+          "type": "string",
+          "description": "Volume profile to be used for storing Data Node data."
+        },
+        "placement": {
+          "description": "Placement constraints for data nodes (e.g., [[\"hostname\", \"UNIQUE\"]]).",
+          "type": "string",
+          "default": "[[\"hostname\", \"UNIQUE\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "readiness_check": {
+          "description": "Readiness check settings. Exercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 5,
+              "minimum": 5
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0,
+              "minimum": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 10,
+              "minimum": 10
+            }
+          }
+        },
+        "rlimits": {
+          "description": "POSIX resource limits applied to the pod. Exercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft": {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard": {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "count"
+      ]
+    },
+    "ingest_nodes": {
+      "description": "Elasticsearch ingest node configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "description": "Number of ingest nodes to run",
+          "type": "integer",
+          "default": 0,
+          "minimum": 0
+        },
+        "cpus": {
+          "description": "Node cpu requirements",
+          "type": "number",
+          "default": 0.5
+        },
+        "mem": {
+          "description": "Node mem requirements",
+          "type": "integer",
+          "default": 2048
+        },
+        "heap": {
+          "description": "The Elasticsearch process JVM heap configuration object",
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "integer",
+              "description": "The amount of JVM heap, in MB, allocated to the Elasticsearch node process.",
+              "default": 512
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "size"
+          ]
+        },
+        "disk": {
+          "description": "Node disk requirements (only respected with persistent volumes)",
+          "type": "integer",
+          "default": 2000
+        },
+        "disk_type": {
+          "type": "string",
+          "description": "Disk type to be used for storing data. [ROOT, MOUNT]",
+          "default": "ROOT"
+        },
+        "volume_profile": {
+          "type": "string",
+          "description": "Volume profile to be used for storing Ingest Node data."
+        },
+        "placement": {
+          "description": "Placement constraints for ingest nodes (e.g., [[\"hostname\", \"UNIQUE\"]]).",
+          "type": "string",
+          "default": "[[\"hostname\", \"UNIQUE\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "readiness_check": {
+          "description": "Readiness check settings. Exercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 5,
+              "minimum": 5
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0,
+              "minimum": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 10,
+              "minimum": 10
+            }
+          }
+        },
+        "rlimits": {
+          "description": "POSIX resource limits applied to the pod. Exercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft": {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard": {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "count"
+      ]
+    },
+    "coordinator_nodes": {
+      "description": "Elasticsearch coordinator node configuration properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "description": "Number of coordinator nodes to run",
+          "type": "integer",
+          "default": 1,
+          "minimum": 0
+        },
+        "cpus": {
+          "description": "Node cpu requirements",
+          "type": "number",
+          "default": 1.0
+        },
+        "mem": {
+          "description": "Node mem requirements",
+          "type": "integer",
+          "default": 2048
+        },
+        "heap": {
+          "description": "The Elasticsearch process JVM heap configuration object",
+          "type": "object",
+          "properties": {
+            "size": {
+              "type": "integer",
+              "description": "The amount of JVM heap, in MB, allocated to the Elasticsearch node process.",
+              "default": 1024
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "size"
+          ]
+        },
+        "disk": {
+          "description": "Node disk requirements (only respected with persistent volumes)",
+          "type": "integer",
+          "default": 1000
+        },
+        "disk_type": {
+          "type": "string",
+          "description": "Disk type to be used for storing data. [ROOT, MOUNT]",
+          "default": "ROOT"
+        },
+        "volume_profile": {
+          "type": "string",
+          "description": "Volume profile to be used for storing Coordinator Node data."
+        },
+        "placement": {
+          "description": "Placement constraints for coordinator nodes (e.g., [[\"hostname\", \"UNIQUE\"]]).",
+          "type": "string",
+          "default": "[[\"hostname\", \"UNIQUE\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "readiness_check": {
+          "description": "Readiness check settings. Exercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last readiness check has completed to start the next check.",
+              "default": 5,
+              "minimum": 5
+            },
+            "delay": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the readiness check attempts.",
+              "default": 0,
+              "minimum": 0
+            },
+            "timeout": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait for a readiness check to succeed.",
+              "default": 10,
+              "minimum": 10
+            }
+          }
+        },
+        "rlimits": {
+          "description": "POSIX resource limits applied to the pod. Exercise caution when modifying these default values as it can lead to spurious task failures.",
+          "type": "object",
+          "properties": {
+            "rlimit_nofile": {
+              "description": "Specifies RLIMIT_NOFILE, a value one greater than the maximum file descriptor number that can be opened by this process.",
+              "type": "object",
+              "properties": {
+                "soft": {
+                  "type": "integer",
+                  "description": "The  soft  limit  is  the  value that the kernel enforces for the corresponding resource.",
+                  "default": 128000,
+                  "minimum": 128000
+                },
+                "hard": {
+                  "type": "integer",
+                  "description": "The  hard  limit  acts as a ceiling for the soft limit.",
+                  "default": 128000,
+                  "minimum": 128000
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "cpus",
+        "mem",
+        "disk",
+        "count"
+      ]
+    },
+    "elasticsearch": {
+      "description": "Elasticsearch service configuration properties",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "custom_elasticsearch_yml": {
+          "description": "Custom YAML to be appended to elasticsearch.yml on each node. This field must be base64 encoded.",
+          "type": "string",
+          "default": "",
+          "media": {
+            "binaryEncoding": "base64",
+            "type": "application/x-yaml"
+          }
+        },
+        "health_user": {
+          "description": "Elastic username to use for X-Pack authentication, if enabled",
+          "type": "string",
+          "default": "elastic"
+        },
+        "health_user_password": {
+          "description": "Password to use with health_user for X-Pack authentication, if enabled. Note that you are not setting the password here. You are telling the framework the credentials to use when sending in health check requests.",
+          "type": "string",
+          "default": "changeme"
+        },
+        "plugins": {
+          "description": "Comma-separated list of plugins to install",
+          "type": "string",
+          "default": ""
+        },
+        "plugin_http_proxy_host": {
+          "description": "HTTP proxy host for plugin installation. Default value '' means that proxy won't be used.",
+          "type": "string",
+          "default": ""
+        },
+        "plugin_http_proxy_port": {
+          "description": "HTTP proxy port for plugin installation. Default value -1 means that proxy won't be used.",
+          "type": "integer",
+          "default": -1
+        },
+        "plugin_https_proxy_host": {
+          "description": "HTTPS proxy host for plugin installation. Default value '' means that proxy won't be used.",
+          "type": "string",
+          "default": ""
+        },
+        "plugin_https_proxy_port": {
+          "description": "HTTPS proxy port for plugin installation. Default value -1 means that proxy won't be used.",
+          "type": "integer",
+          "default": -1
+        },
+        "xpack_http_proxy_host": {
+          "description": "Specifies the address of the proxy server to use to connect to HTTP services.",
+          "type": "string",
+          "default": ""
+        },
+        "xpack_http_proxy_port": {
+          "description": "Specifies the port number to use to connect to the proxy server.",
+          "type": "string",
+          "default": ""
+        },
+        "xpack_graph_enabled": {
+          "description": "By default, Graph is enabled in Elastic Stack. Set to false to disable graph analytics features.",
+          "type": "boolean",
+          "default": true
+        },
+        "xpack_ml_enabled": {
+          "description": "By default, Machine Learning feature is enabled in Elastic Stack. Set to false to disable machine learning features.",
+          "type": "boolean",
+          "default": true
+        },
+        "xpack_monitoring_collection_enabled": {
+          "description": "Set to true to enable the collection of monitoring data. When this setting is false (default), Elasticsearch monitoring data is not collected and all monitoring data from other sources such as Kibana, Beats, and Logstash is ignored.",
+          "type": "boolean",
+          "default": false
+        },
+        "xpack_monitoring_enabled": {
+          "description": "By default, Monitoring feature is enabled in Elastic Stack. Set to false to disable monitoring features.",
+          "type": "boolean",
+          "default": true
+        },
+        "xpack_monitoring_default_exporter_use_ingest": {
+          "description": "Whether to supply a placeholder pipeline to the cluster and a pipeline processor with every bulk request. Defaults to false.",
+          "type": "boolean",
+          "default": false
+        },
+        "xpack_security_audit_enabled": {
+          "description": "Set to true to enable auditing on the node. Defaults to false.",
+          "type": "boolean",
+          "default": false
+        },
+        "xpack_security_enabled": {
+          "description": "Set it to true to enable X-Pack security on all nodes. Defaults to false.",
+          "type": "boolean",
+          "default": false
+        },
+        "xpack_sql_enabled": {
+          "description": "Set to false to disable SQL Access on the node. SQL Access is enabled by default",
+          "type": "boolean",
+          "default": true
+        },
+        "xpack_watcher_enabled": {
+          "description": "By default, Watcher feature is enabled in Elastic Stack. Set to false to disable Watcher.",
+          "type": "boolean",
+          "default": true
+        },
+        "action_destructive_requires_name": {
+          "description": "In order to disable allowing to delete indices via wildcards or _all, set it as true.",
+          "type": "boolean",
+          "default": false
+        },
+        "cluster_blocks_read_only": {
+          "description": "Make the whole cluster read only (indices do not accept write operations), metadata is not allowed to be modified (create or delete indices). Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_blocks_read_only_allow_delete": {
+          "description": "Identical to cluster_blocks_read_only but allows to delete indices to free up resources. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_indices_tombstones_size": {
+          "description": "Index tombstones prevent nodes that are not part of the cluster when a delete occurs from joining the cluster and reimporting the index as though the delete was never issued. To keep the cluster state from growing huge we only keep the last cluster.indices.tombstones.size deletes, which defaults to 500. You can increase it if you expect nodes to be absent from the cluster and miss more than 500 deletes. We think that is rare, thus the default. Tombstones don't take up much space, but we also think that a number like 50,000 is probably too big. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_info_update_interval": {
+          "description": "How often Elasticsearch should check on disk usage for each node in the cluster. Defaults to 30s. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_max_shards_per_node": {
+          "description": "Controls the number of shards allowed in the cluster per data node. The limit defaults to 1,000 shards per data node.",
+          "type": "integer",
+          "default": 1000
+        },
+        "cluster_persistent_tasks_allocation_enable": {
+          "description": "Enable or disable allocation for persistent tasks. all(default) Allows persistent tasks to be assigned to nodes, none - No allocations are allowed for any type of persistent task.",
+          "type": "string",
+          "default": "all"
+        },
+        "cluster_persistent_tasks_allocation_recheck_interval": {
+          "description": "The default is 30 seconds. The minimum permitted value is 10 seconds.",
+          "type": "string",
+          "default": "30s"
+        },
+        "cluster_remote_connect": {
+          "description": "Can be set to false (defaults to true) to prevent certain nodes from connecting to remote clusters.",
+          "type": "boolean",
+          "default": true
+        },
+        "cluster_remote_connections_per_cluster": {
+          "description": "The number of gateway nodes to connect to per remote cluster. Defaults to 3.",
+          "type": "integer",
+          "default": 3
+        },
+        "cluster_routing_allocation_allow_rebalance": {
+          "description": "Specify when shard rebalancing is allowed: always, indices_primaries_active, indices_all_active (default). Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_awareness_attributes": {
+          "description": "Setup shard allocation awareness by telling Elasticsearch which attributes to use. Multiple awareness attributes can be specified, in which case the combination of values from each attribute is considered to be a separate value. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_balance_index": {
+          "description": "Defines the weight factor for the number of shards per index allocated on a specific node (float). Defaults to 0.55f. Raising this raises the tendency to equalize the number of shards per index across all nodes in the cluster. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_balance_shard": {
+          "description": "Defines the weight factor for the total number of shards allocated on a node (float). Defaults to 0.45f. Raising this raises the tendency to equalize the number of shards across all nodes in the cluster. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_balance_threshold": {
+          "description": "Minimal optimization value of operations that should be performed (non negative float). Defaults to 1.0f. Raising this will cause the cluster to be less aggressive about optimizing the shard balance. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_cluster_concurrent_rebalance": {
+          "description": "Allow to control how many concurrent shard rebalances are allowed cluster wide. Defaults to 2. Note that this setting only controls the number of concurrent shard relocations due to imbalances in the cluster. This setting does not limit shard relocations due to allocation filtering or forced awareness. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_disk_include_relocations": {
+          "description": "Defaults to true, which means that Elasticsearch will take into account shards that are currently being relocated to the target node when computing a node's disk usage. Taking relocating shards' sizes into account may, however, mean that the disk usage for a node is incorrectly estimated on the high side, since the relocation could be 90% complete and a recently retrieved disk usage would include the total size of the relocating shard as well as the space already used by the running relocation. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_disk_threshold_enabled": {
+          "description": "Elasticsearch factors in the available disk space on a node before deciding whether to allocate new shards to that node or to actively relocate shards away from that node. Defaults to true. Set to false to disable the disk allocation decider. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_disk_watermark_high": {
+          "description": "Controls the high watermark. It defaults to 90%, meaning ES will attempt to relocate shards to another node if the node disk usage rises above 90%. It can also be set to an absolute byte value (similar to the low watermark) to relocate shards once less than the configured amount of space is available on the node. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_disk_watermark_low": {
+          "description": "Controls the low watermark for disk usage. It defaults to 85%, meaning ES will not allocate new shards to nodes once they have more than 85% disk used. It can also be set to an absolute byte value (like 500mb) to prevent ES from allocating shards if less than the configured amount of space is available. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_enable": {
+          "description": "Enable or disable allocation for specific kinds of shards: all, primaries, new_primaries, none. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_node_concurrent_incoming_recoveries": {
+          "description": "How many concurrent incoming shard recoveries are allowed to happen on a node. Incoming recoveries are the recoveries where the target shard (most likely the replica unless a shard is relocating) is allocated on the node. Defaults to 2. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_node_concurrent_outgoing_recoveries": {
+          "description": "How many concurrent outgoing shard recoveries are allowed to happen on a node. Outgoing recoveries are the recoveries where the source shard (most likely the primary unless a shard is relocating) is allocated on the node. Defaults to 2. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_node_concurrent_recoveries": {
+          "description": "A shortcut to set both cluster.routing.allocation.node_concurrent_incoming_recoveries and cluster.routing.allocation.node_concurrent_outgoing_recoveries. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_node_initial_primaries_recoveries": {
+          "description": "While the recovery of replicas happens over the network, the recovery of an unassigned primary after node restart uses data from the local disk. These should be fast so more initial primary recoveries can happen in parallel on the same node. Defaults to 4. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_same_shard_host": {
+          "description": "Allows to perform a check to prevent allocation of multiple instances of the same shard on a single host, based on host name and host address. Defaults to false, meaning that no check is performed by default. This setting only applies if multiple nodes are started on the same machine. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_total_shards_per_node": {
+          "description": "The maximum number of shards (replicas and primaries) that will be allocated to a single node globally. Defaults to unbounded (-1). Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_rebalance_enable": {
+          "description": "Enable or disable rebalancing for specific kinds of shards: all, primeries, replicas, none. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "discovery_zen_fd_ping_interval": {
+          "description": "How often a node gets pinged. Defaults to 1s. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "discovery_zen_fd_ping_retries": {
+          "description": "How many ping failures / timeouts cause a node to be considered failed. Defaults to 3. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "discovery_zen_fd_ping_timeout": {
+          "description": "How long to wait for a ping response, defaults to 30s. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "discovery_zen_no_master_block": {
+          "description": "Controls what operations should be rejected when there is no active master. There are two valid operations: all and write (defaut). Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "discovery_zen_ping_unicast_hosts.resolve_timeout": {
+          "description": "The amount of time to wait for DNS lookups on each round of pinging. Specified as time units. Defaults to 5s. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "gateway_recover_after_time": {
+          "description": "If the expected number of nodes is not achieved, the recovery process waits for the configured amount of time before trying to recover regardless. Defaults to 5m if one of the expected_nodes settings is configured.",
+          "type": "string",
+          "default": "5m"
+        },
+        "http_compression": {
+          "description": "Support for compression when possible (with Accept-Encoding). Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "http_compression_level": {
+          "description": "Defines the compression level to use for HTTP responses. Valid values are in the range of 1 (minimum compression) and 9 (maximum compression). Defaults to 3.",
+          "type": "integer",
+          "default": 3
+        },
+        "http_cors_allow_credentials": {
+          "description": "Whether the Access-Control-Allow-Credentials header should be returned. Note: This header is only returned when the setting is set to true. Defaults to false.",
+          "type": "boolean",
+          "default": false
+        },
+        "http_cors_allow_headers": {
+          "description": "Which headers to allow. Defaults to X-Requested-With, Content-Type, Content-Length.",
+          "type": "string",
+          "default": "X-Requested-With,Content-Type,Content-Length"
+        },
+        "http_cors_allow_methods": {
+          "description": "Which methods to allow. Defaults to OPTIONS, HEAD, GET, POST, PUT, DELETE.",
+          "type": "string",
+          "default": "OPTIONS,HEAD,GET,POST,PUT,DELETE"
+        },
+        "http_cors_allow_origin": {
+          "description": "Which origins to allow. Defaults to no origins allowed. If you prepend and append a '/' to the value, this will be treated as a regular expression, allowing you to support HTTP and HTTPs. * is a valid value but is considered a security risk as your elasticsearch instance is open to cross origin requests from anywhere.",
+          "type": "string",
+          "default": ""
+        },
+        "http_cors_enabled": {
+          "description": "Enable or disable cross-origin resource sharing, i.e. whether a browser on another origin can execute requests against Elasticsearch. Set to true to enable Elasticsearch to process pre-flight CORS requests.",
+          "type": "boolean",
+          "default": false
+        },
+        "http_cors_max_age": {
+          "description": "Browsers send a \"preflight\" OPTIONS-request to determine CORS settings. Defines how long the result should be cached for. Defaults to 1728000 (20 days)",
+          "type": "integer",
+          "default": 1728000
+        },
+        "http_detailed_errors_enabled": {
+          "description": "Enables or disables the output of detailed error messages and stack traces in response output. Note: When set to false and the error_trace request parameter is specified, an error will be returned; when error_trace is not specified, a simple message will be returned. Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "http_enabled": {
+          "description": "The http module can be completely disabled and not started by setting http.enabled to false. Default is true.",
+          "type": "boolean",
+          "default": true
+        },
+        "http_max_content_length": {
+          "description": "The max content of an HTTP request. Defaults to 100mb. If set to greater than Integer.MAX_VALUE, it will be reset to 100mb.",
+          "type": "string",
+          "default": "100mb"
+        },
+        "http_max_header_size": {
+          "description": "The max size of allowed headers. Defaults to 8kB.",
+          "type": "string",
+          "default": "8kB"
+        },
+        "http_max_initial_line_length": {
+          "description": "The max length of an HTTP URL. Defaults to 4kb.",
+          "type": "string",
+          "default": "4kb"
+        },
+        "http_pipelining": {
+          "description": "Enable or disable HTTP pipelining, defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "http_pipelining_max_events": {
+          "description": "The maximum number of events to be queued up in memory before a HTTP connection is closed, defaults to 10000.",
+          "type": "integer",
+          "default": 10000
+        },
+        "index_routing_allocation_total_shards_per_node": {
+          "description": "The maximum number of shards (replicas and primaries) that will be allocated to a single node. Defaults to unbounded. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_breaker_fielddata_limit": {
+          "description": "Limit for fielddata breaker, defaults to 60% of JVM heap. Empty means do not explicity set. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_breaker_fielddata_overhead": {
+          "description": "A constant that all field data estimations are multiplied with to determine a final estimation. Defaults to 1.03. Empty means do not explicity set. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_breaker_total_limit": {
+          "description": "Starting limit for overall parent breaker, defaults to 70% of JVM heap. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_fielddata_cache_size": {
+          "description": "The max size of the field data cache, eg 30% of node heap space, or an absolute value, eg 12GB. Defaults to unbounded. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_memory_index_buffer_size": {
+          "description": "Accepts either a percentage or a byte size value. It defaults to 10%, meaning that 10% of the total heap allocated to a node will be used as the indexing buffer size shared across all shards. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_memory_max_index_buffer_size": {
+          "description": "If the index_buffer_size is specified as a percentage, then this setting can be used to specify an absolute maximum. Defaults to unbounded. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_memory_min_index_buffer_size": {
+          "description": "If the index_buffer_size is specified as a percentage, then this setting can be used to specify an absolute minimum. Defaults to 48mb. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_queries_cache_size": {
+          "description": "Controls the memory size for the filter cache , defaults to 10%. Accepts either a percentage value, like 5%, or an exact value, like 512mb. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_query_bool_max_clause_count": {
+          "description": "Set the number of clauses used while querying Elasticsearch. Defaults to 1024. If any query expands into more than 1024 boolean clauses, you will get TooManyClauses exception. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_recovery_max_bytes_per_sec": {
+          "description": "This can be set to manage the recovery policy. Defaults to 40mb. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_requests_cache_size": {
+          "description": "The cache is managed at the node level, and has a default maximum size of 1% of the heap. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "network_breaker_inflight_requests_limit": {
+          "description": "Limit for in flight requests breaker, defaults to 100% of JVM heap. This means that it is bound by the limit configured for the parent circuit breaker. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "network_breaker_inflight_requests_overhead": {
+          "description": "A constant that all in flight requests estimations are multiplied with to determine a final estimation. Defaults to 1. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "network_tcp_keep_alive": {
+          "description": "Enable or disable TCP keep alive. Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "network_tcp_no_delay": {
+          "description": "Enable or disable the TCP no delay setting. Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "network_tcp_receive_buffer_size": {
+          "description": "The size of the TCP receive buffer (specified with size units). By default not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "network_tcp_reuse_address": {
+          "description": "Should an address be reused or not. Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "network_tcp_send_buffer_size": {
+          "description": "The size of the TCP send buffer (specified with size units). By default not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "repositories_url_allowed_urls": {
+          "description": "URL Repository supports the following protocols: \"http\", \"https\", \"ftp\", \"file\" and \"jar\". URL repositories with http:, https:, and ftp: URLs have to be whitelisted by specifying allowed URLs in the repositories_url_allowed_urls setting. This setting supports wildcards in the place of host, path, query, and fragment.",
+          "type": "string",
+          "default": ""
+        },
+        "script_allowed_contexts": {
+          "description": "By default all script contexts (search,update,aggs,plugin) are allowed to be executed. This can be modified using the setting script_allowed_contexts. Only the contexts specified as part of the setting will be allowed to be executed. To specify no contexts are allowed, set script_allowed_contexts to be none. Empty string \"\" means all contexts (default).",
+          "type": "string",
+          "default": ""
+        },
+        "script_allowed_types": {
+          "description": "By default all script types (inline,file,stored) are allowed to be executed. This can be modified using the setting script_allowed_types. Only the types specified as part of the setting will be allowed to be executed. To specify no types are allowed, set script.allowed_types to be none. Empty string \"\" means all types (default).",
+          "type": "string",
+          "default": ""
+        },
+        "script_max_compilations_per_minute": {
+          "description": "Limit for the number of unique dynamic scripts within a minute that are allowed to be compiled. Defaults to 15. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "script_max_size_in_bytes": {
+          "description": "The size of scripts is limited to 65,535 bytes. This can be changed by increasing that soft limit, if scripts are really large then a native script engine should be considered.",
+          "type": "string",
+          "default": ""
+        },
+        "script_painless_regex_enabled": {
+          "description": "Regexes are disabled by default because they circumvent Painless\u2019s protection against long running and memory hungry scripts. Set true to enable.",
+          "type": "boolean",
+          "default": false
+        },
+        "search_remote_connect": {
+          "description": "By default, any node in the cluster can act as a cross-cluster client and connect to remote clusters. The search_remote_connect setting can be set to false (defaults to true) to prevent certain nodes from connecting to remote clusters. Cross-cluster search requests must be sent to a node that is allowed to act as a cross-cluster client. Empty means do not explicity set.",
+          "type": "string",
+          "default": "false"
+        },
+        "search_remote_connections_per_cluster": {
+          "description": "The number of nodes to connect to per remote cluster. The default is 3. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "search_remote_initial_connect_timeout": {
+          "description": "The time to wait for remote connections to be established when the node starts. The default is 30s. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "search_remote_node_attr": {
+          "description": "A node attribute to filter out nodes that are eligible as a gateway node in the remote cluster. For instance a node can have a node attribute node_attr_gateway: true such that only nodes with this attribute will be connected to if search_remote_node_attr is set to gateway. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_analyze_queue_size": {
+          "description": "For analyze requests. Thread pool type is fixed with a queue size of 16.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_analyze_size": {
+          "description": "For analyze requests. Thread pool type is fixed with a size of 1.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_bulk_queue_size": {
+          "description": "For bulk operations. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them.  -1 means its unbounded. Defaults to 1000.",
+          "type": "integer",
+          "default": 200
+        },
+        "thread_pool_bulk_size": {
+          "description": "For bulk operations. Thread pool type is fixed with a size of # of available processors. The size parameter controls the number of threads. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_generic_core": {
+          "description": "For generic operations (e.g., background node discovery). The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_generic_keep_alive": {
+          "description": "For generic operations (e.g., background node discovery). The keep_alive parameter determines how long a thread should be kept around in the thread pool without it doing any work.",
+          "type": "string",
+          "default": "30s"
+        },
+        "thread_pool_generic_max": {
+          "description": "For generic operations (e.g., background node discovery). The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_get_queue_size": {
+          "description": "For get operations. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them.  -1 means its unbounded. Defaults to 1000.",
+          "type": "integer",
+          "default": 200
+        },
+        "thread_pool_get_size": {
+          "description": "For get operations. Thread pool type is fixed with a size of # of available processors. The size parameter controls the number of threads. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_index_queue_size": {
+          "description": "For index/delete operations. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them.  -1 means its unbounded. Defaults to 200.",
+          "type": "integer",
+          "default": 200
+        },
+        "thread_pool_index_size": {
+          "description": "For index/delete operations. Thread pool type is fixed with a size of # of available processors. The size parameter controls the number of threads. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_listener_queue_size": {
+          "description": "Mainly for java client executing of action when listener threaded is set to true. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them. -1 means its unbounded. Defaults to 2. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_listener_size": {
+          "description": "Mainly for java client executing of action when listener threaded is set to true. Thread pool type is fixed with a size of # of available processors. The size parameter controls the number of threads. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_refresh_core": {
+          "description": "For refresh operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_refresh_keep_alive": {
+          "description": "For refresh operations. The keep_alive parameter determines how long a thread should be kept around in the thread pool without it doing any work.",
+          "type": "string",
+          "default": "5m"
+        },
+        "thread_pool_refresh_max": {
+          "description": "For refresh operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_search_max_queue_size": {
+          "description": "The max_queue_size setting controls the maximum amount the queue_size can be adjusted.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_search_queue_size": {
+          "description": "For count/search/suggest operations. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them. -1 means its unbounded. Defaults to 1000",
+          "type": "integer",
+          "default": 1000
+        },
+        "thread_pool_search_size": {
+          "description": "For count/search/suggest operations. Thread pool type is fixed with a size of int((# of available_processors * 3) / 2) + 1. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_search_throttled_max_queue_size": {
+          "description": "For operations on search_throttled indices,initial thread pool queue_size of 100.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_search_throttled_queue_size": {
+          "description": "Thread pool type is fixed_auto_queue_size with a size of 1, and initial queue_size of 100.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_search_throttled_size": {
+          "description": "Thread pool type is with a size of 1, and initial queue_size of 100.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_snapshot_core": {
+          "description": "For snapshot/restore operations. Thread pool type is scaling with a keep-alive of 5m and a max of min(5, (# of available processors)/2). This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_snapshot_keep_alive": {
+          "description": "For snapshot/restore operations. The keep_alive parameter determines how long a thread should be kept around in the thread pool without it doing any work.",
+          "type": "string",
+          "default": "5m"
+        },
+        "thread_pool_snapshot_max": {
+          "description": "For snapshot/restore operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_warmer_core": {
+          "description": "For segment warm-up operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_warmer_keep_alive": {
+          "description": "For segment warm-up operations. The keep_alive parameter determines how long a thread should be kept around in the thread pool without it doing any work.",
+          "type": "string",
+          "default": "5m"
+        },
+        "thread_pool_warmer_max": {
+          "description": "For segment warm-up operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_write_queue_size": {
+          "description": "For single-document index/delete/update and bulk requests. Thread pool type is fixed with a queue_size of 200.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_write_size": {
+          "description": "For single-document index/delete/update and bulk requests. Thread pool type is fixed with a size of # of available processors.",
+          "type": "string",
+          "default": ""
+        },
+        "transport_ping_schedule": {
+          "description": "Schedule a regular ping message to ensure that connections are kept alive. Defaults to 5s in the transport client and -1 (disabled) elsewhere.",
+          "type": "string",
+          "default": "-1"
+        },
+        "transport_tcp_compress": {
+          "description": "Set to true to enable compression (LZF) between all nodes. Defaults to false.",
+          "type": "boolean",
+          "default": false
+        },
+        "transport_tcp_connect_timeout": {
+          "description": "The socket connect timeout setting (in time setting format). Defaults to 30s.",
+          "type": "string",
+          "default": "30s"
+        },
+        "xpack_ml_max_anomaly_records": {
+          "description": "The maximum number of records that are output per bucket. Defaults to 500.",
+          "type": "integer",
+          "default": 500
+        },
+        "xpack_ml_max_lazy_ml_nodes": {
+          "description": "The number of lazily spun up Machine Learning nodes. Useful in situations where ML nodes are not desired until the first Machine Learning Job is opened. It defaults to 0 and has a maximum acceptable value of 3.",
+          "type": "integer",
+          "default": 0
+        },
+        "xpack_ml_max_machine_memory_percent": {
+          "description": "The maximum percentage of the machine\u2019s memory that machine learning may use for running analytics processes. (These processes are separate to the Elasticsearch JVM.) Defaults to 30 percent.",
+          "type": "integer",
+          "default": 30
+        },
+        "xpack_ml_max_model_memory_limit": {
+          "description": "The maximum model_memory_limit property value that can be set for any job on this node. If you try to create a job with a model_memory_limit property value that is greater than this setting value, an error occurs.",
+          "type": "string",
+          "default": "4096mb"
+        },
+        "xpack_ml_max_open_jobs": {
+          "description": "The maximum number of jobs that can run on a node. Defaults to 20.",
+          "type": "integer",
+          "default": 20
+        },
+        "xpack_ml_node_concurrent_job_allocations": {
+          "description": "The maximum number of jobs that can concurrently be in the opening state on each node. Defaults to 2.",
+          "type": "integer",
+          "default": 2
+        },
+        "xpack_monitoring_elasticsearch_collection_enabled": {
+          "description": "Controls whether statistics about your Elasticsearch cluster should be collected. Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "xpack_security_audit_index_flush_interval": {
+          "description": "Controls how often buffered events are flushed to the index. Defaults to 1s.",
+          "type": "string",
+          "default": "1s"
+        },
+        "xpack_security_audit_index_rollover": {
+          "description": "Controls how often to roll over to a new index: hourly, daily, weekly, or monthly. Defaults to daily.",
+          "type": "string",
+          "default": "daily"
+        },
+        "xpack_watcher_history_cleaner_service_enabled": {
+          "description": "Set to true (default) to enable the cleaner service.",
+          "type": "boolean",
+          "default": true
+        },
+        "http_content_type_required": {
+          "description": "[DEPRECATED] Starting from Elasticseach 6.0, this setting is no longer configurable and defaults to true. Changing this setting has no effect.",
+          "type": "boolean",
+          "default": true
+        },
+        "xpack_enabled": {
+          "description": "[DEPRECATED] X-Pack is enabled by default on Elastic 6.3+. Changing this setting has no effect.",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/E/elastic/700/marathon.json.mustache
+++ b/repo/packages/E/elastic/700/marathon.json.mustache
@@ -1,0 +1,536 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "user": "{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./elastic-scheduler/bin/elastic ./elastic-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "container": {
+    "type": "MESOS",
+    "volumes": [
+      {
+        "containerPath": "secrets/service-account.json",
+        "secret": "serviceCredential"
+      }
+    ]
+  },
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "PACKAGE_NAME": "elastic",
+    "PACKAGE_VERSION": "2.7.0-6.8.1",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1566211651458",
+    "PACKAGE_BUILD_TIME_STR": "Mon Aug 19 2019 10:47:31 +0000",
+    "ELASTIC_VERSION": "6.8.1",
+    "ELASTIC_STATSD_VERSION": "6.8.1.0",
+    "STATSD_URI": "{{resource.assets.uris.statsd-plugin-zip}}",
+    "ELASTICSEARCH_URI" : "{{resource.assets.uris.elasticsearch-tar-gz}}",
+    "ELASTICSEARCH_JAVA_URI" : "{{resource.assets.uris.elasticsearch-jre-tar-gz}}",
+    "DIAGNOSTICS_URI" : "{{resource.assets.uris.diagnostics-zip}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": "secrets/service-account.json",
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\",\"parameters\":[{\"key\":\"service_account_credential\",\"value\":\"file://secrets/service-account.json\"}]},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"service_account_credential\",\"value\":\"file://secrets/service-account.json\"},{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.service_account_secret}}
+
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+
+    {{#service.security.transport_encryption.enabled}}
+    "TASKCFG_ALL_SECURITY_ENABLED": "true",
+    "ELASTICSEARCH_HEALTH_PROTOCOL": "https",
+    {{/service.security.transport_encryption.enabled}}
+
+    {{^service.security.transport_encryption.enabled}}
+    {{#elasticsearch.xpack_security_enabled}}
+    "TASKCFG_ALL_SECURITY_ENABLED": "true",
+    "ELASTICSEARCH_HEALTH_PROTOCOL": "https",
+    {{/elasticsearch.xpack_security_enabled}}
+    {{/service.security.transport_encryption.enabled}}
+
+    {{^service.security.transport_encryption.enabled}}
+    {{^elasticsearch.xpack_security_enabled}}
+    "TASKCFG_ALL_SECURITY_ENABLED": "false",
+    "ELASTICSEARCH_HEALTH_PROTOCOL": "http",
+    {{/elasticsearch.xpack_security_enabled}}
+    {{/service.security.transport_encryption.enabled}}
+
+    "TASKCFG_ALL_XPACK_SECURITY_ENABLED": "{{elasticsearch.xpack_security_enabled}}",
+
+    {{#service.security.custom_domain}}
+    "SERVICE_TLD": "{{service.security.custom_domain}}",
+    {{/service.security.custom_domain}}
+
+    "DEPLOY_STRATEGY": "{{service.deploy_strategy}}",
+    "UPDATE_STRATEGY": "{{service.update_strategy}}",
+    "MASTER_NODE_CPUS": "{{master_nodes.cpus}}",
+    "MASTER_NODE_MEM": "{{master_nodes.mem}}",
+    "MASTER_NODE_PLACEMENT": "{{{master_nodes.placement}}}",
+    "MASTER_NODE_HEAP_MB": "{{master_nodes.heap.size}}",
+    "MASTER_NODE_DISK": "{{master_nodes.disk}}",
+    "MASTER_NODE_DISK_TYPE": "{{master_nodes.disk_type}}",
+    {{#master_nodes.volume_profile}}
+    "MASTER_NODE_VOLUME_PROFILE": "{{master_nodes.volume_profile}}",
+    {{/master_nodes.volume_profile}}
+    "MASTER_NODE_TRANSPORT_PORT": "{{master_nodes.transport_port}}",
+    "DATA_NODE_COUNT": "{{data_nodes.count}}",
+    "DATA_NODE_CPUS": "{{data_nodes.cpus}}",
+    "DATA_NODE_MEM": "{{data_nodes.mem}}",
+    "DATA_NODE_PLACEMENT": "{{{data_nodes.placement}}}",
+    "DATA_NODE_HEAP_MB": "{{data_nodes.heap.size}}",
+    "DATA_NODE_DISK": "{{data_nodes.disk}}",
+    "DATA_NODE_DISK_TYPE": "{{data_nodes.disk_type}}",
+    {{#data_nodes.volume_profile}}
+    "DATA_NODE_VOLUME_PROFILE": "{{data_nodes.volume_profile}}",
+    {{/data_nodes.volume_profile}}
+    "INGEST_NODE_COUNT": "{{ingest_nodes.count}}",
+    "INGEST_NODE_CPUS": "{{ingest_nodes.cpus}}",
+    "INGEST_NODE_MEM": "{{ingest_nodes.mem}}",
+    "INGEST_NODE_PLACEMENT": "{{{ingest_nodes.placement}}}",
+    "INGEST_NODE_HEAP_MB": "{{ingest_nodes.heap.size}}",
+    "INGEST_NODE_DISK": "{{ingest_nodes.disk}}",
+    "INGEST_NODE_DISK_TYPE": "{{ingest_nodes.disk_type}}",
+    {{#ingest_nodes.volume_profile}}
+    "INGEST_NODE_VOLUME_PROFILE": "{{ingest_nodes.volume_profile}}",
+    {{/ingest_nodes.volume_profile}}
+    "COORDINATOR_NODE_COUNT": "{{coordinator_nodes.count}}",
+    "COORDINATOR_NODE_CPUS": "{{coordinator_nodes.cpus}}",
+    "COORDINATOR_NODE_MEM": "{{coordinator_nodes.mem}}",
+    "COORDINATOR_NODE_PLACEMENT": "{{{coordinator_nodes.placement}}}",
+    "COORDINATOR_NODE_HEAP_MB": "{{coordinator_nodes.heap.size}}",
+    "COORDINATOR_NODE_DISK": "{{coordinator_nodes.disk}}",
+    "COORDINATOR_NODE_DISK_TYPE": "{{coordinator_nodes.disk_type}}",
+    {{#coordinator_nodes.volume_profile}}
+    "COORDINATOR_NODE_VOLUME_PROFILE": "{{coordinator_nodes.volume_profile}}",
+    {{/coordinator_nodes.volume_profile}}
+    {{#service.region}}
+    "SERVICE_REGION": "{{service.region}}",
+    {{/service.region}}
+    "ELASTICSEARCH_HEALTH_USER": "{{elasticsearch.health_user}}",
+    "ELASTICSEARCH_HEALTH_USER_PASSWORD": "{{elasticsearch.health_user_password}}",
+    "TASKCFG_ALL_ELASTICSEARCH_PLUGINS": "{{elasticsearch.plugins}}",
+    "TASKCFG_ALL_PLUGIN_HTTP_PROXY_HOST": "{{elasticsearch.plugin_http_proxy_host}}",
+    "TASKCFG_ALL_PLUGIN_HTTP_PROXY_PORT": "{{elasticsearch.plugin_http_proxy_port}}",
+    "TASKCFG_ALL_PLUGIN_HTTPS_PROXY_HOST": "{{elasticsearch.plugin_https_proxy_host}}",
+    "TASKCFG_ALL_PLUGIN_HTTPS_PROXY_PORT": "{{elasticsearch.plugin_https_proxy_port}}",
+    "TASKCFG_ALL_GATEWAY_RECOVER_AFTER_TIME": "{{elasticsearch.gateway_recover_after_time}}",
+    {{#elasticsearch.script_allowed_contexts}}
+    "TASKCFG_ALL_SCRIPT_ALLOWED_CONTEXTS": "{{elasticsearch.script_allowed_contexts}}",
+    {{/elasticsearch.script_allowed_contexts}}
+    {{#elasticsearch.script_allowed_types}}
+    "TASKCFG_ALL_SCRIPT_ALLOWED_TYPES": "{{elasticsearch.script_allowed_types}}",
+    {{/elasticsearch.script_allowed_types}}
+    {{#elasticsearch.repositories_url_allowed_urls}}
+    "TASKCFG_ALL_REPOSITORIES_URL_ALLOWED_URLS": "{{elasticsearch.repositories_url_allowed_urls}}",
+    {{/elasticsearch.repositories_url_allowed_urls}}
+    "TASKCFG_ALL_NETWORK_TCP_NO_DELAY": "{{elasticsearch.network_tcp_no_delay}}",
+    "TASKCFG_ALL_NETWORK_TCP_KEEP_ALIVE": "{{elasticsearch.network_tcp_keep_alive}}",
+    "TASKCFG_ALL_NETWORK_TCP_REUSE_ADDRESS": "{{elasticsearch.network_tcp_reuse_address}}",
+    {{#elasticsearch.network_tcp_send_buffer_size}}
+    "TASKCFG_ALL_NETWORK_TCP_SEND_BUFFER_SIZE": "{{elasticsearch.network_tcp_send_buffer_size}}",
+    {{/elasticsearch.network_tcp_send_buffer_size}}
+    {{#elasticsearch.network_tcp_receive_buffer_size}}
+    "TASKCFG_ALL_NETWORK_TCP_RECEIVE_BUFFER_SIZE": "{{elasticsearch.network_tcp_receive_buffer_size}}",
+    {{/elasticsearch.network_tcp_receive_buffer_size}}
+    "TASKCFG_ALL_TRANSPORT_TCP_CONNECT_TIMEOUT": "{{elasticsearch.transport_tcp_connect_timeout}}",
+    "TASKCFG_ALL_TRANSPORT_TCP_COMPRESS": "{{elasticsearch.transport_tcp_compress}}",
+    "TASKCFG_ALL_TRANSPORT_PING_SCHEDULE": "{{elasticsearch.transport_ping_schedule}}",
+    "TASKCFG_ALL_HTTP_ENABLED": "{{elasticsearch.http_enabled}}",
+    "TASKCFG_ALL_HTTP_MAX_CONTENT_LENGTH": "{{elasticsearch.http_max_content_length}}",
+    "TASKCFG_ALL_HTTP_MAX_INITIAL_LINE_LENGTH": "{{elasticsearch.http_max_initial_line_length}}",
+    "TASKCFG_ALL_HTTP_MAX_HEADER_SIZE": "{{elasticsearch.http_max_header_size}}",
+    "TASKCFG_ALL_HTTP_COMPRESSION": "{{elasticsearch.http_compression}}",
+    "TASKCFG_ALL_HTTP_COMPRESSION_LEVEL": "{{elasticsearch.http_compression_level}}",
+    "TASKCFG_ALL_HTTP_CORS_ENABLED": "{{elasticsearch.http_cors_enabled}}",
+    {{#elasticsearch.http_cors_allow_origin}}
+    "TASKCFG_ALL_HTTP_CORS_ALLOW_ORIGIN": "{{elasticsearch.http_cors_allow_origin}}",
+    {{/elasticsearch.http_cors_allow_origin}}
+    "TASKCFG_ALL_HTTP_CORS_MAX_AGE": "{{elasticsearch.http_cors_max_age}}",
+    "TASKCFG_ALL_HTTP_CORS_ALLOW_METHODS": "{{elasticsearch.http_cors_allow_methods}}",
+    "TASKCFG_ALL_HTTP_CORS_ALLOW_HEADERS": "{{elasticsearch.http_cors_allow_headers}}",
+    "TASKCFG_ALL_HTTP_CORS_ALLOW_CREDENTIALS": "{{elasticsearch.http_cors_allow_credentials}}",
+    "TASKCFG_ALL_HTTP_DETAILED_ERRORS_ENABLED": "{{elasticsearch.http_detailed_errors_enabled}}",
+    "TASKCFG_ALL_HTTP_PIPELINING": "{{elasticsearch.http_pipelining}}",
+    "TASKCFG_ALL_HTTP_PIPELINING_MAX_EVENTS": "{{elasticsearch.http_pipelining_max_events}}",
+    {{#elasticsearch.thread_pool_index_size}}
+    "TASKCFG_ALL_THREAD_POOL_INDEX_SIZE": "{{elasticsearch.thread_pool_index_size}}",
+    {{/elasticsearch.thread_pool_index_size}}
+    "TASKCFG_ALL_THREAD_POOL_INDEX_QUEUE_SIZE": "{{elasticsearch.thread_pool_index_queue_size}}",
+    {{#elasticsearch.thread_pool_search_size}}
+    "TASKCFG_ALL_THREAD_POOL_SEARCH_SIZE": "{{elasticsearch.thread_pool_search_size}}",
+    {{/elasticsearch.thread_pool_search_size}}
+    "TASKCFG_ALL_THREAD_POOL_SEARCH_QUEUE_SIZE": "{{elasticsearch.thread_pool_search_queue_size}}",
+    {{#elasticsearch.thread_pool_get_size}}
+    "TASKCFG_ALL_THREAD_POOL_GET_SIZE": "{{elasticsearch.thread_pool_get_size}}",
+    {{/elasticsearch.thread_pool_get_size}}
+    "TASKCFG_ALL_THREAD_POOL_GET_QUEUE_SIZE": "{{elasticsearch.thread_pool_get_queue_size}}",
+    {{#elasticsearch.thread_pool_bulk_size}}
+    "TASKCFG_ALL_THREAD_POOL_BULK_SIZE": "{{elasticsearch.thread_pool_bulk_size}}",
+    {{/elasticsearch.thread_pool_bulk_size}}
+    "TASKCFG_ALL_THREAD_POOL_BULK_QUEUE_SIZE": "{{elasticsearch.thread_pool_bulk_queue_size}}",
+    {{#elasticsearch.thread_pool_listener_size}}
+    "TASKCFG_ALL_THREAD_POOL_LISTENER_SIZE": "{{elasticsearch.thread_pool_listener_size}}",
+    {{/elasticsearch.thread_pool_listener_size}}
+    {{#elasticsearch.thread_pool_listener_queue_size}}
+    "TASKCFG_ALL_THREAD_POOL_LISTENER_QUEUE_SIZE": "{{elasticsearch.thread_pool_listener_queue_size}}",
+    {{/elasticsearch.thread_pool_listener_queue_size}}
+    {{#elasticsearch.thread_pool_warmer_core}}
+    "TASKCFG_ALL_THREAD_POOL_WARMER_CORE": "{{elasticsearch.thread_pool_warmer_core}}",
+    {{/elasticsearch.thread_pool_warmer_core}}
+    {{#elasticsearch.thread_pool_warmer_max}}
+    "TASKCFG_ALL_THREAD_POOL_WARMER_MAX": "{{elasticsearch.thread_pool_warmer_max}}",
+    {{/elasticsearch.thread_pool_warmer_max}}
+    "TASKCFG_ALL_THREAD_POOL_WARMER_KEEP_ALIVE": "{{elasticsearch.thread_pool_warmer_keep_alive}}",
+    {{#elasticsearch.thread_pool_snapshot_core}}
+    "TASKCFG_ALL_THREAD_POOL_SNAPSHOT_CORE": "{{elasticsearch.thread_pool_snapshot_core}}",
+    {{/elasticsearch.thread_pool_snapshot_core}}
+    {{#elasticsearch.thread_pool_snapshot_max}}
+    "TASKCFG_ALL_THREAD_POOL_SNAPSHOT_MAX": "{{elasticsearch.thread_pool_snapshot_max}}",
+    {{/elasticsearch.thread_pool_snapshot_max}}
+    "TASKCFG_ALL_THREAD_POOL_SNAPSHOT_KEEP_ALIVE": "{{elasticsearch.thread_pool_snapshot_keep_alive}}",
+    {{#elasticsearch.thread_pool_refresh_core}}
+    "TASKCFG_ALL_THREAD_POOL_REFRESH_CORE": "{{elasticsearch.thread_pool_refresh_core}}",
+    {{/elasticsearch.thread_pool_refresh_core}}
+    {{#elasticsearch.thread_pool_refresh_max}}
+    "TASKCFG_ALL_THREAD_POOL_REFRESH_MAX": "{{elasticsearch.thread_pool_refresh_max}}",
+    {{/elasticsearch.thread_pool_refresh_max}}
+    "TASKCFG_ALL_THREAD_POOL_REFRESH_KEEP_ALIVE": "{{elasticsearch.thread_pool_refresh_keep_alive}}",
+    {{#elasticsearch.thread_pool_generic_core}}
+    "TASKCFG_ALL_THREAD_POOL_GENERIC_CORE": "{{elasticsearch.thread_pool_generic_core}}",
+    {{/elasticsearch.thread_pool_generic_core}}
+    {{#elasticsearch.thread_pool_generic_max}}
+    "TASKCFG_ALL_THREAD_POOL_GENERIC_MAX": "{{elasticsearch.thread_pool_generic_max}}",
+    {{/elasticsearch.thread_pool_generic_max}}
+    "TASKCFG_ALL_THREAD_POOL_GENERIC_KEEP_ALIVE": "{{elasticsearch.thread_pool_generic_keep_alive}}",
+    {{#elasticsearch.indices_breaker_total_limit}}
+    "TASKCFG_ALL_INDICES_BREAKER_TOTAL_LIMIT": "{{elasticsearch.indices_breaker_total_limit}}",
+    {{/elasticsearch.indices_breaker_total_limit}}
+    {{#elasticsearch.indices_breaker_fielddata_limit}}
+    "TASKCFG_ALL_INDICES_BREAKER_FIELDDATA_LIMIT": "{{elasticsearch.indices_breaker_fielddata_limit}}",
+    {{/elasticsearch.indices_breaker_fielddata_limit}}
+    {{#elasticsearch.indices_breaker_fielddata_overhead}}
+    "TASKCFG_ALL_INDICES_BREAKER_FIELDDATA_OVERHEAD": "{{elasticsearch.indices_breaker_fielddata_overhead}}",
+    {{/elasticsearch.indices_breaker_fielddata_overhead}}
+    {{#elasticsearch.network_breaker_inflight_requests_limit}}
+    "TASKCFG_ALL_NETWORK_BREAKER_INGLIGHT_REQUESTS_LIMITS": "{{elasticsearch.network_breaker_inflight_requests_limit}}",
+    {{/elasticsearch.network_breaker_inflight_requests_limit}}
+    {{#elasticsearch.network_breaker_inflight_requests_overhead}}
+    "TASKCFG_ALL_NETWORK_BREAKER_INGLIGHT_REQUESTS_OVERHEAD": "{{elasticsearch.network_breaker_inflight_requests_overhead}}",
+    {{/elasticsearch.network_breaker_inflight_requests_overhead}}
+    {{#elasticsearch.script_max_compilations_per_minute}}
+    "TASKCFG_ALL_SCRIPTS_MAX_COMPILATIONS_PER_MINUTE": "{{elasticsearch.scripts_max_compilations_per_minute}}",
+    {{/elasticsearch.script_max_compilations_per_minute}}
+    {{#elasticsearch.indices_fielddata_cache_size}}
+    "TASKCFG_ALL_INDICES_FIELDDATA_CACHE_SIZE": "{{elasticsearch.indices_fielddata_cache_size}}",
+    {{/elasticsearch.indices_fielddata_cache_size}}
+    {{#elasticsearch.indices_queries_cache_size}}
+    "TASKCFG_ALL_INDICES_QUERIES_CACHE_SIZE": "{{elasticsearch.indices_queries_cache_size}}",
+    {{/elasticsearch.indices_queries_cache_size}}
+    {{#elasticsearch.indices_memory_index_buffer_size}}
+    "TASKCFG_ALL_INDICES_MEMORY_INDEX_BUFFER_SIZE": "{{elasticsearch.indices_memory_index_buffer_size}}",
+    {{/elasticsearch.indices_memory_index_buffer_size}}
+    {{#elasticsearch.indices_memory_min_index_buffer_size}}
+    "TASKCFG_ALL_INDICES_MEMORY_MIN_INDEX_BUFFER_SIZE": "{{elasticsearch.indices_memory_min_index_buffer_size}}",
+    {{/elasticsearch.indices_memory_min_index_buffer_size}}
+    {{#elasticsearch.indices_memory_max_index_buffer_size}}
+    "TASKCFG_ALL_INDICES_MEMORY_MAX_INDEX_BUFFER_SIZE": "{{elasticsearch.indices_memory_max_index_buffer_size}}",
+    {{/elasticsearch.indices_memory_max_index_buffer_size}}
+    {{#elasticsearch.indices_recovery_max_bytes_per_sec}}
+    "TASKCFG_ALL_INDICES_RECOVERY_MAX_BYTES_PER_SEC": "{{elasticsearch.indices_recovery_max_bytes_per_sec}}",
+    {{/elasticsearch.indices_recovery_max_bytes_per_sec}}
+    {{#elasticsearch.search_remote_connections_per_cluster}}
+    "TASKCFG_ALL_SEARCH_REMOTE_CONNECTIONS_PER_CLUSTER": "{{elasticsearch.search_remote_connections_per_cluster}}",
+    {{/elasticsearch.search_remote_connections_per_cluster}}
+    {{#elasticsearch.search_remote_initial_connect_timeout}}
+    "TASKCFG_ALL_SEARCH_REMOTE_INITIAL_CONNECT_TIMEOUT": "{{elasticsearch.search_remote_initial_connect_timeout}}",
+    {{/elasticsearch.search_remote_initial_connect_timeout}}
+    {{#elasticsearch.search_remote_connect}}
+    "TASKCFG_ALL_SEARCH_REMOTE_CONNECT": "{{elasticsearch.search_remote_connect}}",
+    {{/elasticsearch.search_remote_connect}}
+    {{#elasticsearch.indices_query_bool_max_clause_count}}
+    "TASKCFG_ALL_INDICES_QUERY_BOOL_MAX_CLAUSE_COUNT": "{{elasticsearch.indices_query_bool_max_clause_count}}",
+    {{/elasticsearch.indices_query_bool_max_clause_count}}
+    {{#elasticsearch.discovery_zen_ping_unicast_hosts_resolve_timeout}}
+    "TASKCFG_ALL_DISCOVERY_ZEN_PING_UNICAST_HOSTS_RESOLVE_TIMEOUT": "{{elasticsearch.discovery_zen_ping_unicast_hosts_resolve_timeout}}",
+    {{/elasticsearch.discovery_zen_ping_unicast_hosts_resolve_timeout}}
+    {{#elasticsearch.discovery_zen_fd_ping_interval}}
+    "TASKCFG_ALL_DISCOVERY_ZEN_FD_PING_INTERVAL": "{{elasticsearch.discovery_zen_fd_ping_interval}}",
+    {{/elasticsearch.discovery_zen_fd_ping_interval}}
+    {{#elasticsearch.discovery_zen_fd_ping_timeout}}
+    "TASKCFG_ALL_DISCOVERY_ZEN_FD_PING_TIMEOUT": "{{elasticsearch.discovery_zen_fd_ping_timeout}}",
+    {{/elasticsearch.discovery_zen_fd_ping_timeout}}
+    {{#elasticsearch.discovery_zen_fd_ping_retries}}
+    "TASKCFG_ALL_DISCOVERY_ZEN_FD_PING_RETRIES": "{{elasticsearch.discovery_zen_fd_ping_retries}}",
+    {{/elasticsearch.discovery_zen_fd_ping_retries}}
+    {{#elasticsearch.discovery_zen_no_master_block}}
+    "TASKCFG_ALL_DISCOVERY_ZEN_NO_MASTER_BLOCK": "{{elasticsearch.discovery_zen_no_master_block}}",
+    {{/elasticsearch.discovery_zen_no_master_block}}
+    {{#elasticsearch.cluster_blocks_read_only}}
+    "TASKCFG_ALL_CLUSTER_BLOCKS_READ_ONLY": "{{elasticsearch.cluster_blocks_read_only}}",
+    {{/elasticsearch.cluster_blocks_read_only}}
+    {{#elasticsearch.cluster_blocks_read_only_allow_delete}}
+    "TASKCFG_ALL_CLUSTER_BLOCKS_READ_ONLY_ALLOW_DELETE": "{{elasticsearch.cluster_blocks_read_only_allow_delete}}",
+    {{/elasticsearch.cluster_blocks_read_only_allow_delete}}
+    {{#elasticsearch.cluster_indices_tombstones_size}}
+    "TASKCFG_ALL_CLUSTER_INDICES_TOMBSTONES_SIZE": "{{elasticsearch.cluster_indices_tombstones_size}}",
+    {{/elasticsearch.cluster_indices_tombstones_size}}
+    {{#elasticsearch.index_routing_allocation_total_shards_per_node}}
+    "TASKCFG_ALL_INDEX_ROUTING_ALLOCATION_TOTAL_SHARDS_PER_NODE": "{{elasticsearch.index_routing_allocation_total_shards_per_node}}",
+    {{/elasticsearch.index_routing_allocation_total_shards_per_node}}
+    {{#elasticsearch.cluster_routing_allocation_total_shards_per_node}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_TOTAL_SHARDS_PER_NODE": "{{elasticsearch.cluster_routing_allocation_total_shards_per_node}}",
+    {{/elasticsearch.cluster_routing_allocation_total_shards_per_node}}
+    {{#elasticsearch.cluster_routing_allocation_disk_threshold_enabled}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED": "{{elasticsearch.cluster_routing_allocation_disk_threshold_enabled}}",
+    {{/elasticsearch.cluster_routing_allocation_disk_threshold_enabled}}
+    {{#elasticsearch.cluster_routing_allocation_disk_watermark_low}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_LOW": "{{elasticsearch.cluster_routing_allocation_disk_watermark_low}}",
+    {{/elasticsearch.cluster_routing_allocation_disk_watermark_low}}
+    {{#elasticsearch.cluster_routing_allocation_disk_watermark_high}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_DISK_WATERMARK_HIGH": "{{elasticsearch.cluster_routing_allocation_disk_watermark_high}}",
+    {{/elasticsearch.cluster_routing_allocation_disk_watermark_high}}
+    {{#elasticsearch.cluster_info_update_interval}}
+    "TASKCFG_ALL_CLUSTER_INFO_UPDATE_INTERVAL": "{{elasticsearch.cluster_info_update_interval}}",
+    {{/elasticsearch.cluster_info_update_interval}}
+    {{#elasticsearch.cluster_routing_allocation_disk_include_relocations}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_DISK_INCLUDE_RELOCATIONS": "{{elasticsearch.cluster_routing_allocation_disk_include_relocations}}",
+    {{/elasticsearch.cluster_routing_allocation_disk_include_relocations}}
+    {{#elasticsearch.cluster_routing_allocation_enable}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_ENABLE": "{{elasticsearch.cluster_routing_allocation_enable}}",
+    {{/elasticsearch.cluster_routing_allocation_enable}}
+    {{#elasticsearch.cluster_routing_allocation_node_concurrent_incoming_recoveries}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_INCOMING_RECOVERIES": "{{elasticsearch.cluster_routing_allocation_node_concurrent_incoming_recoveries}}",
+    {{/elasticsearch.cluster_routing_allocation_node_concurrent_incoming_recoveries}}
+    {{#elasticsearch.cluster_routing_allocation_node_concurrent_recoveries}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES": "{{elasticsearch.cluster_routing_allocation_node_concurrent_recoveries}}",
+    {{/elasticsearch.cluster_routing_allocation_node_concurrent_recoveries}}
+    {{#elasticsearch.cluster_routing_allocation_node_concurrent_outgoing_recoveries}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_OUTGOING_RECOVERIES": "{{elasticsearch.cluster_routing_allocation_node_concurrent_outgoing_recoveries}}",
+    {{/elasticsearch.cluster_routing_allocation_node_concurrent_outgoing_recoveries}}
+    {{#elasticsearch.cluster_routing_allocation_node_initial_primaries_recoveries}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES": "{{elasticsearch.cluster_routing_allocation_node_initial_primaries_recoveries}}",
+    {{/elasticsearch.cluster_routing_allocation_node_initial_primaries_recoveries}}
+    {{#elasticsearch.cluster_routing_allocation_same_shard_host}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_SAME_SHARD_HOST": "{{elasticsearch.cluster_routing_allocation_same_shard_host}}",
+    {{/elasticsearch.cluster_routing_allocation_same_shard_host}}
+    {{#elasticsearch.cluster_routing_rebalance_enable}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_REBALANCE_ENABLE": "{{elasticsearch.cluster_routing_rebalance_enable}}",
+    {{/elasticsearch.cluster_routing_rebalance_enable}}
+    {{#elasticsearch.cluster_routing_allocation_allow_rebalance}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE": "{{elasticsearch.cluster_routing_allocation_allow_rebalance}}",
+    {{/elasticsearch.cluster_routing_allocation_allow_rebalance}}
+    {{#elasticsearch.cluster_routing_allocation_cluster_concurrent_rebalance}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE": "{{elasticsearch.cluster_routing_allocation_cluster_concurrent_rebalance}}",
+    {{/elasticsearch.cluster_routing_allocation_cluster_concurrent_rebalance}}
+    {{#elasticsearch.cluster_routing_allocation_balance_shard}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_BALANCE_SHARD": "{{elasticsearch.cluster_routing_allocation_balance_shard}}",
+    {{/elasticsearch.cluster_routing_allocation_balance_shard}}
+    {{#elasticsearch.cluster_routing_allocation_balance_index}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_BALANCE_INDEX": "{{elasticsearch.cluster_routing_allocation_balance_index}}",
+    {{/elasticsearch.cluster_routing_allocation_balance_index}}
+    {{#elasticsearch.cluster_routing_allocation_balance_threshold}}
+    "TASKCFG_ALL_CLUSTER_ROUTING_ALLOCATION_BALANCE_THRESHOLD": "{{elasticsearch.cluster_routing_allocation_balance_threshold}}",
+    {{/elasticsearch.cluster_routing_allocation_balance_threshold}}
+    {{#elasticsearch.indices_requests_cache_size}}
+    "TASKCFG_ALL_INDICES_REQUESTS_CACHE_SIZE": "{{elasticsearch.indices_requests_cache_size}}",
+    {{/elasticsearch.indices_requests_cache_size}}
+    {{#elasticsearch.thread_pool_analyze_queue_size}}
+    "TASKCFG_ALL_THREAD_POOL_ANALYZE_QUEUE_SIZE": "{{elasticsearch.thread_pool_analyze_queue_size}}",
+    {{/elasticsearch.thread_pool_analyze_queue_size}}
+    {{#elasticsearch.thread_pool_analyze_size}}
+    "TASKCFG_ALL_THREAD_POOL_ANALYZE_SIZE": "{{elasticsearch.thread_pool_analyze_size}}",
+    {{/elasticsearch.thread_pool_analyze_size}}
+    {{#elasticsearch.thread_pool_search_max_queue_size}}
+    "TASKCFG_ALL_THREAD_POOL_SEARCH_MAX_QUEUE_SIZE": "{{elasticsearch.thread_pool_search_max_queue_size}}",
+    {{/elasticsearch.thread_pool_search_max_queue_size}}
+    {{#elasticsearch.thread_pool_search_throttled_max_queue_size}}
+    "TASKCFG_ALL_THREAD_POOL_SEARCH_THROTTLED_MAX_QUEUE_SIZE": "{{elasticsearch.thread_pool_search_throttled_max_queue_size}}",
+    {{/elasticsearch.thread_pool_search_throttled_max_queue_size}}
+    {{#elasticsearch.thread_pool_search_throttled_size}}
+    "TASKCFG_ALL_THREAD_POOL_SEARCH_THROTTLED_SIZE": "{{elasticsearch.thread_pool_search_throttled_size}}",
+    {{/elasticsearch.thread_pool_search_throttled_size}}
+    {{#elasticsearch.thread_pool_search_throttled_queue_size}}
+    "TASKCFG_ALL_THREAD_POOL_SEARCH_THROTTLED_QUEUE_SIZE": "{{elasticsearch.thread_pool_search_throttled_queue_size}}",
+    {{/elasticsearch.thread_pool_search_throttled_queue_size}}
+    {{#elasticsearch.thread_pool_write_queue_size}}
+    "TASKCFG_ALL_THREAD_POOL_WRITE_QUEUE_SIZE": "{{elasticsearch.thread_pool_write_queue_size}}",
+    {{/elasticsearch.thread_pool_write_queue_size}}
+    {{#elasticsearch.thread_pool_write_size}}
+    "TASKCFG_ALL_THREAD_POOL_WRITE_SIZE": "{{elasticsearch.thread_pool_write_size}}",
+    {{/elasticsearch.thread_pool_write_size}}
+    {{#elasticsearch.xpack_graph_enabled}}
+    "TASKCFG_ALL_XPACK_GRAPH_ENABLED": "{{elasticsearch.xpack_graph_enabled}}",
+    {{/elasticsearch.xpack_graph_enabled}}
+    {{#elasticsearch.xpack_ml_enabled}}
+    "TASLCFG_ALL_XPACK_ML_ENABLED": "{{elasticsearch.xpack_ml_enabled}}",
+    {{/elasticsearch.xpack_ml_enabled}}
+    {{#elasticsearch.xpack_ml_max_open_jobs}}
+    "TASKCFG_ALL_XPACK_ML_MAX_OPEN_JOBS": "{{elasticsearch.xpack_ml_max_open_jobs}}",
+    {{/elasticsearch.xpack_ml_max_open_jobs}}
+    {{#elasticsearch.xpack_ml_max_anomaly_records}}
+    "TASKCFG_ALL_XPACK_ML_MAX_ANOMALY_RECORDS": "{{elasticsearch.xpack_ml_max_anomaly_records}}",
+    {{/elasticsearch.xpack_ml_max_anomaly_records}}
+    {{#elasticsearch.xpack_ml_max_lazy_ml_nodes}}
+    "TASKCFG_ALL_XPACK_ML_MAX_LAZY_ML_NODES": "{{elasticsearch.xpack_ml_max_lazy_ml_nodes}}",
+    {{/elasticsearch.xpack_ml_max_lazy_ml_nodes}}
+    {{#elasticsearch.xpack_ml_max_machine_memory_percent}}
+    "TASKCFG_ALL_XPACK_ML_MAX_MACHINE_MEMORY_PERCENT": "{{elasticsearch.xpack_ml_max_machine_memory_percent}}",
+    {{/elasticsearch.xpack_ml_max_machine_memory_percent}}
+    {{#elasticsearch.xpack_ml_max_model_memory_limit}}
+    "TASKCFG_ALL_XPACK_ML_MAX_MODEL_MEMORY_LIMIT": "{{elasticsearch.xpack_ml_max_model_memory_limit}}",
+    {{/elasticsearch.xpack_ml_max_model_memory_limit}}
+    {{#elasticsearch.xpack_ml_node_concurrent_job_allocations}}
+    "TASKCFG_ALL_XPACK_ML_NODE_CONCURRENT_JOB_ALLOCATIONS": "{{elasticsearch.xpack_ml_node_concurrent_job_allocations}}",
+    {{/elasticsearch.xpack_ml_node_concurrent_job_allocations}}
+    {{#elasticsearch.xpack_monitoring_enabled}}
+    "TASKCFG_ALL_XPACK_MONITORING_ENABLED": "{{elasticsearch.xpack_monitoring_enabled}}",
+    {{/elasticsearch.xpack_monitoring_enabled}}
+    {{#elasticsearch.xpack_monitoring_collection_enabled}}
+    "TASKCFG_ALL_XPACK_MONITORING_COLLECTION_ENABLED": "{{elasticsearch.xpack_monitoring_collection_enabled}}",
+    {{/elasticsearch.xpack_monitoring_collection_enabled}}
+    {{#elasticsearch.xpack_monitoring_elasticsearch_collection_enabled}}
+    "TASKCFG_ALL_XPACK_MONITORING_ELASTICSEARCH_COLLECTION_ENABLED": "{{elasticsearch.xpack_monitoring_elasticsearch_collection_enabled}}",
+    {{/elasticsearch.xpack_monitoring_elasticsearch_collection_enabled}}
+    "TASKCFG_ALL_XPACK_MONITORING_DEFAULT_EXPORTER_USE_INGEST": "{{elasticsearch.xpack_monitoring_default_exporter_use_ingest}}",
+    {{#elasticsearch.xpack_watcher_enabled}}
+    "TASKCFG_ALL_XPACK_WATCHER_ENABLED": "{{elasticsearch.xpack_watcher_enabled}}",
+    {{/elasticsearch.xpack_watcher_enabled}}
+    {{#elasticsearch.xpack_watcher_history_cleaner_service_enabled}}
+    "TASKCFG_ALL_XPACK_WATCHER_HISTORY_CLEANER_SERVICE_ENABLED": "{{elasticsearch.xpack_watcher_history_cleaner_service_enabled}}",
+    {{/elasticsearch.xpack_watcher_history_cleaner_service_enabled}}
+    {{#elasticsearch.xpack_sql_enabled}}
+    "TASKCFG_ALL_XPACK_SQL_ENABLED": "{{elasticsearch.xpack_sql_enabled}}",
+    {{/elasticsearch.xpack_sql_enabled}}
+    {{#elasticsearch.xpack_security_audit_enabled}}
+    "TASKCFG_ALL_XPACK_SECURITY_AUDIT_ENABLED": "{{elasticsearch.xpack_security_audit_enabled}}",
+    {{/elasticsearch.xpack_security_audit_enabled}}
+    {{#elasticsearch.xpack_security_audit_index_flush_interval}}
+    "TASKCFG_ALL_XPACK_SECURITY_AUDIT_INDEX_FLUSH_INTERVAL": "{{elasticsearch.xpack_security_audit_index_flush_interval}}",
+    {{/elasticsearch.xpack_security_audit_index_flush_interval}}
+    {{#elasticsearch.xpack_security_audit_index_rollover}}
+    "TASKCFG_ALL_XPACK_SECURITY_AUDIT_INDEX_ROLLOVER": "{{elasticsearch.xpack_security_audit_index_rollover}}",
+    {{/elasticsearch.xpack_security_audit_index_rollover}}
+    {{#elasticsearch.xpack_http_proxy_host}}
+    "TASKCFG_ALL_XPACK_HTTP_PROXY_HOST": "{{elasticsearch.xpack_http_proxy_host}}",
+    {{/elasticsearch.xpack_http_proxy_host}}
+    {{#elasticsearch.xpack_http_proxy_port}}
+    "TASKCFG_ALL_XPACK_HTTP_PROXY_PORT": "{{elasticsearch.xpack_http_proxy_port}}",
+    {{/elasticsearch.xpack_http_proxy_port}}
+    {{#elasticsearch.cluster_max_shards_per_node}}
+    "TASKCFG_ALL_CLUSTER_MAX_SHARDS_PER_NODE": "{{elasticsearch.cluster_max_shards_per_node}}",
+    {{/elasticsearch.cluster_max_shards_per_node}}
+    {{#elasticsearch.action_destructive_requires_name}}
+    "TASKCFG_ALL_ACTION_DESTRUCTIVE_REQUIRES_NAME": "{{elasticsearch.action_destructive_requires_name}}",
+    {{/elasticsearch.action_destructive_requires_name}}
+    {{#elasticsearch.cluster_persistent_tasks_allocation_enable}}
+    "TASKCFG_ALL_CLUSTER_PERSISTENT_TASKS_ALLOCATION_ENABLE": "{{elasticsearch.cluster_persistent_tasks_allocation_enable}}",
+    {{/elasticsearch.cluster_persistent_tasks_allocation_enable}}
+    {{#elasticsearch.cluster_persistent_tasks_allocation_recheck_interval}}
+    "TASKCFG_ALL_CLUSTER_PERSISTENT_TASKS_ALLOCATION_RECHECK_INTERVAL": "{{elasticsearch.cluster_persistent_tasks_allocation_recheck_interval}}",
+    {{/elasticsearch.cluster_persistent_tasks_allocation_recheck_interval}}
+    {{#elasticsearch.cluster_remote_connect}}
+    "TASKCFG_ALL_CLUSTER_REMOTE_CONNECT": "{{elasticsearch.cluster_remote_connect}}",
+    {{/elasticsearch.cluster_remote_connect}}
+    {{#elasticsearch.cluster_remote_connections_per_cluster}}
+    "TASKCFG_ALL_CLUSTER_REMOTE_CONNECTIONS_PER_CLUSTER": "{{elasticsearch.cluster_remote_connections_per_cluster}}",
+    {{/elasticsearch.cluster_remote_connections_per_cluster}}
+    {{#elasticsearch.script_max_size_in_bytes}}
+    "TASKCFG_ALL_SCRIPT_MAX_SIZE_IN_BYTES": "{{elasticsearch.script_max_size_in_bytes}}",
+    {{/elasticsearch.script_max_size_in_bytes}}
+    {{#elasticsearch.script_painless_regex_enabled}}
+    "TASKCFG_ALL_SCRIPT_PAINLESS_REGEX_ENABLED": "{{elasticsearch.script_painless_regex_enabled}}",
+    {{/elasticsearch.script_painless_regex_enabled}}
+    "CUSTOM_YAML_BLOCK_BASE64": "{{elasticsearch.custom_elasticsearch_yml}}",
+
+    "MASTER_NODE_READINESS_CHECK_INTERVAL": "{{master_nodes.readiness_check.interval}}",
+    "MASTER_NODE_READINESS_CHECK_DELAY": "{{master_nodes.readiness_check.delay}}",
+    "MASTER_NODE_READINESS_CHECK_TIMEOUT": "{{master_nodes.readiness_check.timeout}}",
+
+    "MASTER_NODE_RLIMIT_NOFILE_SOFT": "{{master_nodes.rlimits.rlimit_nofile.soft}}",
+    "MASTER_NODE_RLIMIT_NOFILE_HARD": "{{master_nodes.rlimits.rlimit_nofile.hard}}",
+
+    "DATA_NODE_READINESS_CHECK_INTERVAL": "{{data_nodes.readiness_check.interval}}",
+    "DATA_NODE_READINESS_CHECK_DELAY": "{{data_nodes.readiness_check.delay}}",
+    "DATA_NODE_READINESS_CHECK_TIMEOUT": "{{data_nodes.readiness_check.timeout}}",
+
+    "DATA_NODE_RLIMIT_NOFILE_SOFT": "{{data_nodes.rlimits.rlimit_nofile.soft}}",
+    "DATA_NODE_RLIMIT_NOFILE_HARD": "{{data_nodes.rlimits.rlimit_nofile.hard}}",
+
+    "INGEST_NODE_READINESS_CHECK_INTERVAL": "{{ingest_nodes.readiness_check.interval}}",
+    "INGEST_NODE_READINESS_CHECK_DELAY": "{{ingest_nodes.readiness_check.delay}}",
+    "INGEST_NODE_READINESS_CHECK_TIMEOUT": "{{ingest_nodes.readiness_check.timeout}}",
+
+    "INGEST_NODE_RLIMIT_NOFILE_SOFT": "{{ingest_nodes.rlimits.rlimit_nofile.soft}}",
+    "INGEST_NODE_RLIMIT_NOFILE_HARD": "{{ingest_nodes.rlimits.rlimit_nofile.hard}}",
+
+    "COORDINATOR_NODE_READINESS_CHECK_INTERVAL": "{{coordinator_nodes.readiness_check.interval}}",
+    "COORDINATOR_NODE_READINESS_CHECK_DELAY": "{{coordinator_nodes.readiness_check.delay}}",
+    "COORDINATOR_NODE_READINESS_CHECK_TIMEOUT": "{{coordinator_nodes.readiness_check.timeout}}",
+
+    "COORDINATOR_NODE_RLIMIT_NOFILE_SOFT": "{{coordinator_nodes.rlimits.rlimit_nofile.soft}}",
+    "COORDINATOR_NODE_RLIMIT_NOFILE_HARD": "{{coordinator_nodes.rlimits.rlimit_nofile.hard}}"
+  },
+  "fetch": [
+    { "uri": "{{resource.assets.uris.bootstrap-zip}}", "cache": true },
+    { "uri": "{{resource.assets.uris.jre-tar-gz}}", "cache": true },
+    { "uri": "{{resource.assets.uris.scheduler-zip}}", "cache": true },
+    { "uri": "{{resource.assets.uris.libmesos-bundle-tar-gz}}", "cache": true }
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api"
+    }
+  ],
+  "check": {
+    "http": {
+      "portIndex": 0,
+      "path": "/v1/health"
+    },
+    "intervalSeconds": {{service.check.intervalSeconds}},
+    "timeoutSeconds": {{service.check.timeoutSeconds}},
+    "delaySeconds": {{service.check.delaySeconds}}
+  }
+}

--- a/repo/packages/E/elastic/700/package.json
+++ b/repo/packages/E/elastic/700/package.json
@@ -1,0 +1,35 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "2.6.0-6.6.1"
+  ],
+  "downgradesTo": [
+    "2.6.0-6.6.1"
+  ],
+  "minDcosReleaseVersion": "1.11",
+  "name": "elastic",
+  "version": "2.7.0-6.8.1",
+  "maintainer": "support@mesosphere.io",
+  "description": "Elasticsearch 6, and X-Pack",
+  "selected": true,
+  "framework": true,
+  "tags": [
+    "elastic",
+    "elasticsearch",
+    "kibana",
+    "x-pack"
+  ],
+  "preInstallNotes": "Default configuration requires 3 agent nodes each with: CPU: 4.0 | Memory: 9216MB | Disk: 13500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk\n\nIngest node: No instances by default | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk",
+  "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/2.7.0-6.8.1/\n\tIssues: https://docs.mesosphere.com/support/",
+  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.11 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/2.7.0-6.8.1/uninstall to remove any persistent state if required.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/LICENSE.txt"
+    },
+    {
+      "name": "Elastic License",
+      "url": "https://raw.githubusercontent.com/elastic/elasticsearch/master/x-pack/README.md"
+    }
+  ]
+}

--- a/repo/packages/E/elastic/700/resource.json
+++ b/repo/packages/E/elastic/700/resource.json
@@ -1,0 +1,59 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/openjdk-jre-8u212b03-hotspot-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.12.0.tar.gz",
+      "bootstrap-zip": "https://downloads.mesosphere.com/elastic/assets/2.7.0-6.8.1/bootstrap.zip",
+      "scheduler-zip": "https://downloads.mesosphere.com/elastic/assets/2.7.0-6.8.1/elastic-scheduler.zip",
+      "statsd-plugin-zip": "https://downloads.mesosphere.com/elastic/assets/elasticsearch-statsd-6.8.1.0.zip",
+      "elasticsearch-jre-tar-gz": "https://downloads.mesosphere.com/java/openjdk-jre-8u212b03-hotspot-linux-x64.tar.gz",
+      "elasticsearch-tar-gz": "https://downloads.mesosphere.com/elastic/assets/elasticsearch-6.8.1.tar.gz",
+      "diagnostics-zip": "https://downloads.mesosphere.com/elastic/assets/support-diagnostics-6.4.4-dist.zip"
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/elastic-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/elastic-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/elastic-icon-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "859a6c40dc22015bff530ce483e632c8b0dd91f34bab9c6527ec98e893d3478a"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://downloads.mesosphere.com/elastic/assets/2.7.0-6.8.1/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "706f1aca1492a660c0b74c4ddab1e91d8a3955a3516fd7ef054bffdcd6fbbea7"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://downloads.mesosphere.com/elastic/assets/2.7.0-6.8.1/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "ba6a761f6a64276e7a3461eef2b9699f6b66d6431db2c77c8229d9fbbd35beb2"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://downloads.mesosphere.com/elastic/assets/2.7.0-6.8.1/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Release elastic 2.7.0-6.8.1 (automated commit)

Description:
Source URL: https://infinity-artifacts.s3.amazonaws.com/permanent/elastic/assets/2.7.0-6.8.1/stub-universe-elastic.json

Changes between revisions 600 => 700:
0 files added: []
0 files removed: []
4 files changed:

```
--- 600/config.json
+++ 700/config.json
@@ -8,8 +8,8 @@
         "name": {
           "description": "Unique name for the Elasticsearch service instance consisting of a series of words separated by slashes. Each word must be at least 1 alphanumeric character and may only contain digits (`0-9`), dashes (`-`), dots (`.`), and lowercase letters (`a-z`). The word may not begin or end with a dash",
           "type": "string",
-          "pattern": "^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$",
-          "default": "elastic"
+          "default": "elastic",
+          "pattern": "^(\\/?((\\.\\.)|(([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9])\\.)*([a-z0-9]|[a-z0-9][a-z0-9\\-]*[a-z0-9]))?($|\\/))+$"
         },
         "user": {
           "description": "The user that runs the Elasticsearch services and owns the Mesos sandbox.",
@@ -19,12 +19,18 @@
         "service_account": {
           "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
           "type": "string",
-          "default": ""
+          "default": "",
+          "media": {
+            "type": "application/x-service-account+string"
+          }
         },
         "service_account_secret": {
           "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
           "type": "string",
-          "default": ""
+          "default": "",
+          "media": {
+            "type": "application/x-secret+string"
+          }
         },
         "virtual_network_enabled": {
           "description": "Enable virtual networking",
@@ -56,6 +62,30 @@
           ],
           "default": "INFO"
         },
+        "check": {
+          "description": "Health check used to determine the scheduler health based on the status of the scheduler plans.",
+          "type": "object",
+          "properties": {
+            "intervalSeconds": {
+              "type": "integer",
+              "description": "The period in seconds to wait after the last check has completed to start the next check.",
+              "default": 30,
+              "minimum": 30
+            },
+            "timeoutSeconds": {
+              "type": "integer",
+              "description": " An amount of time in seconds to wait for check to succeed.",
+              "default": 20,
+              "minimum": 20
+            },
+            "delaySeconds": {
+              "type": "integer",
+              "description": "An amount of time in seconds to wait before starting the check attempts.",
+              "default": 15,
+              "minimum": 15
+            }
+          }
+        },
         "deploy_strategy": {
           "description": "Elasticsearch deploy strategy. [parallel, serial]",
           "type": "string",
@@ -65,6 +95,14 @@
           ],
           "default": "parallel"
         },
+        "region": {
+          "description": "All Elastic nodes will run in this region.  When no region is specified the nodes are constrained to the local region.",
+          "type": "string",
+          "default": "",
+          "media": {
+            "type": "application/x-region+string"
+          }
+        },
         "update_strategy": {
           "description": "Elasticsearch update strategy. [parallel, serial]",
           "type": "string",
@@ -73,14 +111,6 @@
             "serial"
           ],
           "default": "serial"
-        },
-        "region": {
-          "description": "All Elastic nodes will run in this region.  When no region is specified the nodes are constrained to the local region.",
-          "type": "string",
-          "default": "",
-          "media": {
-            "type": "application/x-region+string"
-          }
         },
         "security": {
           "description": "Elastic security settings",
@@ -96,6 +126,10 @@
                   "default": false
                 }
               }
+            },
+            "custom_domain": {
+              "type": "string",
+              "description": "A custom domain to be used in place of autoip.dcos.thisdcos.directory. This can be used to expose the service securely outside of the cluster, but requires setting up external DNS. See the service documentation for details."
             }
           }
         }
@@ -146,6 +180,10 @@
           "description": "Disk type to be used for storing data. [ROOT, MOUNT]",
           "default": "ROOT"
         },
+        "volume_profile": {
+          "type": "string",
+          "description": "Volume profile to be used for storing Master Node data."
+        },
         "transport_port": {
           "description": "Transport port for master nodes to listen on.",
           "type": "integer",
@@ -160,7 +198,7 @@
           }
         },
         "readiness_check": {
-          "description": "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "description": "Readiness check settings. Exercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {
@@ -184,7 +222,7 @@
           }
         },
         "rlimits": {
-          "description": "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "description": "POSIX resource limits applied to the pod. Exercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "rlimit_nofile": {
@@ -260,6 +298,10 @@
           "description": "Disk type to be used for storing data. [ROOT, MOUNT]",
           "default": "ROOT"
         },
+        "volume_profile": {
+          "type": "string",
+          "description": "Volume profile to be used for storing Data Node data."
+        },
         "placement": {
           "description": "Placement constraints for data nodes (e.g., [[\"hostname\", \"UNIQUE\"]]).",
           "type": "string",
@@ -269,7 +311,7 @@
           }
         },
         "readiness_check": {
-          "description": "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "description": "Readiness check settings. Exercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {
@@ -293,7 +335,7 @@
           }
         },
         "rlimits": {
-          "description": "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "description": "POSIX resource limits applied to the pod. Exercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "rlimit_nofile": {
@@ -369,6 +411,10 @@
           "description": "Disk type to be used for storing data. [ROOT, MOUNT]",
           "default": "ROOT"
         },
+        "volume_profile": {
+          "type": "string",
+          "description": "Volume profile to be used for storing Ingest Node data."
+        },
         "placement": {
           "description": "Placement constraints for ingest nodes (e.g., [[\"hostname\", \"UNIQUE\"]]).",
           "type": "string",
@@ -378,7 +424,7 @@
           }
         },
         "readiness_check": {
-          "description": "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "description": "Readiness check settings. Exercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {
@@ -402,7 +448,7 @@
           }
         },
         "rlimits": {
-          "description": "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "description": "POSIX resource limits applied to the pod. Exercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "rlimit_nofile": {
@@ -478,6 +524,10 @@
           "description": "Disk type to be used for storing data. [ROOT, MOUNT]",
           "default": "ROOT"
         },
+        "volume_profile": {
+          "type": "string",
+          "description": "Volume profile to be used for storing Coordinator Node data."
+        },
         "placement": {
           "description": "Placement constraints for coordinator nodes (e.g., [[\"hostname\", \"UNIQUE\"]]).",
           "type": "string",
@@ -487,7 +537,7 @@
           }
         },
         "readiness_check": {
-          "description": "Readiness check settings. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "description": "Readiness check settings. Exercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "interval": {
@@ -511,7 +561,7 @@
           }
         },
         "rlimits": {
-          "description": "POSIX resource limits applied to the pod. Excercise caution when modifying these default values as it can lead to spurious task failures.",
+          "description": "POSIX resource limits applied to the pod. Exercise caution when modifying these default values as it can lead to spurious task failures.",
           "type": "object",
           "properties": {
             "rlimit_nofile": {
@@ -547,24 +597,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "xpack_security_enabled": {
-          "description": "Set it to true to enable X-Pack security on all nodes. Defaults to false",
-          "type": "boolean",
-          "default": false
-        },
-        "plugins": {
-          "description": "Comma-separated list of plugins to install",
-          "type": "string",
-          "default": ""
-        },
         "custom_elasticsearch_yml": {
           "description": "Custom YAML to be appended to elasticsearch.yml on each node. This field must be base64 encoded.",
           "type": "string",
+          "default": "",
           "media": {
             "binaryEncoding": "base64",
             "type": "application/x-yaml"
-          },
-          "default": ""
+          }
         },
         "health_user": {
           "description": "Elastic username to use for X-Pack authentication, if enabled",
@@ -576,488 +616,698 @@
           "type": "string",
           "default": "changeme"
         },
+        "plugins": {
+          "description": "Comma-separated list of plugins to install",
+          "type": "string",
+          "default": ""
+        },
+        "plugin_http_proxy_host": {
+          "description": "HTTP proxy host for plugin installation. Default value '' means that proxy won't be used.",
+          "type": "string",
+          "default": ""
+        },
+        "plugin_http_proxy_port": {
+          "description": "HTTP proxy port for plugin installation. Default value -1 means that proxy won't be used.",
+          "type": "integer",
+          "default": -1
+        },
+        "plugin_https_proxy_host": {
+          "description": "HTTPS proxy host for plugin installation. Default value '' means that proxy won't be used.",
+          "type": "string",
+          "default": ""
+        },
+        "plugin_https_proxy_port": {
+          "description": "HTTPS proxy port for plugin installation. Default value -1 means that proxy won't be used.",
+          "type": "integer",
+          "default": -1
+        },
+        "xpack_http_proxy_host": {
+          "description": "Specifies the address of the proxy server to use to connect to HTTP services.",
+          "type": "string",
+          "default": ""
+        },
+        "xpack_http_proxy_port": {
+          "description": "Specifies the port number to use to connect to the proxy server.",
+          "type": "string",
+          "default": ""
+        },
+        "xpack_graph_enabled": {
+          "description": "By default, Graph is enabled in Elastic Stack. Set to false to disable graph analytics features.",
+          "type": "boolean",
+          "default": true
+        },
+        "xpack_ml_enabled": {
+          "description": "By default, Machine Learning feature is enabled in Elastic Stack. Set to false to disable machine learning features.",
+          "type": "boolean",
+          "default": true
+        },
+        "xpack_monitoring_collection_enabled": {
+          "description": "Set to true to enable the collection of monitoring data. When this setting is false (default), Elasticsearch monitoring data is not collected and all monitoring data from other sources such as Kibana, Beats, and Logstash is ignored.",
+          "type": "boolean",
+          "default": false
+        },
+        "xpack_monitoring_enabled": {
+          "description": "By default, Monitoring feature is enabled in Elastic Stack. Set to false to disable monitoring features.",
+          "type": "boolean",
+          "default": true
+        },
+        "xpack_monitoring_default_exporter_use_ingest": {
+          "description": "Whether to supply a placeholder pipeline to the cluster and a pipeline processor with every bulk request. Defaults to false.",
+          "type": "boolean",
+          "default": false
+        },
+        "xpack_security_audit_enabled": {
+          "description": "Set to true to enable auditing on the node. Defaults to false.",
+          "type": "boolean",
+          "default": false
+        },
+        "xpack_security_enabled": {
+          "description": "Set it to true to enable X-Pack security on all nodes. Defaults to false.",
+          "type": "boolean",
+          "default": false
+        },
+        "xpack_sql_enabled": {
+          "description": "Set to false to disable SQL Access on the node. SQL Access is enabled by default",
+          "type": "boolean",
+          "default": true
+        },
+        "xpack_watcher_enabled": {
+          "description": "By default, Watcher feature is enabled in Elastic Stack. Set to false to disable Watcher.",
+          "type": "boolean",
+          "default": true
+        },
+        "action_destructive_requires_name": {
+          "description": "In order to disable allowing to delete indices via wildcards or _all, set it as true.",
+          "type": "boolean",
+          "default": false
+        },
+        "cluster_blocks_read_only": {
+          "description": "Make the whole cluster read only (indices do not accept write operations), metadata is not allowed to be modified (create or delete indices). Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_blocks_read_only_allow_delete": {
+          "description": "Identical to cluster_blocks_read_only but allows to delete indices to free up resources. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_indices_tombstones_size": {
+          "description": "Index tombstones prevent nodes that are not part of the cluster when a delete occurs from joining the cluster and reimporting the index as though the delete was never issued. To keep the cluster state from growing huge we only keep the last cluster.indices.tombstones.size deletes, which defaults to 500. You can increase it if you expect nodes to be absent from the cluster and miss more than 500 deletes. We think that is rare, thus the default. Tombstones don't take up much space, but we also think that a number like 50,000 is probably too big. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_info_update_interval": {
+          "description": "How often Elasticsearch should check on disk usage for each node in the cluster. Defaults to 30s. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_max_shards_per_node": {
+          "description": "Controls the number of shards allowed in the cluster per data node. The limit defaults to 1,000 shards per data node.",
+          "type": "integer",
+          "default": 1000
+        },
+        "cluster_persistent_tasks_allocation_enable": {
+          "description": "Enable or disable allocation for persistent tasks. all(default) Allows persistent tasks to be assigned to nodes, none - No allocations are allowed for any type of persistent task.",
+          "type": "string",
+          "default": "all"
+        },
+        "cluster_persistent_tasks_allocation_recheck_interval": {
+          "description": "The default is 30 seconds. The minimum permitted value is 10 seconds.",
+          "type": "string",
+          "default": "30s"
+        },
+        "cluster_remote_connect": {
+          "description": "Can be set to false (defaults to true) to prevent certain nodes from connecting to remote clusters.",
+          "type": "boolean",
+          "default": true
+        },
+        "cluster_remote_connections_per_cluster": {
+          "description": "The number of gateway nodes to connect to per remote cluster. Defaults to 3.",
+          "type": "integer",
+          "default": 3
+        },
+        "cluster_routing_allocation_allow_rebalance": {
+          "description": "Specify when shard rebalancing is allowed: always, indices_primaries_active, indices_all_active (default). Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_awareness_attributes": {
+          "description": "Setup shard allocation awareness by telling Elasticsearch which attributes to use. Multiple awareness attributes can be specified, in which case the combination of values from each attribute is considered to be a separate value. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_balance_index": {
+          "description": "Defines the weight factor for the number of shards per index allocated on a specific node (float). Defaults to 0.55f. Raising this raises the tendency to equalize the number of shards per index across all nodes in the cluster. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_balance_shard": {
+          "description": "Defines the weight factor for the total number of shards allocated on a node (float). Defaults to 0.45f. Raising this raises the tendency to equalize the number of shards across all nodes in the cluster. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_balance_threshold": {
+          "description": "Minimal optimization value of operations that should be performed (non negative float). Defaults to 1.0f. Raising this will cause the cluster to be less aggressive about optimizing the shard balance. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_cluster_concurrent_rebalance": {
+          "description": "Allow to control how many concurrent shard rebalances are allowed cluster wide. Defaults to 2. Note that this setting only controls the number of concurrent shard relocations due to imbalances in the cluster. This setting does not limit shard relocations due to allocation filtering or forced awareness. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_disk_include_relocations": {
+          "description": "Defaults to true, which means that Elasticsearch will take into account shards that are currently being relocated to the target node when computing a node's disk usage. Taking relocating shards' sizes into account may, however, mean that the disk usage for a node is incorrectly estimated on the high side, since the relocation could be 90% complete and a recently retrieved disk usage would include the total size of the relocating shard as well as the space already used by the running relocation. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_disk_threshold_enabled": {
+          "description": "Elasticsearch factors in the available disk space on a node before deciding whether to allocate new shards to that node or to actively relocate shards away from that node. Defaults to true. Set to false to disable the disk allocation decider. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_disk_watermark_high": {
+          "description": "Controls the high watermark. It defaults to 90%, meaning ES will attempt to relocate shards to another node if the node disk usage rises above 90%. It can also be set to an absolute byte value (similar to the low watermark) to relocate shards once less than the configured amount of space is available on the node. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_disk_watermark_low": {
+          "description": "Controls the low watermark for disk usage. It defaults to 85%, meaning ES will not allocate new shards to nodes once they have more than 85% disk used. It can also be set to an absolute byte value (like 500mb) to prevent ES from allocating shards if less than the configured amount of space is available. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_enable": {
+          "description": "Enable or disable allocation for specific kinds of shards: all, primaries, new_primaries, none. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_node_concurrent_incoming_recoveries": {
+          "description": "How many concurrent incoming shard recoveries are allowed to happen on a node. Incoming recoveries are the recoveries where the target shard (most likely the replica unless a shard is relocating) is allocated on the node. Defaults to 2. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_node_concurrent_outgoing_recoveries": {
+          "description": "How many concurrent outgoing shard recoveries are allowed to happen on a node. Outgoing recoveries are the recoveries where the source shard (most likely the primary unless a shard is relocating) is allocated on the node. Defaults to 2. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_node_concurrent_recoveries": {
+          "description": "A shortcut to set both cluster.routing.allocation.node_concurrent_incoming_recoveries and cluster.routing.allocation.node_concurrent_outgoing_recoveries. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_node_initial_primaries_recoveries": {
+          "description": "While the recovery of replicas happens over the network, the recovery of an unassigned primary after node restart uses data from the local disk. These should be fast so more initial primary recoveries can happen in parallel on the same node. Defaults to 4. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_same_shard_host": {
+          "description": "Allows to perform a check to prevent allocation of multiple instances of the same shard on a single host, based on host name and host address. Defaults to false, meaning that no check is performed by default. This setting only applies if multiple nodes are started on the same machine. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_allocation_total_shards_per_node": {
+          "description": "The maximum number of shards (replicas and primaries) that will be allocated to a single node globally. Defaults to unbounded (-1). Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "cluster_routing_rebalance_enable": {
+          "description": "Enable or disable rebalancing for specific kinds of shards: all, primeries, replicas, none. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "discovery_zen_fd_ping_interval": {
+          "description": "How often a node gets pinged. Defaults to 1s. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "discovery_zen_fd_ping_retries": {
+          "description": "How many ping failures / timeouts cause a node to be considered failed. Defaults to 3. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "discovery_zen_fd_ping_timeout": {
+          "description": "How long to wait for a ping response, defaults to 30s. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "discovery_zen_no_master_block": {
+          "description": "Controls what operations should be rejected when there is no active master. There are two valid operations: all and write (defaut). Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "discovery_zen_ping_unicast_hosts.resolve_timeout": {
+          "description": "The amount of time to wait for DNS lookups on each round of pinging. Specified as time units. Defaults to 5s. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
         "gateway_recover_after_time": {
           "description": "If the expected number of nodes is not achieved, the recovery process waits for the configured amount of time before trying to recover regardless. Defaults to 5m if one of the expected_nodes settings is configured.",
           "type": "string",
           "default": "5m"
         },
+        "http_compression": {
+          "description": "Support for compression when possible (with Accept-Encoding). Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "http_compression_level": {
+          "description": "Defines the compression level to use for HTTP responses. Valid values are in the range of 1 (minimum compression) and 9 (maximum compression). Defaults to 3.",
+          "type": "integer",
+          "default": 3
+        },
+        "http_cors_allow_credentials": {
+          "description": "Whether the Access-Control-Allow-Credentials header should be returned. Note: This header is only returned when the setting is set to true. Defaults to false.",
+          "type": "boolean",
+          "default": false
+        },
+        "http_cors_allow_headers": {
+          "description": "Which headers to allow. Defaults to X-Requested-With, Content-Type, Content-Length.",
+          "type": "string",
+          "default": "X-Requested-With,Content-Type,Content-Length"
+        },
+        "http_cors_allow_methods": {
+          "description": "Which methods to allow. Defaults to OPTIONS, HEAD, GET, POST, PUT, DELETE.",
+          "type": "string",
+          "default": "OPTIONS,HEAD,GET,POST,PUT,DELETE"
+        },
+        "http_cors_allow_origin": {
+          "description": "Which origins to allow. Defaults to no origins allowed. If you prepend and append a '/' to the value, this will be treated as a regular expression, allowing you to support HTTP and HTTPs. * is a valid value but is considered a security risk as your elasticsearch instance is open to cross origin requests from anywhere.",
+          "type": "string",
+          "default": ""
+        },
+        "http_cors_enabled": {
+          "description": "Enable or disable cross-origin resource sharing, i.e. whether a browser on another origin can execute requests against Elasticsearch. Set to true to enable Elasticsearch to process pre-flight CORS requests.",
+          "type": "boolean",
+          "default": false
+        },
+        "http_cors_max_age": {
+          "description": "Browsers send a \"preflight\" OPTIONS-request to determine CORS settings. Defines how long the result should be cached for. Defaults to 1728000 (20 days)",
+          "type": "integer",
+          "default": 1728000
+        },
+        "http_detailed_errors_enabled": {
+          "description": "Enables or disables the output of detailed error messages and stack traces in response output. Note: When set to false and the error_trace request parameter is specified, an error will be returned; when error_trace is not specified, a simple message will be returned. Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "http_enabled": {
+          "description": "The http module can be completely disabled and not started by setting http.enabled to false. Default is true.",
+          "type": "boolean",
+          "default": true
+        },
+        "http_max_content_length": {
+          "description": "The max content of an HTTP request. Defaults to 100mb. If set to greater than Integer.MAX_VALUE, it will be reset to 100mb.",
+          "type": "string",
+          "default": "100mb"
+        },
+        "http_max_header_size": {
+          "description": "The max size of allowed headers. Defaults to 8kB.",
+          "type": "string",
+          "default": "8kB"
+        },
+        "http_max_initial_line_length": {
+          "description": "The max length of an HTTP URL. Defaults to 4kb.",
+          "type": "string",
+          "default": "4kb"
+        },
+        "http_pipelining": {
+          "description": "Enable or disable HTTP pipelining, defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "http_pipelining_max_events": {
+          "description": "The maximum number of events to be queued up in memory before a HTTP connection is closed, defaults to 10000.",
+          "type": "integer",
+          "default": 10000
+        },
+        "index_routing_allocation_total_shards_per_node": {
+          "description": "The maximum number of shards (replicas and primaries) that will be allocated to a single node. Defaults to unbounded. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_breaker_fielddata_limit": {
+          "description": "Limit for fielddata breaker, defaults to 60% of JVM heap. Empty means do not explicity set. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_breaker_fielddata_overhead": {
+          "description": "A constant that all field data estimations are multiplied with to determine a final estimation. Defaults to 1.03. Empty means do not explicity set. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_breaker_total_limit": {
+          "description": "Starting limit for overall parent breaker, defaults to 70% of JVM heap. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_fielddata_cache_size": {
+          "description": "The max size of the field data cache, eg 30% of node heap space, or an absolute value, eg 12GB. Defaults to unbounded. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_memory_index_buffer_size": {
+          "description": "Accepts either a percentage or a byte size value. It defaults to 10%, meaning that 10% of the total heap allocated to a node will be used as the indexing buffer size shared across all shards. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_memory_max_index_buffer_size": {
+          "description": "If the index_buffer_size is specified as a percentage, then this setting can be used to specify an absolute maximum. Defaults to unbounded. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_memory_min_index_buffer_size": {
+          "description": "If the index_buffer_size is specified as a percentage, then this setting can be used to specify an absolute minimum. Defaults to 48mb. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_queries_cache_size": {
+          "description": "Controls the memory size for the filter cache , defaults to 10%. Accepts either a percentage value, like 5%, or an exact value, like 512mb. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_query_bool_max_clause_count": {
+          "description": "Set the number of clauses used while querying Elasticsearch. Defaults to 1024. If any query expands into more than 1024 boolean clauses, you will get TooManyClauses exception. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_recovery_max_bytes_per_sec": {
+          "description": "This can be set to manage the recovery policy. Defaults to 40mb. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "indices_requests_cache_size": {
+          "description": "The cache is managed at the node level, and has a default maximum size of 1% of the heap. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "network_breaker_inflight_requests_limit": {
+          "description": "Limit for in flight requests breaker, defaults to 100% of JVM heap. This means that it is bound by the limit configured for the parent circuit breaker. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "network_breaker_inflight_requests_overhead": {
+          "description": "A constant that all in flight requests estimations are multiplied with to determine a final estimation. Defaults to 1. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "network_tcp_keep_alive": {
+          "description": "Enable or disable TCP keep alive. Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "network_tcp_no_delay": {
+          "description": "Enable or disable the TCP no delay setting. Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "network_tcp_receive_buffer_size": {
+          "description": "The size of the TCP receive buffer (specified with size units). By default not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "network_tcp_reuse_address": {
+          "description": "Should an address be reused or not. Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "network_tcp_send_buffer_size": {
+          "description": "The size of the TCP send buffer (specified with size units). By default not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "repositories_url_allowed_urls": {
+          "description": "URL Repository supports the following protocols: \"http\", \"https\", \"ftp\", \"file\" and \"jar\". URL repositories with http:, https:, and ftp: URLs have to be whitelisted by specifying allowed URLs in the repositories_url_allowed_urls setting. This setting supports wildcards in the place of host, path, query, and fragment.",
+          "type": "string",
+          "default": ""
+        },
+        "script_allowed_contexts": {
+          "description": "By default all script contexts (search,update,aggs,plugin) are allowed to be executed. This can be modified using the setting script_allowed_contexts. Only the contexts specified as part of the setting will be allowed to be executed. To specify no contexts are allowed, set script_allowed_contexts to be none. Empty string \"\" means all contexts (default).",
+          "type": "string",
+          "default": ""
+        },
         "script_allowed_types": {
           "description": "By default all script types (inline,file,stored) are allowed to be executed. This can be modified using the setting script_allowed_types. Only the types specified as part of the setting will be allowed to be executed. To specify no types are allowed, set script.allowed_types to be none. Empty string \"\" means all types (default).",
           "type": "string",
           "default": ""
         },
-        "script_allowed_contexts": {
-          "description": "By default all script contexts (search,update,aggs,plugin) are allowed to be executed. This can be modified using the setting script_allowed_contexts. Only the contexts specified as part of the setting will be allowed to be executed. To specify no contexts are allowed, set script_allowed_contexts to be none. Empty string \"\" means all contexts (default).",
-          "type": "string",
-          "default": ""
-        },
-        "repositories_url_allowed_urls": {
-          "description": "URL Repository supports the following protocols: \"http\", \"https\", \"ftp\", \"file\" and \"jar\". URL repositories with http:, https:, and ftp: URLs have to be whitelisted by specifying allowed URLs in the repositories_url_allowed_urls setting. This setting supports wildcards in the place of host, path, query, and fragment.",
-          "type": "string",
-          "default": ""
-        },
-        "network_tcp_no_delay": {
-          "description": "Enable or disable the TCP no delay setting. Defaults to true.",
-          "type": "boolean",
-          "default": true
-        },
-        "network_tcp_keep_alive": {
-          "description": "Enable or disable TCP keep alive. Defaults to true.",
-          "type": "boolean",
-          "default": true
-        },
-        "network_tcp_reuse_address": {
-          "description": "Should an address be reused or not. Defaults to true.",
-          "type": "boolean",
-          "default": true
-        },
-        "network_tcp_send_buffer_size": {
-          "description": "The size of the TCP send buffer (specified with size units). By default not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "network_tcp_receive_buffer_size": {
-          "description": "The size of the TCP receive buffer (specified with size units). By default not explicitly set.",
-          "type": "string",
-          "default": ""
+        "script_max_compilations_per_minute": {
+          "description": "Limit for the number of unique dynamic scripts within a minute that are allowed to be compiled. Defaults to 15. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "script_max_size_in_bytes": {
+          "description": "The size of scripts is limited to 65,535 bytes. This can be changed by increasing that soft limit, if scripts are really large then a native script engine should be considered.",
+          "type": "string",
+          "default": ""
+        },
+        "script_painless_regex_enabled": {
+          "description": "Regexes are disabled by default because they circumvent Painless\u2019s protection against long running and memory hungry scripts. Set true to enable.",
+          "type": "boolean",
+          "default": false
+        },
+        "search_remote_connect": {
+          "description": "By default, any node in the cluster can act as a cross-cluster client and connect to remote clusters. The search_remote_connect setting can be set to false (defaults to true) to prevent certain nodes from connecting to remote clusters. Cross-cluster search requests must be sent to a node that is allowed to act as a cross-cluster client. Empty means do not explicity set.",
+          "type": "string",
+          "default": "false"
+        },
+        "search_remote_connections_per_cluster": {
+          "description": "The number of nodes to connect to per remote cluster. The default is 3. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "search_remote_initial_connect_timeout": {
+          "description": "The time to wait for remote connections to be established when the node starts. The default is 30s. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "search_remote_node_attr": {
+          "description": "A node attribute to filter out nodes that are eligible as a gateway node in the remote cluster. For instance a node can have a node attribute node_attr_gateway: true such that only nodes with this attribute will be connected to if search_remote_node_attr is set to gateway. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_analyze_queue_size": {
+          "description": "For analyze requests. Thread pool type is fixed with a queue size of 16.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_analyze_size": {
+          "description": "For analyze requests. Thread pool type is fixed with a size of 1.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_bulk_queue_size": {
+          "description": "For bulk operations. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them.  -1 means its unbounded. Defaults to 1000.",
+          "type": "integer",
+          "default": 200
+        },
+        "thread_pool_bulk_size": {
+          "description": "For bulk operations. Thread pool type is fixed with a size of # of available processors. The size parameter controls the number of threads. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_generic_core": {
+          "description": "For generic operations (e.g., background node discovery). The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_generic_keep_alive": {
+          "description": "For generic operations (e.g., background node discovery). The keep_alive parameter determines how long a thread should be kept around in the thread pool without it doing any work.",
+          "type": "string",
+          "default": "30s"
+        },
+        "thread_pool_generic_max": {
+          "description": "For generic operations (e.g., background node discovery). The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_get_queue_size": {
+          "description": "For get operations. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them.  -1 means its unbounded. Defaults to 1000.",
+          "type": "integer",
+          "default": 200
+        },
+        "thread_pool_get_size": {
+          "description": "For get operations. Thread pool type is fixed with a size of # of available processors. The size parameter controls the number of threads. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_index_queue_size": {
+          "description": "For index/delete operations. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them.  -1 means its unbounded. Defaults to 200.",
+          "type": "integer",
+          "default": 200
+        },
+        "thread_pool_index_size": {
+          "description": "For index/delete operations. Thread pool type is fixed with a size of # of available processors. The size parameter controls the number of threads. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_listener_queue_size": {
+          "description": "Mainly for java client executing of action when listener threaded is set to true. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them. -1 means its unbounded. Defaults to 2. Empty means do not explicitly set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_listener_size": {
+          "description": "Mainly for java client executing of action when listener threaded is set to true. Thread pool type is fixed with a size of # of available processors. The size parameter controls the number of threads. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_refresh_core": {
+          "description": "For refresh operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_refresh_keep_alive": {
+          "description": "For refresh operations. The keep_alive parameter determines how long a thread should be kept around in the thread pool without it doing any work.",
+          "type": "string",
+          "default": "5m"
+        },
+        "thread_pool_refresh_max": {
+          "description": "For refresh operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_search_max_queue_size": {
+          "description": "The max_queue_size setting controls the maximum amount the queue_size can be adjusted.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_search_queue_size": {
+          "description": "For count/search/suggest operations. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them. -1 means its unbounded. Defaults to 1000",
+          "type": "integer",
+          "default": 1000
+        },
+        "thread_pool_search_size": {
+          "description": "For count/search/suggest operations. Thread pool type is fixed with a size of int((# of available_processors * 3) / 2) + 1. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_search_throttled_max_queue_size": {
+          "description": "For operations on search_throttled indices,initial thread pool queue_size of 100.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_search_throttled_queue_size": {
+          "description": "Thread pool type is fixed_auto_queue_size with a size of 1, and initial queue_size of 100.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_search_throttled_size": {
+          "description": "Thread pool type is with a size of 1, and initial queue_size of 100.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_snapshot_core": {
+          "description": "For snapshot/restore operations. Thread pool type is scaling with a keep-alive of 5m and a max of min(5, (# of available processors)/2). This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_snapshot_keep_alive": {
+          "description": "For snapshot/restore operations. The keep_alive parameter determines how long a thread should be kept around in the thread pool without it doing any work.",
+          "type": "string",
+          "default": "5m"
+        },
+        "thread_pool_snapshot_max": {
+          "description": "For snapshot/restore operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_warmer_core": {
+          "description": "For segment warm-up operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_warmer_keep_alive": {
+          "description": "For segment warm-up operations. The keep_alive parameter determines how long a thread should be kept around in the thread pool without it doing any work.",
+          "type": "string",
+          "default": "5m"
+        },
+        "thread_pool_warmer_max": {
+          "description": "For segment warm-up operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_write_queue_size": {
+          "description": "For single-document index/delete/update and bulk requests. Thread pool type is fixed with a queue_size of 200.",
+          "type": "string",
+          "default": ""
+        },
+        "thread_pool_write_size": {
+          "description": "For single-document index/delete/update and bulk requests. Thread pool type is fixed with a size of # of available processors.",
+          "type": "string",
+          "default": ""
+        },
+        "transport_ping_schedule": {
+          "description": "Schedule a regular ping message to ensure that connections are kept alive. Defaults to 5s in the transport client and -1 (disabled) elsewhere.",
+          "type": "string",
+          "default": "-1"
+        },
+        "transport_tcp_compress": {
+          "description": "Set to true to enable compression (LZF) between all nodes. Defaults to false.",
+          "type": "boolean",
+          "default": false
         },
         "transport_tcp_connect_timeout": {
           "description": "The socket connect timeout setting (in time setting format). Defaults to 30s.",
           "type": "string",
           "default": "30s"
         },
-        "transport_tcp_compress": {
-          "description": "Set to true to enable compression (LZF) between all nodes. Defaults to false.",
-          "type": "boolean",
-          "default": false
-        },
-        "transport_ping_schedule": {
-          "description": "Schedule a regular ping message to ensure that connections are kept alive. Defaults to 5s in the transport client and -1 (disabled) elsewhere.",
-          "type": "string",
-          "default": "-1"
-        },
-        "http_enabled": {
-          "description": "The http module can be completely disabled and not started by setting http.enabled to false. Default is true.",
-          "type": "boolean",
-          "default": true
-        },
-        "http_max_content_length": {
-          "description": "The max content of an HTTP request. Defaults to 100mb. If set to greater than Integer.MAX_VALUE, it will be reset to 100mb.",
-          "type": "string",
-          "default": "100mb"
-        },
-        "http_max_initial_line_length": {
-          "description": "The max length of an HTTP URL. Defaults to 4kb.",
-          "type": "string",
-          "default": "4kb"
-        },
-        "http_max_header_size": {
-          "description": "The max size of allowed headers. Defaults to 8kB.",
-          "type": "string",
-          "default": "8kB"
-        },
-        "http_compression": {
-          "description": "Support for compression when possible (with Accept-Encoding). Defaults to true.",
-          "type": "boolean",
-          "default": true
-        },
-        "http_compression_level": {
-          "description": "Defines the compression level to use for HTTP responses. Valid values are in the range of 1 (minimum compression) and 9 (maximum compression). Defaults to 3.",
-          "type": "integer",
-          "default": 3
-        },
-        "http_cors_enabled": {
-          "description": "Enable or disable cross-origin resource sharing, i.e. whether a browser on another origin can execute requests against Elasticsearch. Set to true to enable Elasticsearch to process pre-flight CORS requests.",
-          "type": "boolean",
-          "default": false
-        },
-        "http_cors_allow_origin": {
-          "description": "Which origins to allow. Defaults to no origins allowed. If you prepend and append a '/' to the value, this will be treated as a regular expression, allowing you to support HTTP and HTTPs. * is a valid value but is considered a security risk as your elasticsearch instance is open to cross origin requests from anywhere.",
-          "type": "string",
-          "default": ""
-        },
-        "http_cors_max_age": {
-          "description": "Browsers send a \"preflight\" OPTIONS-request to determine CORS settings. Defines how long the result should be cached for. Defaults to 1728000 (20 days)",
-          "type": "integer",
-          "default": 1728000
-        },
-        "http_cors_allow_credentials": {
-          "description": "Whether the Access-Control-Allow-Credentials header should be returned. Note: This header is only returned when the setting is set to true. Defaults to false.",
-          "type": "boolean",
-          "default": false
-        },
-        "http_cors_allow_headers": {
-          "description": "Which headers to allow. Defaults to X-Requested-With, Content-Type, Content-Length.",
-          "type": "string",
-          "default": "X-Requested-With,Content-Type,Content-Length"
-        },
-        "http_cors_allow_methods": {
-          "description": "Which methods to allow. Defaults to OPTIONS, HEAD, GET, POST, PUT, DELETE.",
-          "type": "string",
-          "default": "OPTIONS,HEAD,GET,POST,PUT,DELETE"
-        },
-        "http_detailed_errors_enabled": {
-          "description": "Enables or disables the output of detailed error messages and stack traces in response output. Note: When set to false and the error_trace request parameter is specified, an error will be returned; when error_trace is not specified, a simple message will be returned. Defaults to true.",
-          "type": "boolean",
-          "default": true
-        },
-        "http_pipelining": {
-          "description": "Enable or disable HTTP pipelining, defaults to true.",
-          "type": "boolean",
-          "default": true
-        },
-        "http_pipelining_max_events": {
-          "description": "The maximum number of events to be queued up in memory before a HTTP connection is closed, defaults to 10000.",
-          "type": "integer",
-          "default": 10000
-        },
-        "thread_pool_search_size": {
-          "description": "For count/search/suggest operations. Thread pool type is fixed with a size of int((# of available_processors * 3) / 2) + 1. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_search_queue_size": {
-          "description": "For count/search/suggest operations. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them. -1 means its unbounded. Defaults to 1000",
-          "type": "integer",
-          "default": 1000
-        },
-        "thread_pool_index_size": {
-          "description": "For index/delete operations. Thread pool type is fixed with a size of # of available processors. The size parameter controls the number of threads. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_index_queue_size": {
-          "description": "For index/delete operations. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them.  -1 means its unbounded. Defaults to 200.",
-          "type": "integer",
-          "default": 200
-        },
-        "thread_pool_get_size": {
-          "description": "For get operations. Thread pool type is fixed with a size of # of available processors. The size parameter controls the number of threads. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_get_queue_size": {
-          "description": "For get operations. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them.  -1 means its unbounded. Defaults to 1000.",
-          "type": "integer",
-          "default": 200
-        },
-        "thread_pool_bulk_size": {
-          "description": "For bulk operations. Thread pool type is fixed with a size of # of available processors. The size parameter controls the number of threads. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_bulk_queue_size": {
-          "description": "For bulk operations. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them.  -1 means its unbounded. Defaults to 1000.",
-          "type": "integer",
-          "default": 200
-        },
-        "thread_pool_listener_size": {
-          "description": "Mainly for java client executing of action when listener threaded is set to true. Thread pool type is fixed with a size of # of available processors. The size parameter controls the number of threads. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_listener_queue_size": {
-          "description": "Mainly for java client executing of action when listener threaded is set to true. The queue_size allows to control the size of the queue of pending requests that have no threads to execute them. -1 means its unbounded. Defaults to 2. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_warmer_core": {
-          "description": "For segment warm-up operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_warmer_max": {
-          "description": "For segment warm-up operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_warmer_keep_alive": {
-          "description": "For segment warm-up operations. The keep_alive parameter determines how long a thread should be kept around in the thread pool without it doing any work.",
-          "type": "string",
-          "default": "5m"
-        },
-        "thread_pool_snapshot_core": {
-          "description": "For snapshot/restore operations. Thread pool type is scaling with a keep-alive of 5m and a max of min(5, (# of available processors)/2). This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_snapshot_max": {
-          "description": "For snapshot/restore operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_snapshot_keep_alive": {
-          "description": "For snapshot/restore operations. The keep_alive parameter determines how long a thread should be kept around in the thread pool without it doing any work.",
-          "type": "string",
-          "default": "5m"
-        },
-        "thread_pool_refresh_core": {
-          "description": "For refresh operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_refresh_max": {
-          "description": "For refresh operations. The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_refresh_keep_alive": {
-          "description": "For refresh operations. The keep_alive parameter determines how long a thread should be kept around in the thread pool without it doing any work.",
-          "type": "string",
-          "default": "5m"
-        },
-        "thread_pool_generic_core": {
-          "description": "For generic operations (e.g., background node discovery). The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_generic_max": {
-          "description": "For generic operations (e.g., background node discovery). The scaling thread pool holds a dynamic number of threads. This number is proportional to the workload and varies between the value of the core and max parameters. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "thread_pool_generic_keep_alive": {
-          "description": "For generic operations (e.g., background node discovery). The keep_alive parameter determines how long a thread should be kept around in the thread pool without it doing any work.",
-          "type": "string",
-          "default": "30s"
-        },
-        "indices_breaker_total_limit": {
-          "description": "Starting limit for overall parent breaker, defaults to 70% of JVM heap. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "indices_breaker_fielddata_limit": {
-          "description": "Limit for fielddata breaker, defaults to 60% of JVM heap. Empty means do not explicity set. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "indices_breaker_fielddata_overhead": {
-          "description": "A constant that all field data estimations are multiplied with to determine a final estimation. Defaults to 1.03. Empty means do not explicity set. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "network_breaker_inflight_requests_limit": {
-          "description": "Limit for in flight requests breaker, defaults to 100% of JVM heap. This means that it is bound by the limit configured for the parent circuit breaker. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "network_breaker_inflight_requests_overhead": {
-          "description": "A constant that all in flight requests estimations are multiplied with to determine a final estimation. Defaults to 1. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "script_max_compilations_per_minute": {
-          "description": "Limit for the number of unique dynamic scripts within a minute that are allowed to be compiled. Defaults to 15. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "indices_fielddata_cache_size": {
-          "description": "The max size of the field data cache, eg 30% of node heap space, or an absolute value, eg 12GB. Defaults to unbounded. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "indices_queries_cache_size": {
-          "description": "Controls the memory size for the filter cache , defaults to 10%. Accepts either a percentage value, like 5%, or an exact value, like 512mb. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "indices_memory_index_buffer_size": {
-          "description": "Accepts either a percentage or a byte size value. It defaults to 10%, meaning that 10% of the total heap allocated to a node will be used as the indexing buffer size shared across all shards. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "indices_memory_min_index_buffer_size": {
-          "description": "If the index_buffer_size is specified as a percentage, then this setting can be used to specify an absolute minimum. Defaults to 48mb. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "indices_memory_max_index_buffer_size": {
-          "description": "If the index_buffer_size is specified as a percentage, then this setting can be used to specify an absolute maximum. Defaults to unbounded. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "indices_recovery_max_bytes_per_sec": {
-          "description": "This can be set to manage the recovery policy. Defaults to 40mb. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "search_remote_connections_per_cluster": {
-          "description": "The number of nodes to connect to per remote cluster. The default is 3. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "search_remote_initial_connect_timeout": {
-          "description": "The time to wait for remote connections to be established when the node starts. The default is 30s. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "search_remote_node_attr": {
-          "description": "A node attribute to filter out nodes that are eligible as a gateway node in the remote cluster. For instance a node can have a node attribute node_attr_gateway: true such that only nodes with this attribute will be connected to if search_remote_node_attr is set to gateway. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "search_remote_connect": {
-          "description": "By default, any node in the cluster can act as a cross-cluster client and connect to remote clusters. The search_remote_connect setting can be set to false (defaults to true) to prevent certain nodes from connecting to remote clusters. Cross-cluster search requests must be sent to a node that is allowed to act as a cross-cluster client. Empty means do not explicity set.",
-          "type": "string",
-          "default": ""
-        },
-        "indices_query_bool_max_clause_count": {
-          "description": "Set the number of clauses used while querying Elasticsearch. Defaults to 1024. If any query expands into more than 1024 boolean clauses, you will get TooManyClauses exception. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "discovery_zen_ping_unicast_hosts.resolve_timeout": {
-          "description": "The amount of time to wait for DNS lookups on each round of pinging. Specified as time units. Defaults to 5s. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "discovery_zen_fd_ping_interval": {
-          "description": "How often a node gets pinged. Defaults to 1s. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "discovery_zen_fd_ping_timeout": {
-          "description": "How long to wait for a ping response, defaults to 30s. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "discovery_zen_fd_ping_retries": {
-          "description": "How many ping failures / timeouts cause a node to be considered failed. Defaults to 3. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "discovery_zen_no_master_block": {
-          "description": "Controls what operations should be rejected when there is no active master. There are two valid operations: all and write (defaut). Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_blocks_read_only": {
-          "description": "Make the whole cluster read only (indices do not accept write operations), metadata is not allowed to be modified (create or delete indices). Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_blocks_read_only_allow_delete": {
-          "description": "Identical to cluster_blocks_read_only but allows to delete indices to free up resources. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_indices_tombstones_size": {
-          "description": "Index tombstones prevent nodes that are not part of the cluster when a delete occurs from joining the cluster and reimporting the index as though the delete was never issued. To keep the cluster state from growing huge we only keep the last cluster.indices.tombstones.size deletes, which defaults to 500. You can increase it if you expect nodes to be absent from the cluster and miss more than 500 deletes. We think that is rare, thus the default. Tombstones don't take up much space, but we also think that a number like 50,000 is probably too big. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "index_routing_allocation_total_shards_per_node": {
-          "description": "The maximum number of shards (replicas and primaries) that will be allocated to a single node. Defaults to unbounded. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_total_shards_per_node": {
-          "description": "The maximum number of shards (replicas and primaries) that will be allocated to a single node globally. Defaults to unbounded (-1). Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_awareness_attributes": {
-          "description": "Setup shard allocation awareness by telling Elasticsearch which attributes to use. Multiple awareness attributes can be specified, in which case the combination of values from each attribute is considered to be a separate value. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_disk_threshold_enabled": {
-          "description": "Elasticsearch factors in the available disk space on a node before deciding whether to allocate new shards to that node or to actively relocate shards away from that node. Defaults to true. Set to false to disable the disk allocation decider. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_disk_watermark_low": {
-          "description": "Controls the low watermark for disk usage. It defaults to 85%, meaning ES will not allocate new shards to nodes once they have more than 85% disk used. It can also be set to an absolute byte value (like 500mb) to prevent ES from allocating shards if less than the configured amount of space is available. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_disk_watermark_high": {
-          "description": "Controls the high watermark. It defaults to 90%, meaning ES will attempt to relocate shards to another node if the node disk usage rises above 90%. It can also be set to an absolute byte value (similar to the low watermark) to relocate shards once less than the configured amount of space is available on the node. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_info_update_interval": {
-          "description": "How often Elasticsearch should check on disk usage for each node in the cluster. Defaults to 30s. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_disk_include_relocations": {
-          "description": "Defaults to true, which means that Elasticsearch will take into account shards that are currently being relocated to the target node when computing a node's disk usage. Taking relocating shards' sizes into account may, however, mean that the disk usage for a node is incorrectly estimated on the high side, since the relocation could be 90% complete and a recently retrieved disk usage would include the total size of the relocating shard as well as the space already used by the running relocation. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_enable": {
-          "description": "Enable or disable allocation for specific kinds of shards: all, primaries, new_primaries, none. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_node_concurrent_incoming_recoveries": {
-          "description": "How many concurrent incoming shard recoveries are allowed to happen on a node. Incoming recoveries are the recoveries where the target shard (most likely the replica unless a shard is relocating) is allocated on the node. Defaults to 2. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_node_concurrent_outgoing_recoveries": {
-          "description": "How many concurrent outgoing shard recoveries are allowed to happen on a node. Outgoing recoveries are the recoveries where the source shard (most likely the primary unless a shard is relocating) is allocated on the node. Defaults to 2. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_node_concurrent_recoveries": {
-          "description": "A shortcut to set both cluster.routing.allocation.node_concurrent_incoming_recoveries and cluster.routing.allocation.node_concurrent_outgoing_recoveries. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_node_initial_primaries_recoveries": {
-          "description": "While the recovery of replicas happens over the network, the recovery of an unassigned primary after node restart uses data from the local disk. These should be fast so more initial primary recoveries can happen in parallel on the same node. Defaults to 4. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_same_shard_host": {
-          "description": "Allows to perform a check to prevent allocation of multiple instances of the same shard on a single host, based on host name and host address. Defaults to false, meaning that no check is performed by default. This setting only applies if multiple nodes are started on the same machine. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_rebalance_enable": {
-          "description": "Enable or disable rebalancing for specific kinds of shards: all, primeries, replicas, none. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_allow_rebalance": {
-          "description": "Specify when shard rebalancing is allowed: always, indices_primaries_active, indices_all_active (default). Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_cluster_concurrent_rebalance": {
-          "description": "Allow to control how many concurrent shard rebalances are allowed cluster wide. Defaults to 2. Note that this setting only controls the number of concurrent shard relocations due to imbalances in the cluster. This setting does not limit shard relocations due to allocation filtering or forced awareness. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_balance_shard": {
-          "description": "Defines the weight factor for the total number of shards allocated on a node (float). Defaults to 0.45f. Raising this raises the tendency to equalize the number of shards across all nodes in the cluster. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_balance_index": {
-          "description": "Defines the weight factor for the number of shards per index allocated on a specific node (float). Defaults to 0.55f. Raising this raises the tendency to equalize the number of shards per index across all nodes in the cluster. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "cluster_routing_allocation_balance_threshold": {
-          "description": "Minimal optimization value of operations that should be performed (non negative float). Defaults to 1.0f. Raising this will cause the cluster to be less aggressive about optimizing the shard balance. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
-        },
-        "indices_requests_cache_size": {
-          "description": "The cache is managed at the node level, and has a default maximum size of 1% of the heap. Empty means do not explicitly set.",
-          "type": "string",
-          "default": ""
+        "xpack_ml_max_anomaly_records": {
+          "description": "The maximum number of records that are output per bucket. Defaults to 500.",
+          "type": "integer",
+          "default": 500
+        },
+        "xpack_ml_max_lazy_ml_nodes": {
+          "description": "The number of lazily spun up Machine Learning nodes. Useful in situations where ML nodes are not desired until the first Machine Learning Job is opened. It defaults to 0 and has a maximum acceptable value of 3.",
+          "type": "integer",
+          "default": 0
+        },
+        "xpack_ml_max_machine_memory_percent": {
+          "description": "The maximum percentage of the machine\u2019s memory that machine learning may use for running analytics processes. (These processes are separate to the Elasticsearch JVM.) Defaults to 30 percent.",
+          "type": "integer",
+          "default": 30
+        },
+        "xpack_ml_max_model_memory_limit": {
+          "description": "The maximum model_memory_limit property value that can be set for any job on this node. If you try to create a job with a model_memory_limit property value that is greater than this setting value, an error occurs.",
+          "type": "string",
+          "default": "4096mb"
+        },
+        "xpack_ml_max_open_jobs": {
+          "description": "The maximum number of jobs that can run on a node. Defaults to 20.",
+          "type": "integer",
+          "default": 20
+        },
+        "xpack_ml_node_concurrent_job_allocations": {
+          "description": "The maximum number of jobs that can concurrently be in the opening state on each node. Defaults to 2.",
+          "type": "integer",
+          "default": 2
+        },
+        "xpack_monitoring_elasticsearch_collection_enabled": {
+          "description": "Controls whether statistics about your Elasticsearch cluster should be collected. Defaults to true.",
+          "type": "boolean",
+          "default": true
+        },
+        "xpack_security_audit_index_flush_interval": {
+          "description": "Controls how often buffered events are flushed to the index. Defaults to 1s.",
+          "type": "string",
+          "default": "1s"
+        },
+        "xpack_security_audit_index_rollover": {
+          "description": "Controls how often to roll over to a new index: hourly, daily, weekly, or monthly. Defaults to daily.",
+          "type": "string",
+          "default": "daily"
+        },
+        "xpack_watcher_history_cleaner_service_enabled": {
+          "description": "Set to true (default) to enable the cleaner service.",
+          "type": "boolean",
+          "default": true
+        },
+        "http_content_type_required": {
+          "description": "[DEPRECATED] Starting from Elasticseach 6.0, this setting is no longer configurable and defaults to true. Changing this setting has no effect.",
+          "type": "boolean",
+          "default": true
         },
         "xpack_enabled": {
           "description": "[DEPRECATED] X-Pack is enabled by default on Elastic 6.3+. Changing this setting has no effect.",
-          "type": "boolean",
-          "default": true
-        },
-        "http_content_type_required": {
-          "description": "[DEPRECATED] Starting from Elasticseach 6.0, this setting is no longer configurable and defaults to true. Changing this setting has no effect.",
           "type": "boolean",
           "default": true
         }
--- 600/marathon.json.mustache
+++ 700/marathon.json.mustache
@@ -4,7 +4,7 @@
   "mem": 1024,
   "instances": 1,
   "user": "{{service.user}}",
-  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./elastic-scheduler/bin/elastic ./elastic-scheduler/svc.yml",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./elastic-scheduler/bin/elastic ./elastic-scheduler/svc.yml",
   "labels": {
     "DCOS_COMMONS_API_VERSION": "v1",
     "DCOS_COMMONS_UNINSTALL": "true",
@@ -32,11 +32,11 @@
   {{/service.service_account_secret}}
   "env": {
     "PACKAGE_NAME": "elastic",
-    "PACKAGE_VERSION": "2.6.0-6.6.1",
-    "PACKAGE_BUILD_TIME_EPOCH_MS": "1554284543589",
-    "PACKAGE_BUILD_TIME_STR": "Wed Apr 03 2019 09:42:23 +0000",
-    "ELASTIC_VERSION": "6.6.1",
-    "ELASTIC_STATSD_VERSION": "6.6.1.0",
+    "PACKAGE_VERSION": "2.7.0-6.8.1",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1566211651458",
+    "PACKAGE_BUILD_TIME_STR": "Mon Aug 19 2019 10:47:31 +0000",
+    "ELASTIC_VERSION": "6.8.1",
+    "ELASTIC_STATSD_VERSION": "6.8.1.0",
     "STATSD_URI": "{{resource.assets.uris.statsd-plugin-zip}}",
     "ELASTICSEARCH_URI" : "{{resource.assets.uris.elasticsearch-tar-gz}}",
     "ELASTICSEARCH_JAVA_URI" : "{{resource.assets.uris.elasticsearch-jre-tar-gz}}",
@@ -63,12 +63,29 @@
     {{/service.virtual_network_enabled}}
 
     {{#service.security.transport_encryption.enabled}}
-    "TASKCFG_ALL_SECURITY_TRANSPORT_ENCRYPTION_ENABLED": "{{service.security.transport_encryption.enabled}}",
+    "TASKCFG_ALL_SECURITY_ENABLED": "true",
     "ELASTICSEARCH_HEALTH_PROTOCOL": "https",
     {{/service.security.transport_encryption.enabled}}
+
     {{^service.security.transport_encryption.enabled}}
+    {{#elasticsearch.xpack_security_enabled}}
+    "TASKCFG_ALL_SECURITY_ENABLED": "true",
+    "ELASTICSEARCH_HEALTH_PROTOCOL": "https",
+    {{/elasticsearch.xpack_security_enabled}}
+    {{/service.security.transport_encryption.enabled}}
+
+    {{^service.security.transport_encryption.enabled}}
+    {{^elasticsearch.xpack_security_enabled}}
+    "TASKCFG_ALL_SECURITY_ENABLED": "false",
     "ELASTICSEARCH_HEALTH_PROTOCOL": "http",
+    {{/elasticsearch.xpack_security_enabled}}
     {{/service.security.transport_encryption.enabled}}
+
+    "TASKCFG_ALL_XPACK_SECURITY_ENABLED": "{{elasticsearch.xpack_security_enabled}}",
+
+    {{#service.security.custom_domain}}
+    "SERVICE_TLD": "{{service.security.custom_domain}}",
+    {{/service.security.custom_domain}}
 
     "DEPLOY_STRATEGY": "{{service.deploy_strategy}}",
     "UPDATE_STRATEGY": "{{service.update_strategy}}",
@@ -78,6 +95,9 @@
     "MASTER_NODE_HEAP_MB": "{{master_nodes.heap.size}}",
     "MASTER_NODE_DISK": "{{master_nodes.disk}}",
     "MASTER_NODE_DISK_TYPE": "{{master_nodes.disk_type}}",
+    {{#master_nodes.volume_profile}}
+    "MASTER_NODE_VOLUME_PROFILE": "{{master_nodes.volume_profile}}",
+    {{/master_nodes.volume_profile}}
     "MASTER_NODE_TRANSPORT_PORT": "{{master_nodes.transport_port}}",
     "DATA_NODE_COUNT": "{{data_nodes.count}}",
     "DATA_NODE_CPUS": "{{data_nodes.cpus}}",
@@ -86,6 +106,9 @@
     "DATA_NODE_HEAP_MB": "{{data_nodes.heap.size}}",
     "DATA_NODE_DISK": "{{data_nodes.disk}}",
     "DATA_NODE_DISK_TYPE": "{{data_nodes.disk_type}}",
+    {{#data_nodes.volume_profile}}
+    "DATA_NODE_VOLUME_PROFILE": "{{data_nodes.volume_profile}}",
+    {{/data_nodes.volume_profile}}
     "INGEST_NODE_COUNT": "{{ingest_nodes.count}}",
     "INGEST_NODE_CPUS": "{{ingest_nodes.cpus}}",
     "INGEST_NODE_MEM": "{{ingest_nodes.mem}}",
@@ -93,6 +116,9 @@
     "INGEST_NODE_HEAP_MB": "{{ingest_nodes.heap.size}}",
     "INGEST_NODE_DISK": "{{ingest_nodes.disk}}",
     "INGEST_NODE_DISK_TYPE": "{{ingest_nodes.disk_type}}",
+    {{#ingest_nodes.volume_profile}}
+    "INGEST_NODE_VOLUME_PROFILE": "{{ingest_nodes.volume_profile}}",
+    {{/ingest_nodes.volume_profile}}
     "COORDINATOR_NODE_COUNT": "{{coordinator_nodes.count}}",
     "COORDINATOR_NODE_CPUS": "{{coordinator_nodes.cpus}}",
     "COORDINATOR_NODE_MEM": "{{coordinator_nodes.mem}}",
@@ -100,13 +126,19 @@
     "COORDINATOR_NODE_HEAP_MB": "{{coordinator_nodes.heap.size}}",
     "COORDINATOR_NODE_DISK": "{{coordinator_nodes.disk}}",
     "COORDINATOR_NODE_DISK_TYPE": "{{coordinator_nodes.disk_type}}",
+    {{#coordinator_nodes.volume_profile}}
+    "COORDINATOR_NODE_VOLUME_PROFILE": "{{coordinator_nodes.volume_profile}}",
+    {{/coordinator_nodes.volume_profile}}
     {{#service.region}}
     "SERVICE_REGION": "{{service.region}}",
     {{/service.region}}
     "ELASTICSEARCH_HEALTH_USER": "{{elasticsearch.health_user}}",
     "ELASTICSEARCH_HEALTH_USER_PASSWORD": "{{elasticsearch.health_user_password}}",
-    "TASKCFG_ALL_XPACK_SECURITY_ENABLED": "{{elasticsearch.xpack_security_enabled}}",
     "TASKCFG_ALL_ELASTICSEARCH_PLUGINS": "{{elasticsearch.plugins}}",
+    "TASKCFG_ALL_PLUGIN_HTTP_PROXY_HOST": "{{elasticsearch.plugin_http_proxy_host}}",
+    "TASKCFG_ALL_PLUGIN_HTTP_PROXY_PORT": "{{elasticsearch.plugin_http_proxy_port}}",
+    "TASKCFG_ALL_PLUGIN_HTTPS_PROXY_HOST": "{{elasticsearch.plugin_https_proxy_host}}",
+    "TASKCFG_ALL_PLUGIN_HTTPS_PROXY_PORT": "{{elasticsearch.plugin_https_proxy_port}}",
     "TASKCFG_ALL_GATEWAY_RECOVER_AFTER_TIME": "{{elasticsearch.gateway_recover_after_time}}",
     {{#elasticsearch.script_allowed_contexts}}
     "TASKCFG_ALL_SCRIPT_ALLOWED_CONTEXTS": "{{elasticsearch.script_allowed_contexts}}",
@@ -328,6 +360,112 @@
     {{#elasticsearch.indices_requests_cache_size}}
     "TASKCFG_ALL_INDICES_REQUESTS_CACHE_SIZE": "{{elasticsearch.indices_requests_cache_size}}",
     {{/elasticsearch.indices_requests_cache_size}}
+    {{#elasticsearch.thread_pool_analyze_queue_size}}
+    "TASKCFG_ALL_THREAD_POOL_ANALYZE_QUEUE_SIZE": "{{elasticsearch.thread_pool_analyze_queue_size}}",
+    {{/elasticsearch.thread_pool_analyze_queue_size}}
+    {{#elasticsearch.thread_pool_analyze_size}}
+    "TASKCFG_ALL_THREAD_POOL_ANALYZE_SIZE": "{{elasticsearch.thread_pool_analyze_size}}",
+    {{/elasticsearch.thread_pool_analyze_size}}
+    {{#elasticsearch.thread_pool_search_max_queue_size}}
+    "TASKCFG_ALL_THREAD_POOL_SEARCH_MAX_QUEUE_SIZE": "{{elasticsearch.thread_pool_search_max_queue_size}}",
+    {{/elasticsearch.thread_pool_search_max_queue_size}}
+    {{#elasticsearch.thread_pool_search_throttled_max_queue_size}}
+    "TASKCFG_ALL_THREAD_POOL_SEARCH_THROTTLED_MAX_QUEUE_SIZE": "{{elasticsearch.thread_pool_search_throttled_max_queue_size}}",
+    {{/elasticsearch.thread_pool_search_throttled_max_queue_size}}
+    {{#elasticsearch.thread_pool_search_throttled_size}}
+    "TASKCFG_ALL_THREAD_POOL_SEARCH_THROTTLED_SIZE": "{{elasticsearch.thread_pool_search_throttled_size}}",
+    {{/elasticsearch.thread_pool_search_throttled_size}}
+    {{#elasticsearch.thread_pool_search_throttled_queue_size}}
+    "TASKCFG_ALL_THREAD_POOL_SEARCH_THROTTLED_QUEUE_SIZE": "{{elasticsearch.thread_pool_search_throttled_queue_size}}",
+    {{/elasticsearch.thread_pool_search_throttled_queue_size}}
+    {{#elasticsearch.thread_pool_write_queue_size}}
+    "TASKCFG_ALL_THREAD_POOL_WRITE_QUEUE_SIZE": "{{elasticsearch.thread_pool_write_queue_size}}",
+    {{/elasticsearch.thread_pool_write_queue_size}}
+    {{#elasticsearch.thread_pool_write_size}}
+    "TASKCFG_ALL_THREAD_POOL_WRITE_SIZE": "{{elasticsearch.thread_pool_write_size}}",
+    {{/elasticsearch.thread_pool_write_size}}
+    {{#elasticsearch.xpack_graph_enabled}}
+    "TASKCFG_ALL_XPACK_GRAPH_ENABLED": "{{elasticsearch.xpack_graph_enabled}}",
+    {{/elasticsearch.xpack_graph_enabled}}
+    {{#elasticsearch.xpack_ml_enabled}}
+    "TASLCFG_ALL_XPACK_ML_ENABLED": "{{elasticsearch.xpack_ml_enabled}}",
+    {{/elasticsearch.xpack_ml_enabled}}
+    {{#elasticsearch.xpack_ml_max_open_jobs}}
+    "TASKCFG_ALL_XPACK_ML_MAX_OPEN_JOBS": "{{elasticsearch.xpack_ml_max_open_jobs}}",
+    {{/elasticsearch.xpack_ml_max_open_jobs}}
+    {{#elasticsearch.xpack_ml_max_anomaly_records}}
+    "TASKCFG_ALL_XPACK_ML_MAX_ANOMALY_RECORDS": "{{elasticsearch.xpack_ml_max_anomaly_records}}",
+    {{/elasticsearch.xpack_ml_max_anomaly_records}}
+    {{#elasticsearch.xpack_ml_max_lazy_ml_nodes}}
+    "TASKCFG_ALL_XPACK_ML_MAX_LAZY_ML_NODES": "{{elasticsearch.xpack_ml_max_lazy_ml_nodes}}",
+    {{/elasticsearch.xpack_ml_max_lazy_ml_nodes}}
+    {{#elasticsearch.xpack_ml_max_machine_memory_percent}}
+    "TASKCFG_ALL_XPACK_ML_MAX_MACHINE_MEMORY_PERCENT": "{{elasticsearch.xpack_ml_max_machine_memory_percent}}",
+    {{/elasticsearch.xpack_ml_max_machine_memory_percent}}
+    {{#elasticsearch.xpack_ml_max_model_memory_limit}}
+    "TASKCFG_ALL_XPACK_ML_MAX_MODEL_MEMORY_LIMIT": "{{elasticsearch.xpack_ml_max_model_memory_limit}}",
+    {{/elasticsearch.xpack_ml_max_model_memory_limit}}
+    {{#elasticsearch.xpack_ml_node_concurrent_job_allocations}}
+    "TASKCFG_ALL_XPACK_ML_NODE_CONCURRENT_JOB_ALLOCATIONS": "{{elasticsearch.xpack_ml_node_concurrent_job_allocations}}",
+    {{/elasticsearch.xpack_ml_node_concurrent_job_allocations}}
+    {{#elasticsearch.xpack_monitoring_enabled}}
+    "TASKCFG_ALL_XPACK_MONITORING_ENABLED": "{{elasticsearch.xpack_monitoring_enabled}}",
+    {{/elasticsearch.xpack_monitoring_enabled}}
+    {{#elasticsearch.xpack_monitoring_collection_enabled}}
+    "TASKCFG_ALL_XPACK_MONITORING_COLLECTION_ENABLED": "{{elasticsearch.xpack_monitoring_collection_enabled}}",
+    {{/elasticsearch.xpack_monitoring_collection_enabled}}
+    {{#elasticsearch.xpack_monitoring_elasticsearch_collection_enabled}}
+    "TASKCFG_ALL_XPACK_MONITORING_ELASTICSEARCH_COLLECTION_ENABLED": "{{elasticsearch.xpack_monitoring_elasticsearch_collection_enabled}}",
+    {{/elasticsearch.xpack_monitoring_elasticsearch_collection_enabled}}
+    "TASKCFG_ALL_XPACK_MONITORING_DEFAULT_EXPORTER_USE_INGEST": "{{elasticsearch.xpack_monitoring_default_exporter_use_ingest}}",
+    {{#elasticsearch.xpack_watcher_enabled}}
+    "TASKCFG_ALL_XPACK_WATCHER_ENABLED": "{{elasticsearch.xpack_watcher_enabled}}",
+    {{/elasticsearch.xpack_watcher_enabled}}
+    {{#elasticsearch.xpack_watcher_history_cleaner_service_enabled}}
+    "TASKCFG_ALL_XPACK_WATCHER_HISTORY_CLEANER_SERVICE_ENABLED": "{{elasticsearch.xpack_watcher_history_cleaner_service_enabled}}",
+    {{/elasticsearch.xpack_watcher_history_cleaner_service_enabled}}
+    {{#elasticsearch.xpack_sql_enabled}}
+    "TASKCFG_ALL_XPACK_SQL_ENABLED": "{{elasticsearch.xpack_sql_enabled}}",
+    {{/elasticsearch.xpack_sql_enabled}}
+    {{#elasticsearch.xpack_security_audit_enabled}}
+    "TASKCFG_ALL_XPACK_SECURITY_AUDIT_ENABLED": "{{elasticsearch.xpack_security_audit_enabled}}",
+    {{/elasticsearch.xpack_security_audit_enabled}}
+    {{#elasticsearch.xpack_security_audit_index_flush_interval}}
+    "TASKCFG_ALL_XPACK_SECURITY_AUDIT_INDEX_FLUSH_INTERVAL": "{{elasticsearch.xpack_security_audit_index_flush_interval}}",
+    {{/elasticsearch.xpack_security_audit_index_flush_interval}}
+    {{#elasticsearch.xpack_security_audit_index_rollover}}
+    "TASKCFG_ALL_XPACK_SECURITY_AUDIT_INDEX_ROLLOVER": "{{elasticsearch.xpack_security_audit_index_rollover}}",
+    {{/elasticsearch.xpack_security_audit_index_rollover}}
+    {{#elasticsearch.xpack_http_proxy_host}}
+    "TASKCFG_ALL_XPACK_HTTP_PROXY_HOST": "{{elasticsearch.xpack_http_proxy_host}}",
+    {{/elasticsearch.xpack_http_proxy_host}}
+    {{#elasticsearch.xpack_http_proxy_port}}
+    "TASKCFG_ALL_XPACK_HTTP_PROXY_PORT": "{{elasticsearch.xpack_http_proxy_port}}",
+    {{/elasticsearch.xpack_http_proxy_port}}
+    {{#elasticsearch.cluster_max_shards_per_node}}
+    "TASKCFG_ALL_CLUSTER_MAX_SHARDS_PER_NODE": "{{elasticsearch.cluster_max_shards_per_node}}",
+    {{/elasticsearch.cluster_max_shards_per_node}}
+    {{#elasticsearch.action_destructive_requires_name}}
+    "TASKCFG_ALL_ACTION_DESTRUCTIVE_REQUIRES_NAME": "{{elasticsearch.action_destructive_requires_name}}",
+    {{/elasticsearch.action_destructive_requires_name}}
+    {{#elasticsearch.cluster_persistent_tasks_allocation_enable}}
+    "TASKCFG_ALL_CLUSTER_PERSISTENT_TASKS_ALLOCATION_ENABLE": "{{elasticsearch.cluster_persistent_tasks_allocation_enable}}",
+    {{/elasticsearch.cluster_persistent_tasks_allocation_enable}}
+    {{#elasticsearch.cluster_persistent_tasks_allocation_recheck_interval}}
+    "TASKCFG_ALL_CLUSTER_PERSISTENT_TASKS_ALLOCATION_RECHECK_INTERVAL": "{{elasticsearch.cluster_persistent_tasks_allocation_recheck_interval}}",
+    {{/elasticsearch.cluster_persistent_tasks_allocation_recheck_interval}}
+    {{#elasticsearch.cluster_remote_connect}}
+    "TASKCFG_ALL_CLUSTER_REMOTE_CONNECT": "{{elasticsearch.cluster_remote_connect}}",
+    {{/elasticsearch.cluster_remote_connect}}
+    {{#elasticsearch.cluster_remote_connections_per_cluster}}
+    "TASKCFG_ALL_CLUSTER_REMOTE_CONNECTIONS_PER_CLUSTER": "{{elasticsearch.cluster_remote_connections_per_cluster}}",
+    {{/elasticsearch.cluster_remote_connections_per_cluster}}
+    {{#elasticsearch.script_max_size_in_bytes}}
+    "TASKCFG_ALL_SCRIPT_MAX_SIZE_IN_BYTES": "{{elasticsearch.script_max_size_in_bytes}}",
+    {{/elasticsearch.script_max_size_in_bytes}}
+    {{#elasticsearch.script_painless_regex_enabled}}
+    "TASKCFG_ALL_SCRIPT_PAINLESS_REGEX_ENABLED": "{{elasticsearch.script_painless_regex_enabled}}",
+    {{/elasticsearch.script_painless_regex_enabled}}
     "CUSTOM_YAML_BLOCK_BASE64": "{{elasticsearch.custom_elasticsearch_yml}}",
 
     "MASTER_NODE_READINESS_CHECK_INTERVAL": "{{master_nodes.readiness_check.interval}}",
@@ -385,5 +523,14 @@
       "protocol": "tcp",
       "name": "api"
     }
-  ]
+  ],
+  "check": {
+    "http": {
+      "portIndex": 0,
+      "path": "/v1/health"
+    },
+    "intervalSeconds": {{service.check.intervalSeconds}},
+    "timeoutSeconds": {{service.check.timeoutSeconds}},
+    "delaySeconds": {{service.check.delaySeconds}}
+  }
 }
--- 600/package.json
+++ 700/package.json
@@ -1,14 +1,14 @@
 {
   "packagingVersion": "4.0",
   "upgradesFrom": [
-    "2.5.0-6.3.2"
+    "2.6.0-6.6.1"
   ],
   "downgradesTo": [
-    "2.5.0-6.3.2"
+    "2.6.0-6.6.1"
   ],
-  "minDcosReleaseVersion": "1.10",
+  "minDcosReleaseVersion": "1.11",
   "name": "elastic",
-  "version": "2.6.0-6.6.1",
+  "version": "2.7.0-6.8.1",
   "maintainer": "support@mesosphere.io",
   "description": "Elasticsearch 6, and X-Pack",
   "selected": true,
@@ -20,8 +20,8 @@
     "x-pack"
   ],
   "preInstallNotes": "Default configuration requires 3 agent nodes each with: CPU: 4.0 | Memory: 9216MB | Disk: 13500MB\n\nMore specifically, each instance type requires:\n\nMaster node: 3 instances | 1.0 CPU | 2048 MB MEM | 1 2000 MB Disk\n\nData node: 2 instances | 1.0 CPU | 4096 MB MEM | 1 10000 MB Disk\n\nCoordinator node: 1 instance | 1.0 CPU | 2048 MB MEM | 1 1000 MB Disk\n\nIngest node: No instances by default | 0.5 CPU | 2048 MB MEM | 1 2000 MB Disk",
-  "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/\n\tIssues: https://docs.mesosphere.com/support/",
-  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.10 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/uninstall to remove any persistent state if required.",
+  "postInstallNotes": "The DC/OS Elastic service is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/elastic/2.7.0-6.8.1/\n\tIssues: https://docs.mesosphere.com/support/",
+  "postUninstallNotes": "The DC/OS Elastic service is being uninstalled.\n\nFor DC/OS versions from 1.11 no further action is required. For older DC/OS versions follow the instructions at https://docs.mesosphere.com/service-docs/elastic/2.7.0-6.8.1/uninstall to remove any persistent state if required.",
   "licenses": [
     {
       "name": "Apache License Version 2.0",
--- 600/resource.json
+++ 700/resource.json
@@ -1,13 +1,13 @@
 {
   "assets": {
     "uris": {
-      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u192-linux-x64.tar.gz",
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/openjdk-jre-8u212b03-hotspot-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.12.0.tar.gz",
-      "bootstrap-zip": "https://downloads.mesosphere.com/elastic/assets/2.6.0-6.6.1/bootstrap.zip",
-      "scheduler-zip": "https://downloads.mesosphere.com/elastic/assets/2.6.0-6.6.1/elastic-scheduler.zip",
-      "statsd-plugin-zip": "https://downloads.mesosphere.com/elastic/assets/elasticsearch-statsd-6.6.1.0.zip",
-      "elasticsearch-jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u192-linux-x64.tar.gz",
-      "elasticsearch-tar-gz": "https://downloads.mesosphere.com/elastic/assets/elasticsearch-6.6.1.tar.gz",
+      "bootstrap-zip": "https://downloads.mesosphere.com/elastic/assets/2.7.0-6.8.1/bootstrap.zip",
+      "scheduler-zip": "https://downloads.mesosphere.com/elastic/assets/2.7.0-6.8.1/elastic-scheduler.zip",
+      "statsd-plugin-zip": "https://downloads.mesosphere.com/elastic/assets/elasticsearch-statsd-6.8.1.0.zip",
+      "elasticsearch-jre-tar-gz": "https://downloads.mesosphere.com/java/openjdk-jre-8u212b03-hotspot-linux-x64.tar.gz",
+      "elasticsearch-tar-gz": "https://downloads.mesosphere.com/elastic/assets/elasticsearch-6.8.1.tar.gz",
       "diagnostics-zip": "https://downloads.mesosphere.com/elastic/assets/support-diagnostics-6.4.4-dist.zip"
     }
   },
@@ -23,11 +23,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "bb1fba576b681b88ea0491758cc06dbe397759accaead541aeef88236da63013"
+              "value": "859a6c40dc22015bff530ce483e632c8b0dd91f34bab9c6527ec98e893d3478a"
             }
           ],
           "kind": "executable",
-          "url": "https://downloads.mesosphere.com/elastic/assets/2.6.0-6.6.1/dcos-service-cli-darwin"
+          "url": "https://downloads.mesosphere.com/elastic/assets/2.7.0-6.8.1/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -35,11 +35,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "8085bc61b9ce596cf4b5b6053424ec732d237830b2f31acd419af2ea2ffd4668"
+              "value": "706f1aca1492a660c0b74c4ddab1e91d8a3955a3516fd7ef054bffdcd6fbbea7"
             }
           ],
           "kind": "executable",
-          "url": "https://downloads.mesosphere.com/elastic/assets/2.6.0-6.6.1/dcos-service-cli-linux"
+          "url": "https://downloads.mesosphere.com/elastic/assets/2.7.0-6.8.1/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -47,11 +47,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "a8ce02a11b31c0f832416758b796b0c9ce11917117c39b59a53b3123e15def94"
+              "value": "ba6a761f6a64276e7a3461eef2b9699f6b66d6431db2c77c8229d9fbbd35beb2"
             }
           ],
           "kind": "executable",
-          "url": "https://downloads.mesosphere.com/elastic/assets/2.6.0-6.6.1/dcos-service-cli.exe"
+          "url": "https://downloads.mesosphere.com/elastic/assets/2.7.0-6.8.1/dcos-service-cli.exe"
         }
       }
     }
```
