### PR TITLE
[DCOS-58405] Make it possible to run multiple instances of schema-registry

### DIFF
--- a/repo/packages/C/confluent-schema-registry/100/config.json
+++ b/repo/packages/C/confluent-schema-registry/100/config.json
@@ -68,7 +68,7 @@
           "default": 1,
           "description": "Number of instances to run (currently limited to 1).",
           "minimum": 1,
-          "maximum": 1,
+          "maximum": 2,
           "type": "integer"
         },
         "cpus": {

--- a/repo/packages/C/confluent-schema-registry/100/marathon.json.mustache
+++ b/repo/packages/C/confluent-schema-registry/100/marathon.json.mustache
@@ -162,7 +162,6 @@
     "DCOS_SERVICE_NAME": "{{registry.name}}",
     "DCOS_SERVICE_SCHEME": "http",
     "DCOS_SERVICE_PORT_INDEX": "0",
-    "MARATHON_SINGLE_INSTANCE_APP": "true",
     "DCOS_PACKAGE_FRAMEWORK_NAME": "{{registry.name}}"
   }
 }


### PR DESCRIPTION
This PR makes it possible to run multiple instance (max: 2) of confluent-schema-registry in DCOS.