### PR TITLE
[COPS-5339] Fix resource URIs and make Marathon app template use them. 

### DIFF
--- a/repo/packages/K/kibana/700/marathon.json.mustache
+++ b/repo/packages/K/kibana/700/marathon.json.mustache
@@ -62,13 +62,13 @@
       "cache": true
     },
     {
-      "uri": "https://downloads.mesosphere.com/kibana/assets/2.7.0-6.8.1/nginx.conf.tmpl",
-      "cache": true
-    },
-    {
-      "uri": "https://downloads.mesosphere.com/kibana/assets/2.7.0-6.8.1/init.sh",
+      "uri": "{{resource.assets.uris.init-sh}}",
       "cache": true,
       "executable": true
+    },
+    {
+      "uri": "{{resource.assets.uris.nginx-conf-tmpl}}",
+      "cache": true
     }
   ],
   "upgradeStrategy":{

--- a/repo/packages/K/kibana/700/resource.json
+++ b/repo/packages/K/kibana/700/resource.json
@@ -2,8 +2,8 @@
   "assets": {
     "uris": {
       "kibana-tar-gz": "https://downloads.mesosphere.com/elastic/assets/kibana-6.8.1-linux-x86_64.tar.gz",
-      "init-sh": "https://downloads.mesosphere.com/kibana/assets/2.7.0-6.8.1/nginx.conf.tmpl",
-      "nginx-conf-tmpl": "https://downloads.mesosphere.com/kibana/assets/2.7.0-6.8.1/init.sh"
+      "init-sh": "https://downloads.mesosphere.com/elastic/assets/2.7.0-6.8.1/init.sh",
+      "nginx-conf-tmpl": "https://downloads.mesosphere.com/elastic/assets/2.7.0-6.8.1/nginx.conf.tmpl"
     },
     "container": {
       "docker": {


### PR DESCRIPTION
The Marathon app template was using values relative to artifact-dir instead of
just using the resource URIs present in resources.json, which were
incidentally, incorrect.

This PR fixes the resource URIs and makes the Marathon app use them. This is the
root cause for the recent weirdness we've experienced with the latest Kibana
version Universe package.

This was fixed in the [dcos-elastic-service repository](https://github.com/mesosphere/dcos-elastic-service/pull/42) and I'm propagating the
changes here manually.