### PR TITLE
Release dcos-core-cli 2.0-patch.2

### DIFF
--- a/repo/packages/D/dcos-core-cli/20002/package.json
+++ b/repo/packages/D/dcos-core-cli/20002/package.json
@@ -1,0 +1,16 @@
+{
+    "packagingVersion": "3.0",
+    "name": "dcos-core-cli",
+    "version": "2.0-patch.2",
+    "maintainer": "support@mesosphere.io",
+    "minDcosReleaseVersion": "2.0",
+    "description": "Core DC/OS CLI",
+    "tags": [ "mesosphere", "core", "plugin" ],
+    "selected": false,
+    "licenses": [
+      {
+        "name": "Apache License Version 2.0",
+        "url": "https://raw.githubusercontent.com/dcos/dcos-core-cli/2.0-patch.x/LICENSE"
+      }
+    ]
+  }

--- a/repo/packages/D/dcos-core-cli/20002/resource.json
+++ b/repo/packages/D/dcos-core-cli/20002/resource.json
@@ -1,0 +1,42 @@
+{
+    "cli": {
+        "binaries": {
+            "linux": {
+                "x86-64": {
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-2.0-patch.2.zip",
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "18882b2f43100269b66caf144ade93d21d86081300f0b938644e84a7647cad43"
+                        }
+                    ]
+                }
+            },
+            "darwin": {
+                "x86-64": {
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/darwin/x86-64/dcos-core-cli-2.0-patch.2.zip",
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "f0c0ac0d38f7e574ad6b17ea0b7c2792063b5c3ff18e75f4b13cda9f3fca0c28"
+                        }
+                    ]
+                }
+            },
+            "windows": {
+                "x86-64": {
+                    "kind": "zip",
+                    "url": "https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/windows/x86-64/dcos-core-cli-2.0-patch.2.zip",
+                    "contentHash": [
+                        {
+                            "algo": "sha256",
+                            "value": "bfd913ca7a065704539eea6c44946da1b9b5788bc9ee4f97398131956610b37d"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
New changes include the ones from 2.0-patch.1 and 2.0-patch.2, see https://github.com/dcos/dcos-core-cli/blob/2.0-patch.x/CHANGELOG.md#20-patch2.