### PR TITLE
Add last modified field when generating universe json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,15 +493,12 @@ Currently Universe Server provides support for the following versions of DC/OS
 
 | DC/OS Release Version | Support Level |
 |-----------------------|---------------|
-| 1.6.1                 | Full Support  |
-| 1.7                   | Full Support  |
+| 1.6.1                 | Deprecated    |
+| 1.7                   | Deprecated    |
 | 1.8                   | Full Support  |
 | 1.9                   | Full Support  |
 | 1.10                  | Full Support  |
 | 1.11                  | Full Support  |
 | 1.12                  | Full Support  |
 | 1.13                  | Full Support  |
-| 1.14                  | Full Support  |
-
-
-
+| 2.0                   | Full Support  |

--- a/docker/local-universe/default.conf
+++ b/docker/local-universe/default.conf
@@ -49,7 +49,7 @@ server {
   }
 
   if ($http_user_agent ~ ".*dcos\/1\.14.*") {
-    set $dcos_release_version 1.14;
+    set $dcos_release_version 2.0;
   }
 
   location = /repo-1.7 {

--- a/docker/local-universe/default.conf
+++ b/docker/local-universe/default.conf
@@ -8,7 +8,7 @@ server {
 
   gzip_static on; # nginx will automatically search for a .gz version of a file and serve it if it exists
 
-  set $dcos_release_version 1.6.1;
+  set $dcos_release_version 2.0;
 
   set $serve_json false;
 
@@ -48,7 +48,7 @@ server {
     set $dcos_release_version 1.13;
   }
 
-  if ($http_user_agent ~ ".*dcos\/1\.14.*") {
+  if ($http_user_agent ~ ".*dcos\/2\.0.*") {
     set $dcos_release_version 2.0;
   }
 

--- a/docker/server/build.bash
+++ b/docker/server/build.bash
@@ -27,8 +27,6 @@ function prepare {(
     mkdir -p ${DOCKER_SERVER_DIR}/target
     # copy over the build json repos
     cp -r ${DOCKER_SERVER_DIR}/../../target/repo-*.json ${DOCKER_SERVER_DIR}/target
-    # copy over the build zip repos (only 1.6.1 and 1.7)
-    cp -r ${DOCKER_SERVER_DIR}/../../target/repo-*.zip ${DOCKER_SERVER_DIR}/target
     # copy over the packages files
     (cd ${DOCKER_SERVER_DIR}/../../target; rsync -R */package/* ${DOCKER_SERVER_DIR}/target)
   else

--- a/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
+++ b/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
@@ -6,8 +6,6 @@ server {
 
   gzip_static on; # nginx will automatically search for a .gz version of a file and serve it if it exists
 
-  set $dcos_release_version 1.6.1;
-
   set $serve_json false;
 
   if ($http_accept ~ ".*application/vnd\.dcos\.universe\.repo\+json;charset=utf-8;version=v3.*") {
@@ -57,7 +55,7 @@ server {
     set $dcos_release_version 1.13;
   }
 
-  if ($http_user_agent ~ ".*dcos\/1\.14.*") {
+  if ($http_user_agent ~ ".*dcos\/2\.0.*") {
     set $dcos_release_version 2.0;
   }
 

--- a/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
+++ b/docker/server/nginx/etc/nginx/conf.d/universe.marathon.mesos.conf
@@ -31,7 +31,7 @@ server {
   # We assume a user is running the latest DC/OS if their User-Agent is unknown
   # Historically, we assumed 1.6.1 until its deprecation.
   # User-Agent was added to cosmos in DC/OS Release 1.8
-  set $dcos_release_version 1.14;
+  set $dcos_release_version 2.0;
 
   if ($http_user_agent ~ ".*dcos\/1\.8.*") {
     set $dcos_release_version 1.8;
@@ -58,7 +58,7 @@ server {
   }
 
   if ($http_user_agent ~ ".*dcos\/1\.14.*") {
-    set $dcos_release_version 1.14;
+    set $dcos_release_version 2.0;
   }
 
 

--- a/scripts/gen_universe.py
+++ b/scripts/gen_universe.py
@@ -5,6 +5,7 @@ import argparse
 import base64
 import collections
 import copy
+import git
 import itertools
 import json
 import jsonschema
@@ -16,8 +17,8 @@ import re
 import zipfile
 
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-schema_dir = os.environ.get("SCHEMA_DIR", "{}/../repo/meta/schema/".format(dir_path))
+project_dir = "{}/..".format(os.path.dirname(os.path.realpath(__file__)))
+schema_dir = os.environ.get("SCHEMA_DIR", "{}/repo/meta/schema/".format(project_dir))
 repo_definitions_json = "{}/vX-repo-definitions.json".format(schema_dir)
 
 
@@ -52,6 +53,10 @@ def main():
         print('The path in --repository [{}] is not a directory.'.format(
             args.repository))
         return
+    else:
+        global git_repo
+        git_repo = git.Git(project_dir)
+        print("universe git repo detected at {}".format(project_dir))    
 
     packages = [
         generate_package_from_path(
@@ -76,12 +81,10 @@ def main():
     ct_empty_path = args.outdir / 'repo-empty-v3.content_type'
     create_content_type_file(ct_empty_path, "v3")
 
-    zip_file_dcos_versions = ["1.6.1", "1.7"]
-    json_file_dcos_versions = ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13", "1.14"]
-    # create universe-by-version files for `dcos_versions`
-    dcos_versions = zip_file_dcos_versions + json_file_dcos_versions
+    json_file_dcos_versions = ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13", "2.0"]
+    # create universe-by-version files for `json_file_dcos_versions`
     [render_universe_by_version(
-        args.outdir, copy.deepcopy(packages), version) for version in dcos_versions]
+        args.outdir, copy.deepcopy(packages), version) for version in json_file_dcos_versions]
     for dcos_version in json_file_dcos_versions:
         _populate_dcos_version_json_to_folder(dcos_version, args.outdir)
 
@@ -106,8 +109,8 @@ def get_universe_version_for_dcos(dcos_version):
 
 
 def render_universe_by_version(outdir, packages, version):
-    """Render universe packages for `version`. Zip files for versions < 1.8,
-    and json files for version >= 1.8
+    """Render universe packages for `version`. Zip files for versions < 1.8
+    are no longer updated. Use json files for version >= 1.8
 
     :param outdir: Path to the directory to use to store all universe objects
     :type outdir: str
@@ -119,7 +122,7 @@ def render_universe_by_version(outdir, packages, version):
     """
 
     if LooseVersion(version) < LooseVersion("1.8"):
-        render_zip_universe_by_version(outdir, packages, version)
+        print("zip based universe files are no longer maintained")
     else:
         file_path = render_json_by_version(outdir, packages, version)
         _validate_repo(file_path, version)
@@ -234,31 +237,6 @@ def filter_and_downgrade_packages_by_version(packages, version):
     return packages
 
 
-def render_zip_universe_by_version(outdir, packages, version):
-    """Render zip universe for `version`
-
-    :param outdir: Path to the directory to use to store all universe objects
-    :type outdir: str
-    :param package: package dictionary
-    :type package: dict
-    :param version: DC/OS version
-    :type version: str
-    :rtype: None
-    """
-
-    with tempfile.NamedTemporaryFile() as temp_file:
-        with zipfile.ZipFile(temp_file, mode='w') as zip_file:
-            render_universe_zip(
-                zip_file,
-                filter(
-                    lambda package: filter_by_version(package, version),
-                    packages)
-            )
-
-        zip_name = 'repo-up-to-{}.zip'.format(version)
-        shutil.copy(temp_file.name, str(outdir / zip_name))
-
-
 def filter_by_version(package, version):
     """Prediate for checking for packages of version `version` or less
 
@@ -304,10 +282,18 @@ def read_package(path):
     :rtype: dict
     """
 
-    path = path / 'package.json'
+    package_json_path = path / 'package.json'
 
-    with path.open(encoding='utf-8') as file_object:
-        return json.load(file_object)
+    with package_json_path.open(encoding='utf-8') as file_object:
+        package_json = json.load(file_object)
+
+        # Update the `lastUpdated` field in the `package.json` if it is not already present.
+        if (LooseVersion(package_json.get('packagingVersion', '0.0')) >= LooseVersion("3.0")) \
+                and ("lastUpdated" not in package_json):
+            last_updated = git_repo.log("-1", '--date=unix', '--format=%cd', '--', path)
+            if last_updated:
+                package_json["lastUpdated"] = int(last_updated)
+        return package_json
 
 
 def read_resource(path):
@@ -454,174 +440,6 @@ def enumerate_dcos_packages(packages_path):
                 yield (package.name, int(release_version.name))
 
 
-def render_universe_zip(zip_file, packages):
-    """Populates a zipfile from a list of universe v3 packages. This function
-    creates directories to be backwards compatible with legacy Cosmos.
-
-    :param zip_file: zipfile where we need to write the packages
-    :type zip_file: zipfile.ZipFile
-    :param packages: list of packages
-    :type packages: [dict]
-    :rtype: None
-    """
-
-    packages = sorted(
-        packages,
-        key=lambda package: (package['name'], package['releaseVersion']))
-
-    root = pathlib.Path('universe')
-
-    create_dir_in_zip(zip_file, root)
-
-    create_dir_in_zip(zip_file, root / 'repo')
-
-    create_dir_in_zip(zip_file, root / 'repo' / 'meta')
-    zip_file.writestr(
-        str(root / 'repo' / 'meta' / 'index.json'),
-        json.dumps(create_index(packages)))
-
-    zip_file.writestr(
-        str(root / 'repo' / 'meta' / 'version.json'),
-        json.dumps({'version': '2.0.0'}))
-
-    packagesDir = root / 'repo' / 'packages'
-    create_dir_in_zip(zip_file, packagesDir)
-
-    currentLetter = ''
-    currentPackageName = ''
-    for package in packages:
-        if currentLetter != package['name'][:1].upper():
-            currentLetter = package['name'][:1].upper()
-            create_dir_in_zip(zip_file, packagesDir / currentLetter)
-
-        if currentPackageName != package['name']:
-            currentPackageName = package['name']
-            create_dir_in_zip(
-                zip_file,
-                packagesDir / currentLetter / currentPackageName)
-
-        package_directory = (
-            packagesDir /
-            currentLetter /
-            currentPackageName /
-            str(package['releaseVersion'])
-        )
-        create_dir_in_zip(zip_file, package_directory)
-
-        write_package_in_zip(zip_file, package_directory, package)
-
-
-def create_dir_in_zip(zip_file, directory):
-    """Create a directory in a zip file
-
-    :param zip_file: zip file where the directory will get created
-    :type zip_file: zipfile.ZipFile
-    :param directory: path for the directory
-    :type directory: pathlib.Path
-    :rtype: None
-    """
-
-    zip_file.writestr(str(directory) + '/', b'')
-
-
-def write_package_in_zip(zip_file, path, package):
-    """Write packages files in the zip file
-
-    :param zip_file: zip file where the files will get created
-    :type zip_file: zipfile.ZipFile
-    :param path: path for the package directory. E.g.
-                 universe/repo/packages/M/marathon/0
-    :type path: pathlib.Path
-    :param package: package information dictionary
-    :type package: dict
-    :rtype: None
-    """
-
-    package = downgrade_package_to_v2(package)
-
-    package.pop('releaseVersion')
-
-    resource = package.pop('resource', None)
-    if resource:
-        zip_file.writestr(
-            str(path / 'resource.json'),
-            json.dumps(resource))
-
-    marathon_template = package.pop(
-        'marathon',
-        {}
-    ).get(
-        'v2AppMustacheTemplate'
-    )
-    if marathon_template:
-        zip_file.writestr(
-            str(path / 'marathon.json.mustache'),
-            base64.standard_b64decode(marathon_template))
-
-    config = package.pop('config', None)
-    if config:
-        zip_file.writestr(
-            str(path / 'config.json'),
-            json.dumps(config))
-
-    command = package.pop('command', None)
-    if command:
-        zip_file.writestr(
-            str(path / 'command.json'),
-            json.dumps(command))
-
-    zip_file.writestr(
-        str(path / 'package.json'),
-        json.dumps(package))
-
-
-def create_index(packages):
-    """Create an index for all of the packages
-
-    :param packages: list of packages
-    :type packages: [dict]
-    :rtype: dict
-    """
-
-    index = {
-        'version': '2.0.0',
-        'packages': [
-            create_index_entry(same_packages)
-            for _, same_packages
-            in itertools.groupby(packages, key=lambda package: package['name'])
-        ]
-    }
-
-    return index
-
-
-def create_index_entry(packages):
-    """Create index entry from packages with the same name.
-
-    :param packages: list of packages with the same name
-    :type packages: [dict]
-    :rtype: dict
-    """
-
-    entry = {
-        'versions': {}
-    }
-
-    for package in packages:
-        entry.update({
-            'name': package['name'],
-            'currentVersion': package['version'],
-            'description': package['description'],
-            'framework': package.get('framework', False),
-            'tags': package['tags'],
-            'selected': package.get('selected', False)
-        })
-
-        entry['versions'][package['version']] = str(package['releaseVersion'])
-
-    return entry
-
-
 def v3_to_v2_package(v3_package):
     """Converts a v3 package to a v2 package
 
@@ -657,25 +475,6 @@ def v4_to_v3_package(v4_package):
     package.pop('downgradesTo', None)
     package["packagingVersion"] = "3.0"
     return package
-
-
-def downgrade_package_to_v2(package):
-    """Converts a v4 or v3 package to a v2 package. If given a v2
-    package, it creates a deep copy but does not modify it. It does not
-    modify the original package.
-
-    :param package: v4, v3, or v2 package
-    :type package: dict
-    :return: a v2 package
-    :rtyte: dict
-    """
-    packaging_version = package.get("packagingVersion")
-    if packaging_version == "2.0":
-        return copy.deepcopy(package)
-    elif packaging_version == "3.0":
-        return v3_to_v2_package(package)
-    else:
-        return v3_to_v2_package(v4_to_v3_package(package))
 
 
 def downgrade_package_to_v3(package):
@@ -769,7 +568,7 @@ def _validate_repo(file_path, version):
         sys.exit(
             'ERROR\n\nRepo {} version {} validation errors: {}'.format(
                 file_path,
-                repo_version,
+                version,
                 '\n'.join(errors)
             )
         )

--- a/scripts/requirements/requirements.txt
+++ b/scripts/requirements/requirements.txt
@@ -1,2 +1,3 @@
 jsonschema==2.6.0
 pystache==0.5.4
+gitpython==3.0.2


### PR DESCRIPTION
This PR brings the following changes
- Add support for auto addition of `lastUpdated` field (if not already present).
- Stop updating zip files for DC/OS versions 1.6.1 and 1.7 (Previous URLs would continue to work - we just stop updating them with new packages)
- Rename 1.14 to 2.0
