### PR TITLE
Update sysdig-cloud CPU spec

### DIFF
--- a/repo/packages/S/sysdig-cloud/0/config.json
+++ b/repo/packages/S/sysdig-cloud/0/config.json
@@ -28,9 +28,9 @@
                     "type": "string"
                 },
                 "cpus": {
-                    "default": 0.05,
+                    "default": 1,
                     "description": "CPU (shares) to allocate to each Sysdig Cloud agent task",
-                    "minimum": 0.05,
+                    "minimum": 1,
                     "type": "number"
                 },
                 "instances": {

--- a/repo/packages/S/sysdig-cloud/1/config.json
+++ b/repo/packages/S/sysdig-cloud/1/config.json
@@ -44,9 +44,9 @@
                     "type": "boolean"
                 },
                 "cpus": {
-                    "default": 0.05,
+                    "default": 1,
                     "description": "CPU (shares) to allocate to each Sysdig Cloud agent task",
-                    "minimum": 0.05,
+                    "minimum": 1,
                     "type": "number"
                 },
                 "instances": {


### PR DESCRIPTION
The current documentation for Sysdig Cloud suggests allocating a CPU.
This change updates the spec to match the documentation.

https://sysdigdocs.atlassian.net/wiki/spaces/Platform/pages/192348168/Agent+Install+Mesos+Marathon+DCOS