### PR TITLE
Update build definition schema for package registry CLI

### DIFF
--- a/repo/meta/schema/build-definition-schema.json
+++ b/repo/meta/schema/build-definition-schema.json
@@ -304,6 +304,14 @@
           "$ref": "#/definitions/dcosReleaseVersion",
           "description": "The minimum DC/OS Release Version the package can run on."
         },
+        "hasKnownIssues": {
+          "type": "boolean",
+          "description": "Boolean field indicating if the package has any known issues."
+        },
+        "lastUpdated": {
+          "type": "number",
+          "description": "A unix epoch depicting the last updated date of the package base tech"
+        },
         "marathon": {
           "$ref": "#/definitions/marathon"
         },
@@ -421,6 +429,14 @@
           "$ref": "#/definitions/dcosReleaseVersion",
           "description": "The minimum DC/OS Release Version the package can run on."
         },
+        "hasKnownIssues": {
+          "type": "boolean",
+          "description": "Boolean field indicating if the package has any known issues."
+        },
+        "lastUpdated": {
+          "type": "number",
+          "description": "A unix epoch depicting the last updated date of the package base tech"
+        },
         "marathon": {
           "$ref": "#/definitions/marathon"
         },
@@ -531,6 +547,14 @@
           "required": [
             "packageName"
           ]
+        },
+        "hasKnownIssues": {
+          "type": "boolean",
+          "description": "Boolean field indicating if the package has any known issues."
+        },
+        "lastUpdated": {
+          "type": "number",
+          "description": "A unix epoch depicting the last updated date of the package base tech"
         },
         "marathon": {
           "$ref": "#/definitions/marathon"


### PR DESCRIPTION
This PR updates the build def schema that is used in package registry CLI. I forgot to update this in previous PR (#2387). 