### PR TITLE
Update helloworld package with new CLI binaries

### DIFF
--- a/repo/packages/H/helloworld/0/command.json
+++ b/repo/packages/H/helloworld/0/command.json
@@ -1,6 +1,0 @@
-{
-  "pip": [
-    "dcos<1.0",
-    "git+https://github.com/mesosphere/dcos-helloworld.git#dcos-helloworld=0.1.0"
-  ]
-}

--- a/repo/packages/H/helloworld/0/package.json
+++ b/repo/packages/H/helloworld/0/package.json
@@ -1,5 +1,6 @@
 {
   "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.9",
   "name": "helloworld",
   "version": "0.1.0",
   "website": "https://github.com/mesosphere/dcos-helloworld",

--- a/repo/packages/H/helloworld/0/resource.json
+++ b/repo/packages/H/helloworld/0/resource.json
@@ -1,0 +1,42 @@
+{
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "f0028105a0bea830d5bdc9f07a3f9c9c3af433a016a6bf1b7921cf646e397376"
+            }
+          ],
+          "kind": "zip",
+          "url": "https://github.com/dcos/dcos-http-cli/releases/download/0.1.0/dcos-http-cli.darwin.zip"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "a0a59e0fe4949b96fe3062a6cfa5e6548aa3b43160f9abe354b41676eb5b98c6"
+            }
+          ],
+          "kind": "zip",
+          "url": "https://github.com/dcos/dcos-http-cli/releases/download/0.1.0/dcos-http-cli.linux.zip"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "3ee8ac318abb9c23b67a55e8758419a6d99828c3b60d5dc22546da9bdbcea9f2"
+            }
+          ],
+          "kind": "zip",
+          "url": "https://github.com/dcos/dcos-http-cli/releases/download/0.1.0/dcos-http-cli.windows.zip"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Old version used legacy and now unsupported Python plugins. We need to update it in order to run integration tests.

Fixes: [DCOS_OSS-5539](https://jira.mesosphere.com/browse/DCOS_OSS-5539)
Refs: https://github.com/dcos/dcos-core-cli/pull/382