### PR TITLE
Use downloads.mesosphere.io since Github releases aren't working with Cosmos

### DIFF
--- a/repo/packages/H/helloworld/0/resource.json
+++ b/repo/packages/H/helloworld/0/resource.json
@@ -6,11 +6,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "f0028105a0bea830d5bdc9f07a3f9c9c3af433a016a6bf1b7921cf646e397376"
+              "value": "7f06eb113794b9e021fb396b65c18c9f2b426a6c2443c0444e359c4be7a6dc89"
             }
           ],
           "kind": "zip",
-          "url": "https://github.com/dcos/dcos-http-cli/releases/download/0.1.0/dcos-http-cli.darwin.zip"
+          "url": "https://gitlab.com/janisz/dcos-http-cli/uploads/36c122df16f0a43015d766ddeb27ba7d/dcos-http-cli.darwin.zip"
         }
       },
       "linux": {
@@ -18,11 +18,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "a0a59e0fe4949b96fe3062a6cfa5e6548aa3b43160f9abe354b41676eb5b98c6"
+              "value": "b0f3347d576d82837a794e108490520ca47535a1f6fdbc967b3850fb0d06e374"
             }
           ],
           "kind": "zip",
-          "url": "https://github.com/dcos/dcos-http-cli/releases/download/0.1.0/dcos-http-cli.linux.zip"
+          "url": "https://gitlab.com/janisz/dcos-http-cli/uploads/739523426139bd74e4c0cd64f6f32619/dcos-http-cli.linux.zip"
         }
       },
       "windows": {
@@ -30,11 +30,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "3ee8ac318abb9c23b67a55e8758419a6d99828c3b60d5dc22546da9bdbcea9f2"
+              "value": "0d801d0616d42b03f2308e7bcd93b33ed2515bb3de2a611cb0b9a734720890ca"
             }
           ],
           "kind": "zip",
-          "url": "https://github.com/dcos/dcos-http-cli/releases/download/0.1.0/dcos-http-cli.windows.zip"
+          "url": "https://gitlab.com/janisz/dcos-http-cli/uploads/198addb5390343be900546cd93e86047/dcos-http-cli.windows.zip"
         }
       }
     }

--- a/repo/packages/H/helloworld/0/resource.json
+++ b/repo/packages/H/helloworld/0/resource.json
@@ -10,7 +10,7 @@
             }
           ],
           "kind": "zip",
-          "url": "https://gitlab.com/janisz/dcos-http-cli/uploads/36c122df16f0a43015d766ddeb27ba7d/dcos-http-cli.darwin.zip"
+          "url": "https://downloads.mesosphere.io/dcos-http-cli/0.1.0/dcos-http-cli.darwin.zip"
         }
       },
       "linux": {
@@ -22,7 +22,7 @@
             }
           ],
           "kind": "zip",
-          "url": "https://gitlab.com/janisz/dcos-http-cli/uploads/739523426139bd74e4c0cd64f6f32619/dcos-http-cli.linux.zip"
+          "url": "https://downloads.mesosphere.io/dcos-http-cli/0.1.0/dcos-http-cli.linux.zip"
         }
       },
       "windows": {
@@ -34,7 +34,7 @@
             }
           ],
           "kind": "zip",
-          "url": "https://gitlab.com/janisz/dcos-http-cli/uploads/198addb5390343be900546cd93e86047/dcos-http-cli.windows.zip"
+          "url": "https://downloads.mesosphere.io/dcos-http-cli/0.1.0/dcos-http-cli.windows.zip"
         }
       }
     }


### PR DESCRIPTION
Github return 403 on HEAD requests that's why we need to switch to our mesosphere.downloads.io.

Refs:
* https://gitlab.com/janisz/dcos-http-cli/-/tags/0.1.0
* https://twitter.com/janiszt/status/1186300349956550656