### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+/repo/packages/D/dcos-core-cli/ @janisz @makkes @drewvanstone @br-lewis
+/repo/packages/D/dcos-enterprise-cli/ @janisz @makkes @drewvanstone @br-lewis


### PR DESCRIPTION
This makes reviews easier by automatically requesting appropriate maintainers for updated packages.

It also adds maintainers for CLI packages.