### PR TITLE
Make mysql local volume persist data

### DIFF
--- a/repo/packages/M/mysql/6/config.json
+++ b/repo/packages/M/mysql/6/config.json
@@ -1,0 +1,148 @@
+{
+	"properties": {
+		"service": {
+			"type": "object",
+			"description": "DC/OS service configuration properties",
+			"properties": {
+				"name": {
+					"description": "Name of this service instance",
+					"type": "string",
+					"default": "mysql"
+				}
+			}
+		},
+		"mysql": {
+			"type": "object",
+			"description": "MySQL service configuration properties",
+			"properties": {
+				"cpus": {
+					"description": "CPU shares to allocate to each service instance.",
+					"type": "number",
+					"default": 0.5,
+					"minimum": 0.5
+				},
+				"mem": {
+					"description":  "Memory to allocate to each service instance.",
+					"type": "number",
+					"default": 1024.0,
+					"minimum": 512.0
+				}
+			},
+			"required": [
+				"cpus",
+				"mem"
+			]
+		},
+		"database": {
+			"type": "object",
+			"description": "MySQL database configuration properties",
+			"properties":{
+				"name": {
+					"description": "The name of a database to be created on startup.",
+					"type": "string",
+					"default": "defaultdb"
+				},
+				"username": {
+					"description": "The username of a user to be created with superuser access to this database only.",
+					"type": "string",
+					"default": "admin"
+				},
+				"password": {
+					"description": "The password for a user to be created with superuser access to this database only.",
+					"type": "string",
+					"default": "password"
+				},
+				"root_password": {
+					"description": "Specifies the password that will be set for the MySQL root superuser account.",
+					"type": "string",
+					"default": "root"
+				}
+			}
+		},
+		"storage": {
+			"type": "object",
+			"description": "MySQL storage configuration properties",
+			"properties":{
+				"host_volume": {
+					"description": "If using non-persistent volumes (local volumes), this sets the location of a volume on the host to be used for the service. The final location will be derived from this value plus the name set in `name` (e.g. `/mnt/host_volume/service_name`). This can be a mounted NFS drive. Note that this path must be the same on all DC/OS agents. NOTE: if you don't change the default /tmp value, YOUR DATA WILL NOT BE SAVED IN ANY WAY.",
+					"type": "string",
+					"default": "/tmp"
+				},    
+				"persistence": {
+					"type": "object",
+					"description": "Enable persistent storage.",
+					"properties": {    
+						"enable": {
+							"description": "Enable or disable persistent storage.",
+							"type": "boolean",
+							"default": false                    
+						},
+						"volume_size": {
+							"description": "If a new volume is to be created, this controls its size in MBs.",
+							"type": "number",
+							"default": 256
+						},
+						"external": {
+							"type": "object",
+							"description": "External persistent storage properties",
+								"properties":{   
+									"enable": {
+										"description": "Enable or disable external persistent storage. The `persistence` option must also be selected. Please note that for these to work, your DC/OS cluster MUST have been installed with the right options in `config.yaml`. Also, please note this requires a working  configuration file for the driver (e.g. `rexray.yaml`).",
+										"type": "boolean",
+										"default": false                    
+									},
+									"volume_name": {
+										"description": "Name that your volume driver uses to look up your external volume. When your task is staged on an agent, the volume driver queries the storage service for a volume with this name. If one does not exist, it is created implicitly. Otherwise, the existing volume is reused.",
+										"type": "string",
+										"default": "mysql"
+									},
+									"provider": {
+										"description": "Provider of the external persistent volume. The default value should be correct for most use cases.",
+										"type": "string",
+										"default": "dvdi"
+									},
+									"driver": {
+										"description": "Volume driver to use for storage. The default value should be correct for most use cases.",
+										"type": "string",
+										"default": "rexray"
+									}
+								}
+						}
+					}
+				}
+			}
+		},
+		"networking": {
+			"type": "object",
+			"description": "MySQL networking configuration properties",
+			"properties": {    
+				"port": {
+					"description": "Port number to be used for clear communication internally to the cluster. Currently unused and fixed to be 3306.",
+					"type": "number",
+					"default": 3306
+				},  
+				"host_mode": {
+						"description": "Enable or disable host networking mode. NOTE: this requires the default port to be available on the target host. This also forces to have a single instance per node.",
+						"type": "boolean",
+						"default": false                    
+				},
+				"external_access": {
+					"type": "object",
+					"description": "Enable access from outside the cluster through Marathon-LB.\nNOTE: this connection is unencrypted.",
+						"properties": {    
+							"enable": {
+								"description": "Enable or disable creating a VIP for external access through a public node running Marathon-LB.",
+								"type": "boolean",
+								"default": false                    
+							},
+							"external_access_port": {
+								"description": "For external access, port number to be used for clear communication in the external Marathon-LB load balancer",
+								"type": "number",
+								"default": 13306
+							}
+						}
+					}
+			}      
+		}
+	}
+}

--- a/repo/packages/M/mysql/6/marathon.json.mustache
+++ b/repo/packages/M/mysql/6/marathon.json.mustache
@@ -1,0 +1,111 @@
+{
+  "id": "{{service.name}}",
+  "cpus": {{mysql.cpus}},
+  "mem": {{mysql.mem}},
+  "instances": 1,
+  "env": {
+    "MYSQL_DATABASE": "{{database.name}}",
+    "MYSQL_USER": "{{database.username}}",
+    "MYSQL_PASSWORD": "{{database.password}}",
+    "MYSQL_ROOT_PASSWORD": "{{database.root_password}}",
+    "MYSQL_CONTEXT": "/service/{{service.name}}"
+  },
+  "container": {
+    "type": "DOCKER",
+    "volumes": [{
+      {{^storage.persistence.enable}}
+      "containerPath": "/var/lib/mysql/",
+      "hostPath": "{{storage.host_volume}}/{{service.name}}",
+      {{/storage.persistence.enable}}
+      {{#storage.persistence.enable}}
+      {{^storage.persistence.external.enable}}
+      "containerPath": "var",
+      "persistent": {
+        "size": {{storage.persistence.volume_size}}
+      },
+      {{/storage.persistence.external.enable}}
+      {{#storage.persistence.external.enable}}
+      "containerPath": "/var/lib/mysql",
+      "external": {
+        "name": "{{storage.persistence.external.volume_name}}",
+        "provider": "{{storage.persistence.external.provider}}",
+        "options": { "dvdi/driver": "{{storage.persistence.external.driver}}" }
+      },
+      {{/storage.persistence.external.enable}}
+      {{/storage.persistence.enable}}
+      "mode": "RW"
+      {{#storage.persistence.enable}}
+      {{^storage.persistence.external.enable}}
+      },
+      {
+        "containerPath": "/var/lib/mysql",
+        "hostPath": "var",
+        "mode": "RW"
+      {{/storage.persistence.external.enable}}
+      {{/storage.persistence.enable}}
+    }],
+    "docker": {
+      "image": "{{resource.assets.container.docker.mysql-docker}}",
+      {{#networking.host_mode}}
+      "network": "HOST",
+      {{/networking.host_mode}}            
+      {{^networking.host_mode}}
+      "network": "BRIDGE",
+      "portMappings": [{
+        "containerPort": 3306,
+        "hostPort": 0,
+        {{#networking.external_access.enable}}
+        "servicePort": {{networking.external_access.external_access_port}},
+        {{/networking.external_access.enable}}
+        "protocol": "tcp",
+        "name": "mysql",
+        "labels": {
+          "VIP_0": "/{{service.name}}:{{networking.port}}"
+        }
+      }],
+      {{/networking.host_mode}}
+      "forcePullImage": false
+    }
+  },
+  {{#networking.host_mode}}
+  "portDefinitions": [{
+      "protocol": "tcp",
+      "port": 3306,
+      "name": "mysql",
+      {{#networking.external_access.enable}}
+      "servicePort": {{networking.external_access.external_access_port}},
+      {{/networking.external_access.enable}}
+      "labels": {
+        "VIP_0": "/{{service.name}}:{{networking.port}}"
+      }
+  }],
+  "requirePorts": true,
+  "constraints": [["hostname", "UNIQUE"]],
+  {{/networking.host_mode}}
+  "healthChecks": [{
+    "protocol": "TCP",
+    {{#networking.host_mode}}
+    "port": 3306,
+    {{/networking.host_mode}}
+    {{^networking.host_mode}}
+    "portIndex": 0,
+    {{/networking.host_mode}}    
+    "gracePeriodSeconds": 300,
+    "intervalSeconds": 60,
+    "timeoutSeconds": 20,
+    "maxConsecutiveFailures": 3
+  }],
+  "labels": {
+    "DCOS_PACKAGE_VERSION": "5.7.12-0.3",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    {{#networking.external_access.enable}}
+    "HAPROXY_GROUP": "external",
+    {{/networking.external_access.enable}}
+    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
+  },
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/M/mysql/6/package.json
+++ b/repo/packages/M/mysql/6/package.json
@@ -1,0 +1,21 @@
+{
+  "packagingVersion": "3.0",
+  "minDcosReleaseVersion": "1.7",
+  "name": "mysql",
+  "version": "5.7.12-0.3",
+  "scm": "https://github.com/mysql/mysql-server.git",
+  "maintainer": "https://dcos.io/community/",
+  "website": "https://mysql-ci.org",
+  "description": "MySQL is the world's most popular open source database. With its proven performance, reliability and ease-of-use, MySQL has become the leading database choice for web-based applications, covering the entire range from personal projects and websites, via e-commerce and information services, all the way to high profile web properties including Facebook, Twitter, YouTube, Yahoo! and many more.",
+  "tags": ["database", "mysql", "sql"],
+  "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies.\n\n```Advanced Installation options notes```\n\nstorage / *persistence*: create local persistent volumes for internal storage files to survive across restarts or failures.\n\nstorage / persistence / *external*: create external persistent volumes. This allows to use an external storage system such as Amazon EBS, OpenStack Cinder, EMC Isilon, EMC ScaleIO, EMC XtremIO, EMC VMAX and Google Compute Engine persistent storage. *NOTE*: To use external volumes with DC/OS, you MUST enable them during CLI or Advanced installation.\n\nstorage / *host_volume*:  if persistence is not selected, this package can use a local volume in the host for storage, like a local directory or an NFS mount. The parameter *host_volume* controls the path in the host in which these volumes will be created, which MUST be the same on all nodes of the cluster.\n\nNOTE: If you didn't select persistence in the storage section, or provided a valid value for *host_volume* on installation,\nYOUR DATA WILL NOT BE SAVED IN ANY WAY.\n\nnetworking / *port*: This DC/OS service can be accessed from any other application through a NAMED VIP in the format *`service_name.marathon.l4lb.thisdcos.directory:port`*. Check status of the VIP in the *Network* tab of the DC/OS Dashboard (Enterprise DC/OS only).\n\nnetworking / *external_access*: create an entry in Marathon-LB for accessing the service from outside of the cluster\n\nnetworking / *external_access_port*: port to be used in Marathon-LB for accessing the service.",
+ "postInstallNotes": "Service installed.\n\nDefault login: `admin`/`password`. This username/password combination only applies if you haven't changed the defaults.",
+ "postUninstallNotes": "Service uninstalled. Note that any persisting data still exists and will need to be manually removed.",
+  "licenses": [
+    {
+      "name": "GNU GENERAL PUBLIC LICENSE",
+      "url": "https://github.com/mysql/mysql-server/blob/5.7/COPYING"
+    }
+  ],
+  "lastUpdated": 1491426142
+}

--- a/repo/packages/M/mysql/6/resource.json
+++ b/repo/packages/M/mysql/6/resource.json
@@ -1,0 +1,14 @@
+{
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/mysql-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/mysql-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/mysql-icon-large.png"
+  },
+  "assets": {
+    "container": {
+      "docker": {
+        "mysql-docker": "mysql:5.7.12"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently, when `storage.persistence.enable` is enabled, we use the containerPath `var` to persist data. However, mysql does not write data to this directory, but instead, still writing to `/var/lib/data`.  So, after rebooting, the data will get lost.   The fix is based on https://docs.d2iq.com/mesosphere/dcos/1.12/storage/persistent-volume/#stateful-mysql-on-marathon