### PR TITLE
feat(dcos-ui): add 2.83.1 dcos-ui version

### DIFF
--- a/repo/packages/D/dcos-ui/3/package.json
+++ b/repo/packages/D/dcos-ui/3/package.json
@@ -1,0 +1,23 @@
+{
+  "packagingVersion": "4.0",
+  "name": "dcos-ui",
+  "version": "2.83.1",
+  "tags": [
+    "dcos-ui",
+    "dcos",
+    "ui"
+  ],
+  "maintainer": "frontend-dev@mesosphere.io",
+  "description": "DC/OS UI",
+  "scm": "https://github.com/dcos/dcos-ui",
+  "website": "https://dcos.io/",
+  "framework": false,
+  "minDcosReleaseVersion": "1.13",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/dcos/dcos-ui/master/LICENSE"
+    }
+  ],
+  "lastUpdated": 1574252033
+}

--- a/repo/packages/D/dcos-ui/3/resource.json
+++ b/repo/packages/D/dcos-ui/3/resource.json
@@ -1,0 +1,7 @@
+{
+  "assets": {
+    "uris": {
+      "dcos-ui-bundle": "https://downloads.mesosphere.io/dcos-ui/1.13%2Bdcos-ui-enterprise-v2.83.1%2B5aaebdd4.tar.gz"
+    }
+  }
+}


### PR DESCRIPTION
This adds the latest DC/OS ui version release to the universe for 1.13.