### PR TITLE
Move from Docker to UCR for Confluent Replicator

### DIFF
--- a/repo/packages/C/confluent-replicator/200/marathon.json.mustache
+++ b/repo/packages/C/confluent-replicator/200/marathon.json.mustache
@@ -6,7 +6,7 @@
   "user": "{{replicator.user}}",
   "maintainer": "partner-support@confluent.io", 
   "container": {
-    "type": "DOCKER",
+    "type": "MESOS",
     "docker": {
       {{^replicator.virtual_network_enabled}}
       "network": "BRIDGE",


### PR DESCRIPTION
All other Confluent components use the UCR instead of Docker. Setting this to UCR allows us to monitor the memory usage for example too. Tested and verified on our test and production clusters.