### PR TITLE
add DCOS-UI 2.83.3

### DIFF
--- a/repo/packages/D/dcos-ui/3/package.json
+++ b/repo/packages/D/dcos-ui/3/package.json
@@ -1,0 +1,23 @@
+{
+  "packagingVersion": "4.0",
+  "name": "dcos-ui",
+  "version": "2.83.3",
+  "tags": [
+    "dcos-ui",
+    "dcos",
+    "ui"
+  ],
+  "maintainer": "frontend-dev@mesosphere.io",
+  "description": "DC/OS UI",
+  "scm": "https://github.com/dcos/dcos-ui",
+  "website": "https://dcos.io/",
+  "framework": false,
+  "minDcosReleaseVersion": "1.13",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/dcos/dcos-ui/master/LICENSE"
+    }
+  ],
+  "lastUpdated": 1575633796
+}

--- a/repo/packages/D/dcos-ui/3/resource.json
+++ b/repo/packages/D/dcos-ui/3/resource.json
@@ -1,0 +1,7 @@
+{
+  "assets": {
+    "uris": {
+      "dcos-ui-bundle": "https://downloads.mesosphere.io/dcos-ui/1.13%2Bdcos-ui-enterprise-v2.83.3%2B5aaebdd4.tar.gz"
+    }
+  }
+}


### PR DESCRIPTION
This release of DCOS-UI fixes a couple issues, most notably a
performance issue that rendered the ServicesTable unusable on large
instances (with a lot of groups).
