### PR TITLE
Revert "[DCOS-61537] Change container type to MESOS in replicator"

### DIFF
--- a/repo/packages/C/confluent-replicator/200/marathon.json.mustache
+++ b/repo/packages/C/confluent-replicator/200/marathon.json.mustache
@@ -6,14 +6,11 @@
   "user": "{{replicator.user}}",
   "maintainer": "partner-support@confluent.io", 
   "container": {
-    "type": "MESOS",
+    "type": "DOCKER",
     "docker": {
-      "image": "{{resource.assets.container.docker.image}}",
-      "forcePullImage": true
-    },
-    {{^replicator.virtual_network_enabled}}
+      {{^replicator.virtual_network_enabled}}
       "network": "BRIDGE",
-    {{/replicator.virtual_network_enabled}} 
+      {{/replicator.virtual_network_enabled}} 
       "portMappings": [ {
           "containerPort": 8083,
           "hostPort": 0,
@@ -21,7 +18,10 @@
           "labels": {
             "VIP_0": "{{replicator.name}}:8083"
           }
-      } ]
+      } ],
+      "image": "{{resource.assets.container.docker.image}}",
+      "forcePullImage": true
+    }
   },
   {{#replicator.virtual_network_enabled}}
   "networks": [


### PR DESCRIPTION
Reverts mesosphere/universe#2453 as the customer faced a broken replicator when running it in non VN mode.