### PR TITLE
[DCOS-62649] Migrate 'spinnaker' assets to downloads.mesosphere.com

### DIFF
--- a/repo/packages/S/spinnaker/0/resource.json
+++ b/repo/packages/S/spinnaker/0/resource.json
@@ -15,7 +15,7 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
-      "scheduler-zip": "https://mbgl-bucket.s3.amazonaws.com/spinnaker/assets/0.1.0-1.4.2/spinnaker-scheduler.zip",
+      "scheduler-zip": "https://downloads.mesosphere.com/spinnaker/assets/0.1.0-1.4.2/spinnaker-scheduler.zip",
       "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.30.2/executor.zip",
       "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.30.2/bootstrap.zip"
     }
@@ -36,7 +36,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://mbgl-bucket.s3.amazonaws.com/spinnaker/assets/0.1.0-1.4.2/dcos-service-cli-darwin"
+          "url": "https://downloads.mesosphere.com/spinnaker/assets/0.1.0-1.4.2/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -48,7 +48,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://mbgl-bucket.s3.amazonaws.com/spinnaker/assets/0.1.0-1.4.2/dcos-service-cli-linux"
+          "url": "https://downloads.mesosphere.com/spinnaker/assets/0.1.0-1.4.2/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -60,7 +60,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://mbgl-bucket.s3.amazonaws.com/spinnaker/assets/0.1.0-1.4.2/dcos-service-cli.exe"
+          "url": "https://downloads.mesosphere.com/spinnaker/assets/0.1.0-1.4.2/dcos-service-cli.exe"
         }
       }
     }

--- a/repo/packages/S/spinnaker/1/resource.json
+++ b/repo/packages/S/spinnaker/1/resource.json
@@ -17,8 +17,8 @@
             "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz", 
             "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip", 
             "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip", 
-            "scheduler-zip": "https://ecosystem-repo.s3.amazonaws.com/sdk/artifacts/0.42.1/operator-scheduler.zip", 
-            "svc": "https://ecosystem-repo.s3.amazonaws.com/spinnaker/artifacts/0.2.0-1.4.2/svc.yml"
+            "scheduler-zip": "https://downloads.mesosphere.com/sdk/artifacts/0.42.1/operator-scheduler.zip",
+            "svc": "https://downloads.mesosphere.com/spinnaker/artifacts/0.2.0-1.4.2/svc.yml"
         }
     }, 
     "images": {

--- a/repo/packages/S/spinnaker/2/resource.json
+++ b/repo/packages/S/spinnaker/2/resource.json
@@ -18,8 +18,8 @@
             "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz", 
             "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip", 
             "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip", 
-            "scheduler-zip": "https://ecosystem-repo.s3.amazonaws.com/sdk/artifacts/0.42.1/operator-scheduler.zip", 
-            "svc": "https://ecosystem-repo.s3.amazonaws.com/spinnaker/artifacts/0.3.0-1.9.2/svc.yml"
+            "scheduler-zip": "https://downloads.mesosphere.com/sdk/artifacts/0.42.1/operator-scheduler.zip",
+            "svc": "https://downloads.mesosphere.com/spinnaker/artifacts/0.3.0-1.9.2/svc.yml"
         }
     }, 
     "images": {

--- a/repo/packages/S/spinnaker/3/resource.json
+++ b/repo/packages/S/spinnaker/3/resource.json
@@ -18,8 +18,8 @@
             "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz", 
             "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip", 
             "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip", 
-            "scheduler-zip": "https://ecosystem-repo.s3.amazonaws.com/sdk/artifacts/0.42.1/operator-scheduler.zip", 
-            "svc": "https://mesostcs-spinnaker-bucket.s3.amazonaws.com/spinnaker/artifacts/0.3.1-1.9.2/svc.yml"
+            "scheduler-zip": "https://downloads.mesosphere.com/sdk/artifacts/0.42.1/operator-scheduler.zip",
+            "svc": "https://downloads.mesosphere.com/spinnaker/artifacts/0.3.1-1.9.2/svc.yml"
         }
     }, 
     "images": {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Spinnaker - Migrate artifacts to downloads.mesosphere.com

Resolves [DCOS-62649](https://jira.mesosphere.com/browse/DCOS-62649)

## How were these changes tested?

Manually testing of service on DCOS 2.0 cluster.

## Release Notes

NA