### PR TITLE
[D2IQ-62644] Percona-pxc-mysql - Migrate artifacts to downloads.mesosphere.com

### DIFF
--- a/repo/packages/P/percona-pxc-mysql/100/marathon.json.mustache
+++ b/repo/packages/P/percona-pxc-mysql/100/marathon.json.mustache
@@ -31,8 +31,8 @@
   "env": {
     "PACKAGE_NAME": "percona-pxc-mysql",
     "PACKAGE_VERSION": "0.2.0-5.7.21",
-    "PACKAGE_BUILD_TIME_EPOCH_MS": "1552562293172",
-    "PACKAGE_BUILD_TIME_STR": "Thu Mar 14 2019 11:18:13 +0000",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1580917238561",
+    "PACKAGE_BUILD_TIME_STR": "Wed Feb 05 2020 15:40:38 +0000",
     "FRAMEWORK_NAME": "{{service.name}}",
 
     {{#service.check_for_nobody_leave_unchecked_for_root}}
@@ -45,7 +45,7 @@
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
     "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
     "MESOS_API_VERSION": "V1",
-    
+
     "TASKCFG_ALL_PXC_CLUSTER_NAME": "{{pxc.cluster_name}}",
     "TASKCFG_ALL_PXC_APP_USER_NAME": "{{pxc.application_user_name}}",
 
@@ -147,7 +147,6 @@
     "TASKCFG_ALL_WSREP_SST_RECEIVE_ADDRESS": "{{pxc-advanced.wsrep_sst_receive_address}}",
     "TASKCFG_ALL_WSREP_SYNC_WAIT": "{{pxc-advanced.wsrep_sync_wait}}",
 
-    
     "IMAGE_IS_NOBODY": "{{service.check_for_nobody_leave_unchecked_for_root}}",
     "PXC_DOCKER_IMAGE_ROOT": "{{resource.assets.container.docker.percona-xtradb-cluster-root}}",
     "PXC_DOCKER_IMAGE_NOBODY": "{{resource.assets.container.docker.percona-xtradb-cluster-nobody}}",
@@ -172,7 +171,6 @@
     "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
     {{/service.service_account_secret}}
     "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
- 
   },
   "uris": [
     "{{resource.assets.uris.bootstrap-zip}}",

--- a/repo/packages/P/percona-pxc-mysql/100/marathon.json.mustache
+++ b/repo/packages/P/percona-pxc-mysql/100/marathon.json.mustache
@@ -21,6 +21,7 @@
     "DCOS_SERVICE_PORT_INDEX": "0",
     "DCOS_SERVICE_SCHEME": "http"
   },
+
   {{#service.service_account_secret}}
   "secrets": {
     "serviceCredential": {
@@ -28,6 +29,7 @@
     }
   },
   {{/service.service_account_secret}}
+
   "env": {
     "PACKAGE_NAME": "percona-pxc-mysql",
     "PACKAGE_VERSION": "0.2.0-5.7.21",
@@ -49,7 +51,6 @@
     "TASKCFG_ALL_PXC_CLUSTER_NAME": "{{pxc.cluster_name}}",
     "TASKCFG_ALL_PXC_APP_USER_NAME": "{{pxc.application_user_name}}",
 
-
     "PXC_MYSQL_ROOT_PASSWORD": "{{pxc.mysql_root_password}}",
     "PXC_XTRABKP_PASSWORD": "{{pxc.xtrabackup_password}}",
     "PXC_APP_USER_PASSWORD": "{{pxc.application_user_password}}",
@@ -58,11 +59,13 @@
     "PXC_COUNT": "{{pxc.count}}",
     "TASKCFG_ALL_PXC_PORT": "{{pxc.pxc_port}}",
     "PXC_PLACEMENT": "{{{pxc.placement_constraint}}}",
+
     {{#service.virtual_network_enabled}}
     "ENABLE_VIRTUAL_NETWORK": "yes",
     "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
     "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
     {{/service.virtual_network_enabled}}
+
     "PXC_CPUS": "{{pxc.cpus}}",
     "PXC_MEM": "{{pxc.mem}}",
     "PXC_DISK": "{{pxc.disk}}",
@@ -101,7 +104,6 @@
 
     "TASKCFG_ALL_PROXYSQL_CLUSTER_NAME_PXC": "{{pxc.cluster_name}}",
 
-
     {{#service.enable_secrets}}
     "TASKCFG_ALL_PXC_ENABLE_SECRETS": "{{service.enable_secrets}}",
     {{/service.enable_secrets}}
@@ -115,7 +117,6 @@
     {{#service.pam_enabled}}
     "TASKCFG_ALL_PXC_PAM_ENABLED": "{{service.pam_enabled}}",
     {{/service.pam_enabled}}
-
 
     "TASKCFG_ALL_PXC_ENCRYPT_CLUSTER_TRAFFIC": "{{pxc-advanced.pxc_encrypt_cluster_traffic}}",
     "TASKCFG_ALL_PXC_MAINT_MODE": "{{pxc-advanced.pxc_maint_mode}}",

--- a/repo/packages/P/percona-pxc-mysql/100/resource.json
+++ b/repo/packages/P/percona-pxc-mysql/100/resource.json
@@ -4,12 +4,12 @@
       "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz",
       "bootstrap-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip",
-      "scheduler-zip": "https://pxc-bucket.s3.amazonaws.com/pxc/assets/0.2.0-5.7.21/percona-pxc-mysql-scheduler.zip",
+      "scheduler-zip": "https://downloads.mesosphere.com/percona-pxc-mysql/assets/0.2.0-5.7.21/percona-pxc-mysql-scheduler.zip",
       "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip",
-      "pip-uri": "https://bootstrap.pypa.io/get-pip.py",
-      "zk-uri": "https://s3-ap-northeast-1.amazonaws.com/pxc-utils/zookeepercli-linux-amd64-binary.tar.gz",
-      "mysqld-exporter-uri": "https://s3-ap-northeast-1.amazonaws.com/pxc-utils/mysqld_exporter-0.7.1.linux-amd64.tar.gz",
-      "mc-uri": "https://dl.minio.io/client/mc/release/linux-amd64/mc"
+      "pip-uri": "https://downloads.mesosphere.com/percona-pxc-mysql/assets/get-pip.py",
+      "zk-uri": "https://downloads.mesosphere.com/percona-pxc-mysql/assets/zookeepercli-linux-amd64-binary.tar.gz",
+      "mysqld-exporter-uri": "https://downloads.mesosphere.com/percona-pxc-mysql/assets/mysqld_exporter-0.7.1.linux-amd64.tar.gz",
+      "mc-uri": "https://downloads.mesosphere.com/percona-pxc-mysql/assets/mc"
     },
     "container": {
       "docker": {
@@ -23,9 +23,9 @@
     }
   },
   "images": {
-    "icon-small": "https://s3.amazonaws.com/pxc-icons/pxc-icon-small.png",
-    "icon-medium": "https://s3.amazonaws.com/pxc-icons/pxc-icon-medium.png",
-    "icon-large": "https://s3.amazonaws.com/pxc-icons/pxc-icon-large.png"
+    "icon-small": "https://downloads.mesosphere.com/percona-pxc-mysql/assets/pxc-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/percona-pxc-mysql/assets/pxc-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/percona-pxc-mysql/assets/pxc-icon-large.png"
   },
   "cli": {
     "binaries": {


### PR DESCRIPTION
Resolves [D2IQ-62644](https://jira.mesosphere.com/browse/D2IQ-62644)

## What changes were proposed in this pull request?
Migrated the S3 bucket artifacts to downloads.mesosphere.com to avoid the issues after S3 bucket deletion. Hence changing the existing resource-uris, images paths.

## How were these changes tested?
- Successfully deployed the Percona-pxc-mysql service on DCOS 2.0 cluster.
- Soaked on soak200s, soak201s clusters.