### PR TITLE
[D2IQ-62649] Spinnaker service migration of S3 artifacts to downloads.mesosphere.com

### DIFF
--- a/repo/packages/S/spinnaker/0/resource.json
+++ b/repo/packages/S/spinnaker/0/resource.json
@@ -15,7 +15,7 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/jre-8u144-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.io/libmesos-bundle/libmesos-bundle-1.10-1.4-63e0814.tar.gz",
-      "scheduler-zip": "https://mbgl-bucket.s3.amazonaws.com/spinnaker/assets/0.1.0-1.4.2/spinnaker-scheduler.zip",
+      "scheduler-zip": "https://downloads.mesosphere.com/spinnaker/assets/0.1.0-1.4.2/spinnaker-scheduler.zip",
       "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.30.2/executor.zip",
       "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.30.2/bootstrap.zip"
     }
@@ -36,7 +36,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://mbgl-bucket.s3.amazonaws.com/spinnaker/assets/0.1.0-1.4.2/dcos-service-cli-darwin"
+          "url": "https://downloads.mesosphere.com/spinnaker/assets/0.1.0-1.4.2/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -48,7 +48,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://mbgl-bucket.s3.amazonaws.com/spinnaker/assets/0.1.0-1.4.2/dcos-service-cli-linux"
+          "url": "https://downloads.mesosphere.com/spinnaker/assets/0.1.0-1.4.2/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -60,7 +60,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://mbgl-bucket.s3.amazonaws.com/spinnaker/assets/0.1.0-1.4.2/dcos-service-cli.exe"
+          "url": "https://downloads.mesosphere.com/spinnaker/assets/0.1.0-1.4.2/dcos-service-cli.exe"
         }
       }
     }

--- a/repo/packages/S/spinnaker/2/resource.json
+++ b/repo/packages/S/spinnaker/2/resource.json
@@ -18,8 +18,8 @@
             "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz", 
             "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip", 
             "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip", 
-            "scheduler-zip": "https://ecosystem-repo.s3.amazonaws.com/sdk/artifacts/0.42.1/operator-scheduler.zip", 
-            "svc": "https://ecosystem-repo.s3.amazonaws.com/spinnaker/artifacts/0.3.0-1.9.2/svc.yml"
+            "scheduler-zip": "https://downloads.mesosphere.com/dcosdev-sdk/assets/0.42.1/operator-scheduler.zip",
+            "svc": "https://downloads.mesosphere.com/spinnaker/assets/0.3.0-1.9.2/svc.yml"
         }
     }, 
     "images": {

--- a/repo/packages/S/spinnaker/3/resource.json
+++ b/repo/packages/S/spinnaker/3/resource.json
@@ -18,8 +18,8 @@
             "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz", 
             "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip", 
             "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip", 
-            "scheduler-zip": "https://ecosystem-repo.s3.amazonaws.com/sdk/artifacts/0.42.1/operator-scheduler.zip", 
-            "svc": "https://mesostcs-spinnaker-bucket.s3.amazonaws.com/spinnaker/artifacts/0.3.1-1.9.2/svc.yml"
+            "scheduler-zip": "https://downloads.mesosphere.com/dcosdev-sdk/assets/0.42.1/operator-scheduler.zip",
+            "svc": "https://downloads.mesosphere.com/spinnaker/assets/0.3.1-1.9.2/svc.yml"
         }
     }, 
     "images": {

--- a/repo/packages/S/spinnaker/4/config.json
+++ b/repo/packages/S/spinnaker/4/config.json
@@ -1,0 +1,509 @@
+{
+    "type": "object", 
+    "properties": {
+        "service": {
+            "type": "object", 
+            "description": "Spinnaker service configuration properties", 
+            "properties": {
+                "name": {
+                    "title": "Service name", 
+                    "description": "The name of the service instance", 
+                    "type": "string", 
+                    "default": "spinnaker"
+                }, 
+                "user": {
+                    "title": "User", 
+                    "description": "The user that the service will run as.", 
+                    "type": "string", 
+                    "default": "root"
+                }, 
+                "proxy-hostname": {
+                    "title": "Public service proxy or LB hostname", 
+                    "description": "Public service proxy or LB hostname, usually the hostname of the public agent", 
+                    "type": "string", 
+                    "default": ""
+                }, 
+                "proxy-deck-port": {
+                    "title": "Public service proxy or LB deck port number", 
+                    "description": "Public service proxy or LB deck port number", 
+                    "type": "integer", 
+                    "default": 9001
+                }, 
+                "proxy-gate-port": {
+                    "title": "Public service proxy or LB gate port number", 
+                    "description": "Public service proxy or LB gate port number", 
+                    "type": "integer", 
+                    "default": 8084
+                }, 
+                "service_account": {
+                    "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.", 
+                    "type": "string", 
+                    "default": ""
+                }, 
+                "service_account_secret": {
+                    "title": "Credential secret name (optional)", 
+                    "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.", 
+                    "type": "string", 
+                    "default": ""
+                }, 
+                "virtual_network_enabled": {
+                    "description": "Enable virtual networking", 
+                    "type": "boolean", 
+                    "default": false
+                }, 
+                "virtual_network_name": {
+                    "description": "The name of the virtual network to join", 
+                    "type": "string", 
+                    "default": "dcos"
+                }, 
+                "virtual_network_plugin_labels": {
+                    "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n", 
+                    "type": "string", 
+                    "default": ""
+                }, 
+                "log_level": {
+                    "description": "The log level for the DC/OS service.", 
+                    "type": "string", 
+                    "enum": [
+                        "OFF", 
+                        "FATAL", 
+                        "ERROR", 
+                        "WARN", 
+                        "INFO", 
+                        "DEBUG", 
+                        "TRACE", 
+                        "ALL"
+                    ], 
+                    "default": "INFO"
+                }, 
+                "spinnaker_debug": {
+                    "description": "Enable spinnaker debug messages", 
+                    "type": "boolean", 
+                    "default": false
+                }, 
+                "security": {
+                    "description": "Security settings", 
+                    "type": "object", 
+                    "properties": {
+                        "transport_encryption": {
+                            "type": "object", 
+                            "description": "Transport encryption settings", 
+                            "properties": {
+                                "enabled": {
+                                    "description": "Enable transport encryption (TLS)", 
+                                    "type": "boolean", 
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }, 
+            "required": [
+                "name", 
+                "user", 
+                "proxy-hostname"
+            ]
+        }, 
+        "redis": {
+            "description": "configuration properties", 
+            "type": "object", 
+            "properties": {
+                "cpus": {
+                    "title": "CPU count", 
+                    "description": "pod CPU requirements", 
+                    "type": "number", 
+                    "default": 0.5
+                }, 
+                "mem": {
+                    "title": "Memory size (MB)", 
+                    "description": "pod mem requirements (in MB)", 
+                    "type": "integer", 
+                    "default": 2048
+                }, 
+                "placement": {
+                    "description": "Placement constraints (e.g., [[\"hostname\", \"UNIQUE\"]]).", 
+                    "type": "string", 
+                    "default": "[[\"hostname\", \"UNIQUE\"]]", 
+                    "media": {
+                        "type": "application/x-zone-constraints+json"
+                    }
+                }
+            }, 
+            "required": [
+                "cpus", 
+                "mem"
+            ]
+        }, 
+        "front": {
+            "description": "configuration properties", 
+            "type": "object", 
+            "properties": {
+                "config": {
+                    "title": "front50-local yml config", 
+                    "description": "front50-local.yml config base64 encoded", 
+                    "type": "string", 
+                    "media": {
+                        "binaryEncoding": "base64", 
+                        "type": "application/x-yaml"
+                    }, 
+                    "default": "Y2Fzc2FuZHJhOgogIGVuYWJsZWQ6IGZhbHNlCgpzcGlubmFrZXI6CiAgY2Fzc2FuZHJhOgogICAgZW5hYmxlZDogZmFsc2UKICAgIGVtYmVkZGVkOiB0cnVlCiAgczM6CiAgICBlbmFibGVkOiB0cnVlCiAgICBidWNrZXQ6IG15LXNwaW5uYWtlci1idWNrZXQKICAgIHJvb3RGb2xkZXI6IGZyb250NTAKICAgIGVuZHBvaW50OiBodHRwOi8vbWluaW8ubWFyYXRob24ubDRsYi50aGlzZGNvcy5kaXJlY3Rvcnk6OTAwMAogIGdjczoKICAgIGVuYWJsZWQ6IGZhbHNlCiAgICBidWNrZXQ6IG15LXNwaW5uYWtlci1idWNrZXQKICAgIGJ1Y2tldExvY2F0aW9uOiB1cwogICAgcm9vdEZvbGRlcjogZnJvbnQ1MAogICAgcHJvamVjdDogbXktcHJvamVjdAogICAganNvblBhdGg6IC9tbnQvbWVzb3Mvc2FuZGJveC9kYXRhL2tleXMvZ2NwX2tleS5qc29uCg=="
+                }, 
+                "secrets_enabled": {
+                    "description": "enable usage of secrets for s3 or gcs", 
+                    "type": "boolean", 
+                    "default": false
+                }, 
+                "aws_access_key_id": {
+                    "title": "aws access key id", 
+                    "description": "aws access key id, if no secrets are used for s3", 
+                    "type": "string", 
+                    "default": "minio"
+                }, 
+                "aws_secret_access_key": {
+                    "title": "aws secret access key", 
+                    "description": "aws secret access key, if no secrets are used for s3", 
+                    "type": "string", 
+                    "default": "minio123"
+                }, 
+                "count": {
+                    "description": "Number of front services to create", 
+                    "type": "integer", 
+                    "default": 1, 
+                    "minimum": 1
+                }, 
+                "cpus": {
+                    "title": "CPU count", 
+                    "description": "pod CPU requirements", 
+                    "type": "number", 
+                    "default": 0.5
+                }, 
+                "mem": {
+                    "title": "Memory size (MB)", 
+                    "description": "pod mem requirements (in MB)", 
+                    "type": "integer", 
+                    "default": 2048
+                }, 
+                "placement": {
+                    "description": "Placement constraints (e.g., [[\"hostname\", \"UNIQUE\"]]).", 
+                    "type": "string", 
+                    "default": "[[\"hostname\", \"UNIQUE\"]]", 
+                    "media": {
+                        "type": "application/x-zone-constraints+json"
+                    }
+                }
+            }, 
+            "required": [
+                "config", 
+                "cpus", 
+                "mem"
+            ]
+        }, 
+        "fiat": {
+            "description": "configuration properties", 
+            "type": "object", 
+            "properties": {
+                "config": {
+                    "title": "fiat-local yml config", 
+                    "description": "fiat-local.yml config base64 encoded", 
+                    "type": "string", 
+                    "media": {
+                        "binaryEncoding": "base64", 
+                        "type": "application/x-yaml"
+                    }, 
+                    "default": ""
+                }, 
+                "count": {
+                    "description": "Number of fiat services to create", 
+                    "type": "integer", 
+                    "default": 1, 
+                    "minimum": 1
+                }, 
+                "cpus": {
+                    "title": "CPU count", 
+                    "description": "pod CPU requirements", 
+                    "type": "number", 
+                    "default": 0.5
+                }, 
+                "mem": {
+                    "title": "Memory size (MB)", 
+                    "description": "pod mem requirements (in MB)", 
+                    "type": "integer", 
+                    "default": 2048
+                }, 
+                "placement": {
+                    "description": "Placement constraints (e.g., [[\"hostname\", \"UNIQUE\"]]).", 
+                    "type": "string", 
+                    "default": "[[\"hostname\", \"UNIQUE\"]]", 
+                    "media": {
+                        "type": "application/x-zone-constraints+json"
+                    }
+                }
+            }, 
+            "required": [
+                "cpus", 
+                "mem"
+            ]
+        }, 
+        "clouddriver": {
+            "description": "configuration properties", 
+            "type": "object", 
+            "properties": {
+                "config": {
+                    "title": "clouddriver-local yml config", 
+                    "description": "clouddriver-local.yml config base64 encoded", 
+                    "type": "string", 
+                    "media": {
+                        "binaryEncoding": "base64", 
+                        "type": "application/x-yaml"
+                    }, 
+                    "default": "ZG9ja2VyUmVnaXN0cnk6CiAgZW5hYmxlZDogdHJ1ZQogIGFjY291bnRzOgogIC0gbmFtZTogbXktZG9ja2VyLXJlZ2lzdHJ5LWFjY291bnQKICAgIGFkZHJlc3M6IGh0dHBzOi8vaW5kZXguZG9ja2VyLmlvLwogICAgcmVwb3NpdG9yaWVzOgogICAgICAtIGxpYnJhcnkvbmdpbngKICAgICAgLSBsaWJyYXJ5L3Bvc3RncmVzCiAgICB1c2VybmFtZTogbWVzb3NwaGVyZQojICAgIHBhc3N3b3JkOiAuLi4gICAgCgpkY29zOgogIGVuYWJsZWQ6IHRydWUKICBjbHVzdGVyczoKICAgIC0gbmFtZTogbXktZGNvcwogICAgICBkY29zVXJsOiBodHRwczovL2xlYWRlci5tZXNvcwogICAgICBpbnNlY3VyZVNraXBUbHNWZXJpZnk6IHRydWUKICBhY2NvdW50czoKICAgIC0gbmFtZTogbXktZGNvcy1hY2NvdW50CiAgICAgIGRvY2tlclJlZ2lzdHJpZXM6CiAgICAgICAgLSBhY2NvdW50TmFtZTogbXktZG9ja2VyLXJlZ2lzdHJ5LWFjY291bnQKICAgICAgY2x1c3RlcnM6CiAgICAgICAgLSBuYW1lOiBteS1kY29zCiAgICAgICAgICB1aWQ6IGJvb3RzdHJhcHVzZXIKICAgICAgICAgIHBhc3N3b3JkOiBkZWxldGVtZQoKI2t1YmVybmV0ZXM6CiMgIGVuYWJsZWQ6IHRydWUKIyAgYWNjb3VudHM6CiMgICAgLSBuYW1lOiBteS1rdWJlcm5ldGVzLWFjY291bnQKIyAgICAgIHByb3ZpZGVyVmVyc2lvbjogdjIKIyAgICAgIG5hbWVzcGFjZTogCiMgICAgICAgIC0gZGVmYXVsdAojICAgICAga3ViZWNvbmZpZ0ZpbGU6ICR7TUVTT1NfU0FOREJPWH0va3ViZWNvbmZpZwojICAgICAgZG9ja2VyUmVnaXN0cmllczoKIyAgICAgICAgLSBhY2NvdW50TmFtZTogbXktZG9ja2VyLXJlZ2lzdHJ5LWFjY291bnQ="
+                }, 
+                "kubeconfig_secret_enabled": {
+                    "description": "enable kubeconfig secret named <service_name>/kubeconfig", 
+                    "type": "boolean", 
+                    "default": false
+                }, 
+                "count": {
+                    "description": "Number of clouddriver services to create", 
+                    "type": "integer", 
+                    "default": 1, 
+                    "minimum": 1
+                }, 
+                "cpus": {
+                    "title": "CPU count", 
+                    "description": "pod CPU requirements", 
+                    "type": "number", 
+                    "default": 0.5
+                }, 
+                "mem": {
+                    "title": "Memory size (MB)", 
+                    "description": "pod mem requirements (in MB)", 
+                    "type": "integer", 
+                    "default": 2048
+                }, 
+                "placement": {
+                    "description": "Placement constraints (e.g., [[\"hostname\", \"UNIQUE\"]]).", 
+                    "type": "string", 
+                    "default": "[[\"hostname\", \"UNIQUE\"]]", 
+                    "media": {
+                        "type": "application/x-zone-constraints+json"
+                    }
+                }
+            }, 
+            "required": [
+                "config", 
+                "cpus", 
+                "mem"
+            ]
+        }, 
+        "orca": {
+            "description": "configuration properties", 
+            "type": "object", 
+            "properties": {
+                "config": {
+                    "title": "orca-local yml config", 
+                    "description": "orca-local.yml config base64 encoded", 
+                    "type": "string", 
+                    "media": {
+                        "binaryEncoding": "base64", 
+                        "type": "application/x-yaml"
+                    }, 
+                    "default": ""
+                }, 
+                "count": {
+                    "description": "Number of orca services to create", 
+                    "type": "integer", 
+                    "default": 1, 
+                    "minimum": 1
+                }, 
+                "cpus": {
+                    "title": "CPU count", 
+                    "description": "pod CPU requirements", 
+                    "type": "number", 
+                    "default": 0.5
+                }, 
+                "mem": {
+                    "title": "Memory size (MB)", 
+                    "description": "pod mem requirements (in MB)", 
+                    "type": "integer", 
+                    "default": 2048
+                }, 
+                "placement": {
+                    "description": "Placement constraints (e.g., [[\"hostname\", \"UNIQUE\"]]).", 
+                    "type": "string", 
+                    "default": "[[\"hostname\", \"UNIQUE\"]]", 
+                    "media": {
+                        "type": "application/x-zone-constraints+json"
+                    }
+                }
+            }, 
+            "required": [
+                "cpus", 
+                "mem"
+            ]
+        }, 
+        "gate": {
+            "description": "configuration properties", 
+            "type": "object", 
+            "properties": {
+                "config": {
+                    "title": "gate-local yml config", 
+                    "description": "gate-local.yml config bbase64 encoded", 
+                    "type": "string", 
+                    "media": {
+                        "binaryEncoding": "base64", 
+                        "type": "application/x-yaml"
+                    }, 
+                    "default": "I3NlY3VyaXR5OgojICBvYXV0aDI6CiMgICAgY2xpZW50OgojICAgICAgY2xpZW50SWQ6IC4uLgojICAgICAgY2xpZW50U2VjcmV0OiAuLi4KIyAgICAgIHVzZXJBdXRob3JpemF0aW9uVXJpOiBodHRwczovL2dpdGh1Yi5jb20vbG9naW4vb2F1dGgvYXV0aG9yaXplCiMgICAgICBhY2Nlc3NUb2tlblVyaTogaHR0cHM6Ly9naXRodWIuY29tL2xvZ2luL29hdXRoL2FjY2Vzc190b2tlbgojICAgICAgc2NvcGU6IHVzZXI6ZW1haWwKIyAgICByZXNvdXJjZToKIyAgICAgIHVzZXJJbmZvVXJpOiBodHRwczovL2FwaS5naXRodWIuY29tL3VzZXIKIyAgICB1c2VySW5mb01hcHBpbmc6CiMgICAgICBlbWFpbDogZW1haWwKIyAgICAgIGZpcnN0TmFtZToKIyAgICAgIGxhc3ROYW1lOiBuYW1lCiMgICAgICB1c2VybmFtZTogbG9naW4K"
+                }, 
+                "count": {
+                    "description": "Number of gate services to create", 
+                    "type": "integer", 
+                    "default": 1, 
+                    "minimum": 1
+                }, 
+                "cpus": {
+                    "title": "CPU count", 
+                    "description": "pod CPU requirements", 
+                    "type": "number", 
+                    "default": 0.5
+                }, 
+                "mem": {
+                    "title": "Memory size (MB)", 
+                    "description": "pod mem requirements (in MB)", 
+                    "type": "integer", 
+                    "default": 2048
+                }, 
+                "placement": {
+                    "description": "Placement constraints (e.g., [[\"hostname\", \"UNIQUE\"]]).", 
+                    "type": "string", 
+                    "default": "[[\"hostname\", \"UNIQUE\"]]", 
+                    "media": {
+                        "type": "application/x-zone-constraints+json"
+                    }
+                }
+            }, 
+            "required": [
+                "cpus", 
+                "mem"
+            ]
+        }, 
+        "deck": {
+            "description": "configuration properties", 
+            "type": "object", 
+            "properties": {
+                "count": {
+                    "description": "Number of deck services to create", 
+                    "type": "integer", 
+                    "default": 1, 
+                    "minimum": 1
+                }, 
+                "cpus": {
+                    "title": "CPU count", 
+                    "description": "pod CPU requirements", 
+                    "type": "number", 
+                    "default": 0.1
+                }, 
+                "mem": {
+                    "title": "Memory size (MB)", 
+                    "description": "pod mem requirements (in MB)", 
+                    "type": "integer", 
+                    "default": 512
+                }, 
+                "placement": {
+                    "description": "Placement constraints (e.g., [[\"hostname\", \"UNIQUE\"]]).", 
+                    "type": "string", 
+                    "default": "[[\"hostname\", \"UNIQUE\"]]", 
+                    "media": {
+                        "type": "application/x-zone-constraints+json"
+                    }
+                }
+            }, 
+            "required": [
+                "cpus", 
+                "mem"
+            ]
+        }, 
+        "echo": {
+            "description": "configuration properties", 
+            "type": "object", 
+            "properties": {
+                "config": {
+                    "title": "echo-local yml config", 
+                    "description": "echo-local.yml config base64 encoded", 
+                    "type": "string", 
+                    "media": {
+                        "binaryEncoding": "base64", 
+                        "type": "application/x-yaml"
+                    }, 
+                    "default": "bWFpbDoKICBlbmFibGVkOiBmYWxzZQojICBmcm9tOiA8ZnJvbS1nbWFpbC1hZGRyZXNzPgojc3ByaW5nOgojICBtYWlsOgojICAgIGhvc3Q6IHNtdHAuZ21haWwuY29tCiMgICAgdXNlcm5hbWU6IDxmcm9tLWdtYWlsLWFkZHJlc3M+CiMgICAgcGFzc3dvcmQ6IDxhcHAtcGFzc3dvcmQsIHNlZSBodHRwczovL3N1cHBvcnQuZ29vZ2xlLmNvbS9hY2NvdW50cy9hbnN3ZXIvMTg1ODMzP2hsPWVuID4KIyAgICBwcm9wZXJ0aWVzOgojICAgICAgbWFpbDoKIyAgICAgICAgc210cDoKIyAgICAgICAgICBhdXRoOiB0cnVlCiMgICAgICAgICAgc3NsOgojICAgICAgICAgICAgZW5hYmxlOiB0cnVlCiMgICAgICAgICAgc29ja2V0RmFjdG9yeToKIyAgICAgICAgICAgIHBvcnQ6IDQ2NQojICAgICAgICAgICAgY2xhc3M6IGphdmF4Lm5ldC5zc2wuU1NMU29ja2V0RmFjdG9yeQojICAgICAgICAgICAgZmFsbGJhY2s6IGZhbHNl"
+                }, 
+                "cpus": {
+                    "title": "CPU count", 
+                    "description": "pod CPU requirements", 
+                    "type": "number", 
+                    "default": 0.5
+                }, 
+                "mem": {
+                    "title": "Memory size (MB)", 
+                    "description": "pod mem requirements (in MB)", 
+                    "type": "integer", 
+                    "default": 2048
+                }, 
+                "placement": {
+                    "description": "Placement constraints (e.g., [[\"hostname\", \"UNIQUE\"]]).", 
+                    "type": "string", 
+                    "default": "[[\"hostname\", \"UNIQUE\"]]", 
+                    "media": {
+                        "type": "application/x-zone-constraints+json"
+                    }
+                }
+            }, 
+            "required": [
+                "cpus", 
+                "mem"
+            ]
+        }, 
+        "igor": {
+            "description": "configuration properties", 
+            "type": "object", 
+            "properties": {
+                "config": {
+                    "title": "igor-local yml config", 
+                    "description": "igor-local.yml config base64 encoded", 
+                    "type": "string", 
+                    "media": {
+                        "binaryEncoding": "base64", 
+                        "type": "application/x-yaml"
+                    }, 
+                    "default": "ZG9ja2VyUmVnaXN0cnk6CiAgZW5hYmxlZDogdHJ1ZQo="
+                }, 
+                "cpus": {
+                    "title": "CPU count", 
+                    "description": "pod CPU requirements", 
+                    "type": "number", 
+                    "default": 0.5
+                }, 
+                "mem": {
+                    "title": "Memory size (MB)", 
+                    "description": "pod mem requirements (in MB)", 
+                    "type": "integer", 
+                    "default": 2048
+                }, 
+                "placement": {
+                    "description": "Placement constraints (e.g., [[\"hostname\", \"UNIQUE\"]]).", 
+                    "type": "string", 
+                    "default": "[[\"hostname\", \"UNIQUE\"]]", 
+                    "media": {
+                        "type": "application/x-zone-constraints+json"
+                    }
+                }
+            }, 
+            "required": [
+                "cpus", 
+                "mem"
+            ]
+        }
+    }
+}

--- a/repo/packages/S/spinnaker/4/marathon.json.mustache
+++ b/repo/packages/S/spinnaker/4/marathon.json.mustache
@@ -1,0 +1,156 @@
+
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "user": "{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre/); export JAVA_HOME=${JAVA_HOME%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./operator-scheduler/bin/operator svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "PACKAGE_NAME": "{{package-name}}",
+    "PACKAGE_VERSION": "{{package-version}}",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1584373875074",
+    "PACKAGE_BUILD_TIME_STR": "2020-03-16T15:51:15.074866",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "SLEEP_DURATION": "{{service.sleep}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    "MESOS_API_VERSION": "V1",
+
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.service_account_secret}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+
+    "SERVICE_PROXY_HOSTNAME": "{{service.proxy-hostname}}",
+    "SERVICE_PROXY_DECK_PORT": "{{service.proxy-deck-port}}",
+    "SERVICE_PROXY_GATE_PORT": "{{service.proxy-gate-port}}",
+
+    {{#service.spinnaker_debug}}
+    "SERVICE_SPINNAKER_DEBUG": "--debug",
+    {{/service.spinnaker_debug}}
+
+    "SECURITY_TRANSPORT_ENCRYPTION_ENABLED": "{{service.security.transport_encryption.enabled}}",
+    {{#service.security.transport_encryption.enabled}}
+    "PROTOCOL": "https",
+    {{/service.security.transport_encryption.enabled}}
+    {{^service.security.transport_encryption.enabled}}
+    "PROTOCOL": "http",
+    {{/service.security.transport_encryption.enabled}}
+
+    "REDIS_CPUS": "{{redis.cpus}}",
+    "REDIS_MEM": "{{redis.mem}}",
+    "REDIS_PLACEMENT": "{{{redis.placement_constraint}}}",
+    "REDIS_DOCKER_IMAGE": "{{resource.assets.container.docker.redis}}",
+    "FRONT_COUNT": "{{front.count}}",
+    "FRONT_CPUS": "{{front.cpus}}",
+    "FRONT_MEM": "{{front.mem}}",
+    "FRONT_CONFIG": "{{front.config}}",
+    "FRONT_PLACEMENT": "{{{front.placement_constraint}}}",
+    "FRONT_DOCKER_IMAGE": "{{resource.assets.container.docker.front}}",
+    "FIAT_COUNT": "{{fiat.count}}",
+    "FIAT_CPUS": "{{fiat.cpus}}",
+    "FIAT_MEM": "{{fiat.mem}}",
+    "FIAT_CONFIG": "{{fiat.config}}",
+    "FIAT_PLACEMENT": "{{{fiat.placement_constraint}}}",
+    "FIAT_DOCKER_IMAGE": "{{resource.assets.container.docker.fiat}}",
+    "CLOUDDRIVER_COUNT": "{{clouddriver.count}}",
+    "CLOUDDRIVER_CPUS": "{{clouddriver.cpus}}",
+    "CLOUDDRIVER_MEM": "{{clouddriver.mem}}",
+    "CLOUDDRIVER_CONFIG": "{{clouddriver.config}}",
+    "CLOUDDRIVER_PLACEMENT": "{{{clouddriver.placement_constraint}}}",
+    "CLOUDDRIVER_DOCKER_IMAGE": "{{resource.assets.container.docker.clouddriver}}",
+    "ORCA_COUNT": "{{orca.count}}",
+    "ORCA_CPUS": "{{orca.cpus}}",
+    "ORCA_MEM": "{{orca.mem}}",
+    "ORCA_CONFIG": "{{orca.config}}",
+    "ORCA_PLACEMENT": "{{{orca.placement_constraint}}}",
+    "ORCA_DOCKER_IMAGE": "{{resource.assets.container.docker.orca}}",
+    "GATE_COUNT": "{{gate.count}}",
+    "GATE_CPUS": "{{gate.cpus}}",
+    "GATE_MEM": "{{gate.mem}}",
+    "GATE_CONFIG": "{{gate.config}}",
+    "GATE_PLACEMENT": "{{{gate.placement_constraint}}}",
+    "GATE_DOCKER_IMAGE": "{{resource.assets.container.docker.gate}}",
+    "DECK_COUNT": "{{deck.count}}",
+    "DECK_CPUS": "{{deck.cpus}}",
+    "DECK_MEM": "{{deck.mem}}",
+    "DECK_PLACEMENT": "{{{deck.placement_constraint}}}",
+    "DECK_DOCKER_IMAGE": "{{resource.assets.container.docker.deck}}",
+    "ECHO_CPUS": "{{echo.cpus}}",
+    "ECHO_MEM": "{{echo.mem}}",
+    "ECHO_CONFIG": "{{echo.config}}",
+    "ECHO_PLACEMENT": "{{{echo.placement_constraint}}}",
+    "ECHO_DOCKER_IMAGE": "{{resource.assets.container.docker.echo}}",
+    "IGOR_CPUS": "{{igor.cpus}}",
+    "IGOR_MEM": "{{igor.mem}}",
+    "IGOR_CONFIG": "{{igor.config}}",
+    "IGOR_PLACEMENT": "{{{igor.placement_constraint}}}",
+    "IGOR_DOCKER_IMAGE": "{{resource.assets.container.docker.igor}}",
+
+    "FRONT_SECRETS_ENABLED": "{{front.secrets_enabled}}",
+    "FRONT_AWS_ACCESS_KEY_ID": "{{front.aws_access_key_id}}",
+    "FRONT_AWS_SECRET_ACCESS_KEY": "{{front.aws_secret_access_key}}",
+
+    "CLOUDDRIVER_KUBECONFIG_SECRET_ENABLED": "{{clouddriver.kubeconfig_secret_enabled}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "{{resource.assets.uris.svc}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/S/spinnaker/4/package.json
+++ b/repo/packages/S/spinnaker/4/package.json
@@ -1,0 +1,29 @@
+{
+    "packagingVersion": "4.0", 
+    "minDcosReleaseVersion": "1.10", 
+    "upgradesFrom": [
+        "*"
+    ], 
+    "downgradesTo": [
+        "*"
+    ], 
+    "name": "spinnaker", 
+    "version": "0.3.2-1.9.2", 
+    "maintainer": "support@mesosphere.io", 
+    "description": "DC/OS Spinnaker is an automated service that makes it easy to deploy and manage Spinnaker on DC/OS. Spinnaker is an open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence. Created at Netflix, it has been battle-tested in production by hundreds of teams over millions of deployments. It combines a powerful and flexible pipeline management system with integrations to the major cloud providers. \n\n\tDocumentation: https://docs.mesosphere.com/services/spinnaker/0.3.0-1.9.2/", 
+    "selected": false, 
+    "framework": true, 
+    "tags": [
+        "0.42.1", 
+        "spinnaker"
+    ], 
+    "preInstallNotes": "\n\nThe DC/OS Spinnaker service currently only works with DC/OS Enterprise.\n\n", 
+    "postInstallNotes": "DC/OS Spinnaker is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/services/spinnaker/0.3.0-1.9.2/\n", 
+    "postUninstallNotes": "DC/OS Spinnaker is being uninstalled.", 
+    "licenses": [
+        {
+            "name": "Apache License Version 2.0", 
+            "url": "https://raw.githubusercontent.com/spinnaker/spinnaker/master/LICENSE.txt"
+        }
+    ]
+}

--- a/repo/packages/S/spinnaker/4/resource.json
+++ b/repo/packages/S/spinnaker/4/resource.json
@@ -1,0 +1,70 @@
+{
+    "assets": {
+        "container": {
+            "docker": {
+                "echo": "quay.io/spinnaker/echo:version-2.0.1", 
+                "clouddriver": "quay.io/spinnaker/clouddriver:version-3.4.2", 
+                "deck": "mesostcs/spinnaker-deck:version-2.4.2", 
+                "fiat": "quay.io/spinnaker/fiat:version-1.0.1", 
+                "front": "quay.io/spinnaker/front50:version-0.12.0", 
+                "gate": "quay.io/spinnaker/gate:version-1.1.1", 
+                "igor": "quay.io/spinnaker/igor:version-0.12.0", 
+                "orca": "quay.io/spinnaker/orca:version-1.0.0", 
+                "redis": "redis"
+            }
+        }, 
+        "uris": {
+            "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz", 
+            "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.11.0.tar.gz", 
+            "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/bootstrap.zip", 
+            "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/executor.zip", 
+            "scheduler-zip": "https://downloads.mesosphere.com/dcosdev-sdk/assets/0.42.1/operator-scheduler.zip", 
+            "svc": "https://downloads.mesosphere.com/spinnaker/assets/0.3.2-1.9.2/svc.yml"
+        }
+    }, 
+    "images": {
+        "icon-small": "https://downloads.mesosphere.com/assets/universe/000/spinnaker-icon-small.png", 
+        "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/spinnaker-icon-medium.png", 
+        "icon-large": "https://downloads.mesosphere.com/assets/universe/000/spinnaker-icon-large.png"
+    }, 
+    "cli": {
+        "binaries": {
+            "darwin": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256", 
+                            "value": "c459d2109b31fc0b423f8cacd49df855ef898e63609f7050957f4a0e044d5432"
+                        }
+                    ], 
+                    "kind": "executable", 
+                    "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/dcos-service-cli-darwin"
+                }
+            }, 
+            "linux": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256", 
+                            "value": "e580ee8b71c0c26b1a1a605ca09cbd3528a2c031a8de11519024ccbbce862339"
+                        }
+                    ], 
+                    "kind": "executable", 
+                    "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/dcos-service-cli-linux"
+                }
+            }, 
+            "windows": {
+                "x86-64": {
+                    "contentHash": [
+                        {
+                            "algo": "sha256", 
+                            "value": "9135f9456a40cd53e27e73e44fc94c1d4cbf27d9b59f2b47d82bad3ae0f8c714"
+                        }
+                    ], 
+                    "kind": "executable", 
+                    "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.42.1/dcos-service-cli.exe"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Resolves [DCOS-62649](https://jira.mesosphere.com/browse/DCOS-62649) 
Migrated the S3 bucket artifacts of existing versions 0.1.0-1.4.2, 0.3.0-1.9.2, 0.3.1-1.9.2 to downloads.mesosphere.com to avoid the issues after S3 bucket deletion. Hence changing the existing resource-uris paths.
Hot-fix release - Releasing a new hot-fix release 0.3.2-1.9.2 with migrated links in resource.json.

## How were these changes tested?
- Successfully deployed the Spinnaker service on DCOS 2.0 cluster.
- Soaked versions 0.1.0-1.4.2, 0.3.0-1.9.2, 0.3.1-1.9.2, 0.3.2-1.9.2 on soak201s soak cluster.

## Release Notes
Hot-fix release after S3 artifacts migration to downloads.mesosphere.com.