### PR TITLE
[D2IQ-62647] Nifi artifacts migration from S3 to downloads.mesosphere.com

### DIFF
--- a/repo/packages/N/nifi/100/resource.json
+++ b/repo/packages/N/nifi/100/resource.json
@@ -4,19 +4,19 @@
       "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
       "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/bootstrap.zip",
-      "scheduler-zip": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.1.0-1.5.0/nifi-scheduler.zip",
+      "scheduler-zip": "https://downloads.mesosphere.com/nifi/assets/0.1.0-1.5.0/nifi-scheduler.zip",
       "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/executor.zip",
-      "nifi-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-binary/nifi-1.5.0-bin.tar.gz",
-      "nifi-toolkit": "https://s3-ap-southeast-2.amazonaws.com/nifi-toolkit/nifi-toolkit-1.5.0-bin.tar.gz",
-      "nifi-janitor-jar": "https://s3-ap-southeast-2.amazonaws.com/nifi-toolkit/dcos-nifi-janitor.jar",
-      "nifi-statsd-jar": "https://s3-ap-southeast-2.amazonaws.com/nifi-toolkit/dcos-nifi-statsd.jar",
-      "nifi-python-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-python/python-2.7.14.tar.gz"
+      "nifi-tar-gz": "https://downloads.mesosphere.com/nifi/assets/0.1.0-1.5.0/nifi-1.5.0-bin.tar.gz",
+      "nifi-toolkit": "https://downloads.mesosphere.com/nifi/assets/0.1.0-1.5.0/nifi-toolkit-1.5.0-bin.tar.gz",
+      "nifi-janitor-jar": "https://downloads.mesosphere.com/nifi/assets/0.1.0-1.5.0/dcos-nifi-janitor.jar",
+      "nifi-statsd-jar": "https://downloads.mesosphere.com/nifi/assets/0.1.0-1.5.0/dcos-nifi-statsd.jar",
+      "nifi-python-tar-gz": "https://downloads.mesosphere.com/nifi/assets/python-2.7.14.tar.gz"
     }
   },
   "images": {
-    "icon-small": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-small.png",
-    "icon-medium": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-medium.png",
-    "icon-large": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-large.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-large.png"
   },
   "cli": {
     "binaries": {
@@ -29,7 +29,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/dcos-service-cli-darwin"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.1.0-1.5.0/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -41,7 +41,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/dcos-service-cli-linux"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.1.0-1.5.0/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -53,7 +53,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/dcos-service-cli.exe"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.1.0-1.5.0/dcos-service-cli.exe"
         }
       }
     }

--- a/repo/packages/N/nifi/200/resource.json
+++ b/repo/packages/N/nifi/200/resource.json
@@ -3,21 +3,21 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
-      "bootstrap-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/bootstrap.zip",
-      "scheduler-zip": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.2.0-1.5.0/nifi-scheduler.zip",
-      "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/executor.zip",
-      "nifi-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-binary/nifi-1.5.0-bin.tar.gz",
-      "nifi-toolkit": "https://s3-ap-southeast-2.amazonaws.com/nifi-toolkit/nifi-toolkit-1.5.0-bin.tar.gz",
-      "nifi-janitor-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.2.0-1.5.0/nifi-janitor.jar",
-      "nifi-statsd-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.2.0-1.5.0/nifi-statsd.jar",
-      "nifi-api-access-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.2.0-1.5.0/nifi-api-access.jar",
-      "nifi-python-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-python/python-2.7.14.tar.gz"
+      "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/bootstrap.zip",
+      "scheduler-zip": "https://downloads.mesosphere.com/nifi/assets/0.2.0-1.5.0/nifi-scheduler.zip",
+      "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/executor.zip",
+      "nifi-tar-gz": "https://downloads.mesosphere.com/nifi/assets/0.2.0-1.5.0/nifi-1.5.0-bin.tar.gz",
+      "nifi-toolkit": "https://downloads.mesosphere.com/nifi/assets/0.2.0-1.5.0/nifi-toolkit-1.5.0-bin.tar.gz",
+      "nifi-janitor-jar": "https://downloads.mesosphere.com/nifi/assets/0.2.0-1.5.0/nifi-janitor.jar",
+      "nifi-statsd-jar": "https://downloads.mesosphere.com/nifi/assets/0.2.0-1.5.0/nifi-statsd.jar",
+      "nifi-api-access-jar": "https://downloads.mesosphere.com/nifi/assets/0.2.0-1.5.0/nifi-api-access.jar",
+      "nifi-python-tar-gz": "https://downloads.mesosphere.com/nifi/assets/python-2.7.14.tar.gz"
     }
   },
   "images": {
-    "icon-small": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-small.png",
-    "icon-medium": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-medium.png",
-    "icon-large": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-large.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-large.png"
   },
   "cli": {
     "binaries": {
@@ -30,7 +30,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.2.0-1.5.0/dcos-service-cli-darwin"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.2.0-1.5.0/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -42,7 +42,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.2.0-1.5.0/dcos-service-cli-linux"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.2.0-1.5.0/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -54,7 +54,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.2.0-1.5.0/dcos-service-cli.exe"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.2.0-1.5.0/dcos-service-cli.exe"
         }
       }
     }

--- a/repo/packages/N/nifi/300/resource.json
+++ b/repo/packages/N/nifi/300/resource.json
@@ -3,15 +3,15 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
-      "bootstrap-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/bootstrap.zip",
-      "scheduler-zip": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.3.0-1.7.1/nifi-scheduler.zip",
-      "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/executor.zip",
-      "nifi-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-binary/nifi-1.7.1-bin.tar.gz",
-      "nifi-toolkit": "https://s3-ap-southeast-2.amazonaws.com/nifi-toolkit/nifi-toolkit-1.7.1-bin.tar.gz",
-      "nifi-janitor-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.3.0-1.7.1/nifi-janitor.jar",
-      "nifi-statsd-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.3.0-1.7.1/nifi-statsd.jar",
-      "nifi-api-access-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.3.0-1.7.1/nifi-api-access.jar",
-      "nifi-python-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-python/python-2.7.14.tar.gz"
+      "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/bootstrap.zip",
+      "scheduler-zip": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/nifi-scheduler.zip",
+      "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/executor.zip",
+      "nifi-tar-gz": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/nifi-1.7.1-bin.tar.gz",
+      "nifi-toolkit": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/nifi-toolkit-1.7.1-bin.tar.gz",
+      "nifi-janitor-jar": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/nifi-janitor.jar",
+      "nifi-statsd-jar": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/nifi-statsd.jar",
+      "nifi-api-access-jar": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/nifi-api-access.jar",
+      "nifi-python-tar-gz": "https://downloads.mesosphere.com/nifi/assets/python-2.7.14.tar.gz"
     },
     "container": {
       "docker": {
@@ -20,9 +20,9 @@
     }
   },
   "images": {
-    "icon-small": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-small.png",
-    "icon-medium": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-medium.png",
-    "icon-large": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-large.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-large.png"
   },
   "cli": {
     "binaries": {
@@ -35,7 +35,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.3.0-1.7.1/dcos-service-cli-darwin"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -47,7 +47,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.3.0-1.7.1/dcos-service-cli-linux"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -59,7 +59,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.3.0-1.7.1/dcos-service-cli.exe"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/dcos-service-cli.exe"
         }
       }
     }

--- a/repo/packages/N/nifi/400/resource.json
+++ b/repo/packages/N/nifi/400/resource.json
@@ -3,15 +3,15 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
-      "bootstrap-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/bootstrap.zip",
-      "scheduler-zip": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.0-1.8.0/nifi-scheduler.zip",
-      "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/executor.zip",
-      "nifi-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-binary/nifi-1.8.0-bin.tar.gz",
-      "nifi-toolkit": "https://s3-ap-southeast-2.amazonaws.com/nifi-toolkit/nifi-toolkit-1.8.0-bin.tar.gz",
-      "nifi-janitor-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.0-1.8.0/nifi-janitor.jar",
-      "nifi-statsd-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.0-1.8.0/nifi-statsd.jar",
-      "nifi-api-access-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.0-1.8.0/nifi-api-access.jar",
-      "nifi-python-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-python/python-2.7.14.tar.gz"
+      "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/bootstrap.zip",
+      "scheduler-zip": "https://downloads.mesosphere.com/nifi/assets/0.4.0-1.8.0/nifi-scheduler.zip",
+      "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/executor.zip",
+      "nifi-tar-gz": "https://downloads.mesosphere.com/nifi/assets/0.4.0-1.8.0/nifi-1.8.0-bin.tar.gz",
+      "nifi-toolkit": "https://downloads.mesosphere.com/nifi/assets/0.4.0-1.8.0/nifi-toolkit-1.8.0-bin.tar.gz",
+      "nifi-janitor-jar": "https://downloads.mesosphere.com/nifi/assets/0.4.0-1.8.0/nifi-janitor.jar",
+      "nifi-statsd-jar": "https://downloads.mesosphere.com/nifi/assets/0.4.0-1.8.0/nifi-statsd.jar",
+      "nifi-api-access-jar": "https://downloads.mesosphere.com/nifi/assets/0.4.0-1.8.0/nifi-api-access.jar",
+      "nifi-python-tar-gz": "https://downloads.mesosphere.com/nifi/assets/python-2.7.14.tar.gz"
     },
     "container": {
       "docker": {
@@ -20,9 +20,9 @@
     }
   },
   "images": {
-    "icon-small": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-small.png",
-    "icon-medium": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-medium.png",
-    "icon-large": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-large.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-large.png"
   },
   "cli": {
     "binaries": {
@@ -35,7 +35,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.0-1.8.0/dcos-service-cli-darwin"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.4.0-1.8.0/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -47,7 +47,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.0-1.8.0/dcos-service-cli-linux"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.4.0-1.8.0/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -59,7 +59,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.0-1.8.0/dcos-service-cli.exe"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.4.0-1.8.0/dcos-service-cli.exe"
         }
       }
     }

--- a/repo/packages/N/nifi/500/resource.json
+++ b/repo/packages/N/nifi/500/resource.json
@@ -3,15 +3,15 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
-      "bootstrap-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/bootstrap.zip",
-      "scheduler-zip": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.1-1.8.0/nifi-scheduler.zip",
-      "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/executor.zip",
-      "nifi-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-binary/nifi-1.8.0-bin.tar.gz",
-      "nifi-toolkit": "https://s3-ap-southeast-2.amazonaws.com/nifi-toolkit/nifi-toolkit-1.8.0-bin.tar.gz",
-      "nifi-janitor-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.1-1.8.0/nifi-janitor.jar",
-      "nifi-statsd-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.1-1.8.0/nifi-statsd.jar",
-      "nifi-api-access-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.1-1.8.0/nifi-api-access.jar",
-      "nifi-python-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-python/python-2.7.14.tar.gz"
+      "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/bootstrap.zip",
+      "scheduler-zip": "https://downloads.mesosphere.com/nifi/assets/0.4.1-1.8.0/nifi-scheduler.zip",
+      "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/executor.zip",
+      "nifi-tar-gz": "https://downloads.mesosphere.com/nifi/assets/0.4.1-1.8.0/nifi-1.8.0-bin.tar.gz",
+      "nifi-toolkit": "https://downloads.mesosphere.com/nifi/assets/0.4.1-1.8.0/nifi-toolkit-1.8.0-bin.tar.gz",
+      "nifi-janitor-jar": "https://downloads.mesosphere.com/nifi/assets/0.4.1-1.8.0/nifi-janitor.jar",
+      "nifi-statsd-jar": "https://downloads.mesosphere.com/nifi/assets/0.4.1-1.8.0/nifi-statsd.jar",
+      "nifi-api-access-jar": "https://downloads.mesosphere.com/nifi/assets/0.4.1-1.8.0/nifi-api-access.jar",
+      "nifi-python-tar-gz": "https://downloads.mesosphere.com/nifi/assets/python-2.7.14.tar.gz"
     },
     "container": {
       "docker": {
@@ -20,9 +20,9 @@
     }
   },
   "images": {
-    "icon-small": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-small.png",
-    "icon-medium": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-medium.png",
-    "icon-large": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-large.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-large.png"
   },
   "cli": {
     "binaries": {
@@ -35,7 +35,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.1-1.8.0/dcos-service-cli-darwin"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.4.1-1.8.0/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -47,7 +47,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.1-1.8.0/dcos-service-cli-linux"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.4.1-1.8.0/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -59,7 +59,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.4.1-1.8.0/dcos-service-cli.exe"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.4.1-1.8.0/dcos-service-cli.exe"
         }
       }
     }

--- a/repo/packages/N/nifi/600/resource.json
+++ b/repo/packages/N/nifi/600/resource.json
@@ -3,15 +3,15 @@
     "uris": {
       "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
-      "bootstrap-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/bootstrap.zip",
-      "scheduler-zip": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.5.0-1.9.2/nifi-scheduler.zip",
-      "executor-zip": "http://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/executor.zip",
-      "nifi-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-binary/nifi-1.9.2-bin.tar.gz",
-      "nifi-toolkit": "https://s3-ap-southeast-2.amazonaws.com/nifi-toolkit/nifi-toolkit-1.9.2-bin.tar.gz",
-      "nifi-janitor-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.5.0-1.9.2/nifi-janitor.jar",
-      "nifi-statsd-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.5.0-1.9.2/nifi-statsd.jar",
-      "nifi-api-access-jar": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.5.0-1.9.2/nifi-api-access.jar",
-      "nifi-python-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-python/python-2.7.14.tar.gz"
+      "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/bootstrap.zip",
+      "scheduler-zip": "https://downloads.mesosphere.com/nifi/assets/0.5.0-1.9.2/nifi-scheduler.zip",
+      "executor-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.40.2/executor.zip",
+      "nifi-tar-gz": "https://downloads.mesosphere.com/nifi/assets/0.5.0-1.9.2/nifi-1.9.2-bin.tar.gz",
+      "nifi-toolkit": "https://downloads.mesosphere.com/nifi/assets/0.5.0-1.9.2/nifi-toolkit-1.9.2-bin.tar.gz",
+      "nifi-janitor-jar": "https://downloads.mesosphere.com/nifi/assets/0.5.0-1.9.2/nifi-janitor.jar",
+      "nifi-statsd-jar": "https://downloads.mesosphere.com/nifi/assets/0.5.0-1.9.2/nifi-statsd.jar",
+      "nifi-api-access-jar": "https://downloads.mesosphere.com/nifi/assets/0.5.0-1.9.2/nifi-api-access.jar",
+      "nifi-python-tar-gz": "https://downloads.mesosphere.com/nifi/assets/python-2.7.14.tar.gz"
     },
     "container": {
       "docker": {
@@ -20,9 +20,9 @@
     }
   },
   "images": {
-    "icon-small": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-small.png",
-    "icon-medium": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-medium.png",
-    "icon-large": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-large.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-large.png"
   },
   "cli": {
     "binaries": {
@@ -35,7 +35,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.5.0-1.9.2/dcos-service-cli-darwin"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.5.0-1.9.2/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -47,7 +47,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.5.0-1.9.2/dcos-service-cli-linux"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.5.0-1.9.2/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -59,7 +59,7 @@
             }
           ],
           "kind": "executable",
-          "url": "https://nifi-bucket.s3.amazonaws.com/nifi/assets/0.5.0-1.9.2/dcos-service-cli.exe"
+          "url": "https://downloads.mesosphere.com/nifi/assets/0.5.0-1.9.2/dcos-service-cli.exe"
         }
       }
     }

--- a/repo/packages/P/portworx-nifi/0/resource.json
+++ b/repo/packages/P/portworx-nifi/0/resource.json
@@ -20,9 +20,9 @@
     }
   },
   "images": {
-    "icon-small": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-small.png",
-    "icon-medium": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-medium.png",
-    "icon-large": "https://s3-us-west-1.amazonaws.com/nifi-icons/nifi-icon-large.png"
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-large.png"
   },
   "cli": {
     "binaries": {


### PR DESCRIPTION
Resolves [D2IQ-62647 ](https://jira.d2iq.com/browse/D2IQ-62647)

Migrated the S3 bucket artifacts to downloads.mesosphere.com to avoid the issues after S3 bucket deletion. Changed existing resource-uris, images paths.

Soaked on soak200s, soak201s clusters.