### PR TITLE
Add airfield 0.3.0

### DIFF
--- a/repo/packages/A/airfield/2/config.json
+++ b/repo/packages/A/airfield/2/config.json
@@ -1,0 +1,145 @@
+
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "airfield",
+          "title": "Service name"
+        },
+        "user": {
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root",
+          "title": "User"
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": "",
+          "title": "Credential secret name (optional)"
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": false
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "marathon_lb_vhost": {
+          "description": "The domain name to make airfield available under, must be pointing to your marathon-lb",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "user"
+      ]
+    },
+    "node": {
+      "description": "airfield pod configuration properties",
+      "type": "object",
+      "properties": {
+        "cpus": {
+          "title": "CPU count",
+          "description": "airfield pod CPU requirements",
+          "type": "number",
+          "default": 0.5
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "airfield pod mem requirements (in MB)",
+          "type": "integer",
+          "default": 512
+        }
+      },
+      "required": [
+        "cpus",
+        "mem"
+      ]
+    },
+    "airfield": {
+      "description": "Airfield specific configuration",
+      "type": "object",
+      "properties": {
+        "consul_endpoint": {
+          "title": "Endpoint for consul",
+          "description": "HTTP Endpoint for consul, e.g. \"http://api.consul.l4lb.thisdcos.directory:8500/v1\" if you use the consul package. Either this or etcd_endpoint must be set",
+          "type": "string"
+        },
+        "etcd_endpoint": {
+          "title": "Endpoint for etcd",
+          "description": "Endpoint for etcd, e.g. \"http://api.etcd.l4lb.thisdcos.directory:2379\" if you use the etcd package. Either this or consul_endpoint must be set",
+          "type": "string"
+        },
+        "app_group": {
+          "title": "Marathon App group for zeppelin instances",
+          "description": "app group to start zeppelin instances under. If not set \"airfield-zeppelin\" is used.",
+          "type": "string"
+        },
+        "dcos_groups_mapping_base64": {
+          "title": "DC/OS groups mapping base64 encoded",
+          "description": "JSON-key-value mapping of group names to marathon app groups. Encoded in base64.",
+          "type": "string"
+        },
+        "config_base_key": {
+          "title": "Key prefix in consul/etcd",
+          "description": "Key prefix in consul/etcd to use for storing airfield config. If not set \"airfield\" is used.",
+          "type": "string"
+        },
+        "dcos_base_url": {
+          "title": "Base URL of the DC/OS adminrouter",
+          "description": "URL of the DC/OS adminrouter. Default works under EE clusters in permissive/strict mode. Set this to \"http://leader.mesos\" if running on OpenSource DC/OS",
+          "type": "string"
+        },
+        "oidc_config_base64": {
+          "title": "Base64-encoded oidc config",
+          "description": "OIDC client configuration. See https://github.com/MaibornWolff/dcos-airfield/blob/master/airfield-microservice/airfield/resources/keycloak_example.json for an example. Encode the file with 'base64 -wc 0 oidc.json' and use the result as value for this config.",
+          "type": "string",
+          "default": ""
+        },
+        "hdfs_config": {
+          "title": "HDFS Config URL",
+          "description": "URL to download hdfs-site.xml and core-site.xml from to configure HDFS access. Will be passed to zeppelin. For a default DC/OS HDFS installation this is 'http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints'",
+          "type": "string"
+        },
+        "cost_tracking": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Enable cost tracking",
+              "type": "boolean",
+              "default": false
+            },
+            "currency": {
+              "title": "Currency",
+              "description": "Currency to use when displaying costs. Has no effect on cost calculation.",
+              "type": "string",
+              "default": "EURO"
+            },
+            "cost_gb_per_minute": {
+              "title": "Cost of 1 GB per minute",
+              "description": "Cost of 1 GB of RAM reserved for an instance for 1 minute.",
+              "type": "number",
+              "default": 0.0
+            },
+            "cost_core_per_minute": {
+              "title": "Cost of 1 core per minute",
+              "description": "Cost of 1 cpu core reserved for an instance for 1 minute.",
+              "type": "number",
+              "default": 0.0
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/A/airfield/2/marathon.json.mustache
+++ b/repo/packages/A/airfield/2/marathon.json.mustache
@@ -1,0 +1,107 @@
+
+{
+  "id": "{{service.name}}",
+  "user": "{{service.user}}",
+  "instances": 1,
+  "cpus": {{node.cpus}},
+  "mem": {{node.mem}},
+  "container": {
+    "type": "MESOS",
+    "portMappings": [
+      {
+        "containerPort": 5000
+      }
+    ],
+    "docker": {
+      "image": "{{resource.assets.container.docker.airfield}}",
+      "forcePullImage": false
+    }
+  },
+  "networks": [
+    {{#service.virtual_network_enabled}}
+    {
+      "name": "{{service.virtual_network_name}}",
+      "mode": "container"
+    }
+    {{/service.virtual_network_enabled}}
+    {{^service.virtual_network_enabled}}
+    {
+      "mode": "container/bridge"
+    }
+    {{/service.virtual_network_enabled}}
+  ],
+  "labels": {
+    {{#service.marathon_lb_vhost}}
+    "HAPROXY_GROUP": "external",
+    "HAPROXY_0_VHOST": "{{service.marathon_lb_vhost}}",
+    {{/service.marathon_lb_vhost}}
+    "DCOS_SERVICE_NAME": "{{service.name}}"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": {
+      "secret": "serviceCredential"
+    },
+    {{/service.service_account_secret}}
+    "ZEPPELIN_DOCKER_IMAGE": "{{resource.assets.container.docker.zeppelin}}",
+    "SPARK_MESOS_EXECUTOR_DOCKER_IMAGE": "{{resource.assets.container.docker.spark}}",
+    {{#airfield.dcos_base_url}}
+    "DCOS_BASE_URL": "{{airfield.dcos_base_url}}",
+    {{/airfield.dcos_base_url}}
+    {{#airfield.consul_endpoint}}
+    "AIRFIELD_CONSUL_ENDPOINT": "{{airfield.consul_endpoint}}",
+    {{/airfield.consul_endpoint}}
+    {{#airfield.etcd_endpoint}}
+    "AIRFIELD_ETCD_ENDPOINT": "{{airfield.etcd_endpoint}}",
+    {{/airfield.etcd_endpoint}}
+    {{#airfield.config_base_key}}
+    "AIRFIELD_CONFIG_BASE_KEY": "{{airfield.config_base_key}}",
+    {{/airfield.config_base_key}}
+    {{#airfield.app_group}}
+    "AIRFIELD_MARATHON_APP_GROUP": "{{airfield.app_group}}",
+    {{/airfield.app_group}}
+    {{#airfield.dcos_groups_mapping_base64}}
+    "AIRFIELD_DCOS_GROUPS_ENABLED": "true",
+    "AIRFIELD_DCOS_GROUPS_MAPPING_BASE64": "{{airfield.dcos_groups_mapping_base64}}",
+    {{/airfield.dcos_groups_mapping_base64}}
+    {{#airfield.oidc_config_base64}}
+    "AIRFIELD_OIDC_ACTIVATED": "true",
+    "AIRFIELD_OIDC_SECRET_BASE64": "{{airfield.oidc_config_base64}}",
+    {{/airfield.oidc_config_base64}}
+    {{#airfield.cost_tracking.enabled}}
+    "AIRFIELD_COST_TRACKING_ENABLED": "true",
+    "AIRFIELD_COST_CORE_PER_MINUTE": "{{airfield.cost_tracking.cost_core_per_minute}}",
+    "AIRFIELD_COST_GB_PER_MINUTE": "{{airfield.cost_tracking.cost_gb_per_minute}}",
+    "AIRFIELD_COST_CURRENCY": "{{airfield.cost_tracking.currency}}",
+    {{/airfield.cost_tracking.enabled}}
+    {{#airfield.hdfs_config}}
+    "HDFS_CONFIG_FOLDER": "{{airfield.hdfs_config}}",
+    {{/airfield.hdfs_config}}
+    "PACKAGE_NAME": "airfield",
+    "PACKAGE_VERSION": "0.3.0",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1589809994526",
+    "PACKAGE_BUILD_TIME_STR": "2020-05-18T13:53:14.526854"
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/",
+      "portIndex": 0,
+      "timeoutSeconds": 10,
+      "gracePeriodSeconds": 20,
+      "intervalSeconds": 20,
+      "maxConsecutiveFailures": 6
+    }
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  }
+}

--- a/repo/packages/A/airfield/2/package.json
+++ b/repo/packages/A/airfield/2/package.json
@@ -18,5 +18,6 @@
     }
   ],
   "postInstallNotes": "Airfield is being installed!\n\n\tDocumentation: https://github.com/MaibornWolff/dcos-airfield\n\tIssues: https://github.com/MaibornWolff/dcos-airfield",
-  "postUninstallNotes": "Airfield is being uninstalled."
+  "postUninstallNotes": "Airfield is being uninstalled.",
+  "lastUpdated": 1589952106
 }

--- a/repo/packages/A/airfield/2/package.json
+++ b/repo/packages/A/airfield/2/package.json
@@ -1,0 +1,22 @@
+
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [],
+  "downgradesTo": [],
+  "minDcosReleaseVersion": "1.11",
+  "name": "airfield",
+  "version": "0.3.0",
+  "maintainer": "https://github.com/MaibornWolff/dcos-airfield",
+  "description": "Airfield - easily start and manage zeppelin instances on DC/OS",
+  "selected": false,
+  "framework": false,
+  "tags": ["airfield", "zeppelin", "spark"],
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/MaibornWolff/dcos-airfield/master/LICENSE"
+    }
+  ],
+  "postInstallNotes": "Airfield is being installed!\n\n\tDocumentation: https://github.com/MaibornWolff/dcos-airfield\n\tIssues: https://github.com/MaibornWolff/dcos-airfield",
+  "postUninstallNotes": "Airfield is being uninstalled."
+}

--- a/repo/packages/A/airfield/2/resource.json
+++ b/repo/packages/A/airfield/2/resource.json
@@ -1,0 +1,17 @@
+
+{
+  "assets": {
+    "container": {
+      "docker": {
+        "airfield": "maibornwolff/airfield:0.3.0",
+        "zeppelin": "maibornwolff/zeppelin:1.1-0.8.1-all-2.4.0",
+        "spark": "mesosphere/spark:2.7.0-2.4.0-hadoop-2.7"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://github.com/MaibornWolff/dcos-airfield/raw/master/img/icon-service-default-small.png",
+    "icon-medium": "https://github.com/MaibornWolff/dcos-airfield/raw/master/img/icon-service-default-medium.png",
+    "icon-large": "https://github.com/MaibornWolff/dcos-airfield/raw/master/img/icon-service-default-large.png"
+  }
+}


### PR DESCRIPTION
New features:
* Cost tracking for instances (configure a cost per minute for cores and RAM and see how much money your instances cost)
* Support for Marathon groups (allows you to use quotas in DC/OS 2.0 to restrict resource usage)
* Better frontend performance
* Better handling of instance restarts/reconfigurations
* Better handling of notebook import/export

Source: https://github.com/MaibornWolff/dcos-airfield