### PR TITLE
[WIP]Add rabbitmq

### DIFF
--- a/repo/packages/R/rabbitmq/0/config.json
+++ b/repo/packages/R/rabbitmq/0/config.json
@@ -1,0 +1,214 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "description": "The name of the service instance",
+          "type": "string",
+          "default": "rabbitmq",
+          "title": "Service name"
+        },
+        "user": {
+          "description": "The user that the service will run as.",
+          "type": "string",
+          "default": "root",
+          "title": "User"
+        },
+        "service_account": {
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string",
+          "default": ""
+        },
+        "service_account_secret": {
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "type": "string",
+          "default": "",
+          "title": "Credential secret name (optional)"
+        },
+        "virtual_network_enabled": {
+          "description": "Enable virtual networking",
+          "type": "boolean",
+          "default": true
+        },
+        "virtual_network_name": {
+          "description": "The name of the virtual network to join",
+          "type": "string",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string",
+          "default": ""
+        },
+        "log_level": {
+          "description": "The log level for the DC/OS service.",
+          "type": "string",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Marathon-style placement constraint for scheduler. Example: 'hostname:UNIQUE'. By the way since the framework requires specific ports UNIQUE constraints is implicit.",
+          "type": "string",
+          "default": ""
+        },
+        "sleep": {
+          "description": "The sleep duration in seconds before tasks exit.",
+          "type": "number",
+          "default": 1000
+        }
+      },
+      "required": [
+        "name",
+        "sleep",
+        "user"
+      ]
+    },
+    "rabbitmq-resources": {
+      "description": "RabbitMQ nodes resources properties",
+      "type": "object",
+      "properties": {
+        "count": {
+          "title": "Node count",
+          "description": "Number of Template pods to run",
+          "type": "integer",
+          "default": 3
+        },
+        "cpus": {
+          "title": "CPU count",
+          "description": "Template pod CPU requirements",
+          "type": "number",
+          "default": 1
+        },
+        "mem": {
+          "title": "Memory size (MB)",
+          "description": "Template pod mem requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "disk": {
+          "title": "Disk size (MB)",
+          "description": "Template pod persistent disk requirements (in MB)",
+          "type": "integer",
+          "default": 1024
+        },
+        "disk_type": {
+          "title": "Disk type [ROOT, MOUNT]",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "type": "string",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "default": "ROOT"
+        },
+        "docker_image": {
+          "title": "Docker image",
+          "description": "docker image to use",
+          "type": "string",
+          "default": "hyge/rabbitmq:3.7.17-management"
+        },
+        "placement_constraint": {
+          "title": "Placement constraint",
+          "description": "Placement constraints for rabbitmq servers. Example: [[\"hostname\", \"UNIQUE\"]]",
+          "type": "string",
+          "default": "[[\"hostname\", \"UNIQUE\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "disk_type",
+        "docker_image"
+      ]
+    },
+    "rabbitmq-configuration": {
+      "description": "RabbitMQ configuration properties",
+      "type": "object",
+      "properties": {
+        "amqp_port": {
+          "title": "AMQP port",
+          "description": "The port where rabbitmq will listen for processing messages",
+          "type": "integer",
+          "default": 5672
+        },
+        "mgmt_port": {
+          "title": "RabbitMQ HTTP listener port",
+          "description": "The port where rabbitmq management console will listen",
+          "type": "integer",
+          "default": 15672
+        },
+        "cluster_name": {
+          "title": "Cluster Name",
+          "description": "[UNIMPLEMENTED] set the cluster name",
+          "type": "string",
+          "default": "rabbit"
+        },
+        "erlang_cookie": {
+          "title": "Erlang cookie",
+          "description": "The port where rabbitmq will listen",
+          "type": "string",
+          "default": "joinuswehavecookies"
+        },
+        "dist_port": {
+          "title": "DIST port",
+          "description": "The port where rabbitmq will listen for clustering",
+          "type": "integer",
+          "default": 25672
+        },
+        "epmd_port": {
+          "title": "EPMD port",
+          "description": "The port where rabbitmq will listen for processing messages",
+          "type": "integer",
+          "default": 4369
+        },
+        "default_pass": {
+          "title": "Default Password",
+          "description": "The default password",
+          "type": "string",
+          "default": "password"
+        },
+        "default_user": {
+          "title": "Default Admin username",
+          "description": "The default admin username",
+          "type": "string",
+          "default": "admin"
+        },
+        "log_level": {
+          "description": "The log level for the rabbitmq server.",
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "info",
+            "debug"
+          ],
+          "default": "info"
+        }
+      },
+      "required": [
+        "amqp_port",
+        "mgmt_port",
+        "cluster_name",
+        "erlang_cookie"
+      ]
+    }
+  }
+}

--- a/repo/packages/R/rabbitmq/0/marathon.json.mustache
+++ b/repo/packages/R/rabbitmq/0/marathon.json.mustache
@@ -1,0 +1,102 @@
+
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "user": "{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*); export JAVA_HOME=${JAVA_HOME%%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./operator-scheduler/bin/rabbitmq ./operator-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+    "PACKAGE_NAME": "rabbitmq",
+    "PACKAGE_VERSION": "stub-universe",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1576131495271",
+    "PACKAGE_BUILD_TIME_STR": "Thu Dec 12 2019 06:18:15 +0000",
+    "SERVICE_NAME": "{{service.name}}",
+    "SERVICE_USER": "{{service.user}}",
+    "SERVICE_PRINCIPAL": "{{service.principal}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    "RABBITMQ_RES_COUNT": "{{rabbitmq-resources.count}}",
+    "RABBITMQ_SVC_PLACEMENT": "{{service.placement_constraint}}",
+    "RABBITMQ_RES_CPUS": "{{rabbitmq-resources.cpus}}",
+    "RABBITMQ_RES_MEM": "{{rabbitmq-resources.mem}}",
+    "RABBITMQ_RES_DISK": "{{rabbitmq-resources.disk}}",
+    "RABBITMQ_RES_DISK_TYPE": "{{rabbitmq-resources.disk_type}}",
+    "RABBITMQ_RES_DOCKER_IMAGE": "{{ rabbitmq-resources.docker_image }}",
+    "RABBITMQ_RES_PLACEMENT": "{{rabbitmq-resources.placement_constraint}}",
+
+    "RABBITMQ_CFG_NODE_EPMD_PORT": "{{rabbitmq-configuration.epmd_port}}",
+    "RABBITMQ_CFG_NODE_AMQP_PORT": "{{rabbitmq-configuration.amqp_port}}",
+
+    "RABBITMQ_CFG_NODE_DIST_PORT": "{{rabbitmq-configuration.dist_port}}",
+    "RABBITMQ_CFG_MGMT_PORT": "{{rabbitmq-configuration.mgmt_port}}",
+    "RABBITMQ_CFG_ERLANG_COOKIE": "{{rabbitmq-configuration.erlang_cookie}}",
+    "RABBITMQ_CFG_CLUSTER_NAME": "{{ rabbitmq-configuration.cluster_name }}",
+    "RABBITMQ_LOG_LEVEL": "{{ rabbitmq-configuration.log_level }}",
+
+    "RABBITMQ_DEFAULT_PASS":"{{rabbitmq-configuration.default_pass}}",
+    "RABBITMQ_DEFAULT_USER":"{{rabbitmq-configuration.default_user}}",
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.service_account_secret}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/R/rabbitmq/0/package.json
+++ b/repo/packages/R/rabbitmq/0/package.json
@@ -1,0 +1,23 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "*"
+  ],
+  "downgradesTo": [
+    "*"
+  ],
+  "minDcosReleaseVersion": "1.12",
+  "name": "rabbitmq",
+  "version": "0.1.1-3.7.17",
+  "maintainer": "hge@d2iq.com",
+  "description": "Rabbitmq cluster on DC/OS",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "0.1.0",
+    "rabbitmq"
+  ],
+  "postInstallNotes": "DC/OS rabbitmq is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/rabbitmq/\n\tIssues: https://docs.mesosphere.com/support/",
+  "postUninstallNotes": "DC/OS rabbitmq is being uninstalled.",
+  "lastUpdated": 1576131497
+}

--- a/repo/packages/R/rabbitmq/0/resource.json
+++ b/repo/packages/R/rabbitmq/0/resource.json
@@ -1,0 +1,61 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/openjdk-jre-8u212b03-hotspot-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.14-beta.tar.gz",
+      "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.56.3/bootstrap.zip",
+      "scheduler-zip": "https://hge-dcos.s3.amazonaws.com/autodelete7d/rabbitmq/20191212-061814-d1H2fxAbVFrQVIte/operator-scheduler.zip",
+      "mc-uri": "https://dl.minio.io/client/mc/release/linux-amd64/mc"
+    },
+    "container": {
+      "docker": {
+        "rabbitmq": "hyge/rabbitmq:3.7.17-management"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://github.com/rabbitmq/rabbitmq-website/blob/master/site/img/rabbitmq_logo_30x30.png?raw=true",
+    "icon-medium": "https://github.com/rabbitmq/rabbitmq-website/blob/master/site/img/rabbitmq_logo_30x30.png?raw=true",
+    "icon-large": "https://github.com/rabbitmq/rabbitmq-website/blob/master/site/img/rabbitmq_logo_30x30.png?raw=true"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "cc1f17a9b1e5154b7da7e448defd62cf82faf69ed12f9975b1e1e7c30bc9da16"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://hge-dcos.s3.amazonaws.com/autodelete7d/rabbitmq/20191212-061814-d1H2fxAbVFrQVIte/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "d191b52e8641b41d770ad86de0e9b4524cd2cc77251762080ceba7656d1baf10"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://hge-dcos.s3.amazonaws.com/autodelete7d/rabbitmq/20191212-061814-d1H2fxAbVFrQVIte/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "be725657f3d6967802885dccd0a98051647f753119728a2ecfb434b3e83dde5a"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://hge-dcos.s3.amazonaws.com/autodelete7d/rabbitmq/20191212-061814-d1H2fxAbVFrQVIte/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added rabbitmq cluster as a service. Use the dns name `rabbitmq-X-server.rabbitmq.autoip.dcos.thisdcos.directory` to form cluster. Support scaling up.

TODO list:
1. Move `hge-dcos.s3.amazonaws.com/autodelete7d/rabbitmq/` to a official S3 address.
2. Move docker image `hyge/rabbitmq:3.7.17-management` to a official repo.