### PR TITLE
Add redis cluster

### DIFF
--- a/repo/packages/R/redis-cluster/0/config.json
+++ b/repo/packages/R/redis-cluster/0/config.json
@@ -1,0 +1,211 @@
+{
+  "properties": {
+    "nodes": {
+      "description": "DC/OS Redis node configuration properties",
+      "properties": {
+        "count": {
+          "default": 6,
+          "description": "Number of Template pods to run, should be a multiple of (replicas + 1)",
+          "title": "Node count",
+          "minimum": 6,
+          "type": "integer"
+        },
+        "replicas": {
+          "default": 1,
+          "description": "Replicas of redis-cluster",
+          "title": "Cluster replicas",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "cpus": {
+          "default": 0.5,
+          "description": "Template pod CPU requirements",
+          "title": "CPU count",
+          "type": "number"
+        },
+        "disk": {
+          "default": 1024,
+          "description": "Template pod persistent disk requirements (in MB)",
+          "title": "Disk size (MB)",
+          "type": "integer"
+        },
+        "disk_type": {
+          "default": "ROOT",
+          "description": "Mount volumes require preconfiguration in DC/OS",
+          "enum": [
+            "ROOT",
+            "MOUNT"
+          ],
+          "title": "Disk type [ROOT, MOUNT]",
+          "type": "string"
+        },
+        "docker_image": {
+          "default": "redis",
+          "description": "docker image to use",
+          "title": "Docker image",
+          "type": "string"
+        },
+        "mem": {
+          "default": 1024,
+          "description": "Template pod mem requirements (in MB)",
+          "title": "Memory size (MB)",
+          "type": "integer"
+        },
+        "placement_constraint": {
+          "default": "[[\"hostname\", \"UNIQUE\"]]",
+          "description": "Placement constraints for redis-cluster servers. Example: [[\"hostname\", \"UNIQUE\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          },
+          "title": "Placement constraint",
+          "type": "string"
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "disk",
+        "disk_type",
+        "docker_image"
+      ],
+      "type": "object"
+    },
+    "service": {
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "log_level": {
+          "default": "INFO",
+          "description": "The log level for the DC/OS service.",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "type": "string"
+        },
+        "name": {
+          "default": "redis-cluster",
+          "description": "The name of the service instance",
+          "title": "Service name",
+          "type": "string"
+        },
+        "placement_constraint": {
+          "default": "",
+          "description": "Marathon-style placement constraint for scheduler. Example: 'hostname:UNIQUE'. By the way since the framework requires specific ports UNIQUE constraints is implicit.",
+          "title": "Placement constraint",
+          "type": "string"
+        },
+        "service_account": {
+          "default": "",
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "type": "string"
+        },
+        "service_account_secret": {
+          "default": "",
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "title": "Credential secret name (optional)",
+          "type": "string"
+        },
+        "sleep": {
+          "default": 1000,
+          "description": "The sleep duration in seconds before tasks exit.",
+          "type": "number"
+        },
+        "user": {
+          "default": "root",
+          "description": "The user that the service will run as.",
+          "title": "User",
+          "type": "string"
+        },
+        "virtual_network_enabled": {
+          "default": true,
+          "description": "Enable virtual networking",
+          "type": "boolean"
+        },
+        "virtual_network_name": {
+          "default": "dcos",
+          "description": "The name of the virtual network to join",
+          "type": "string"
+        },
+        "virtual_network_plugin_labels": {
+          "default": "",
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "sleep",
+        "user"
+      ],
+      "type": "object"
+    },
+    "redis": {
+      "description": "Redis configuration properties",
+      "type": "object",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "description": "The port that will be used for redis-cli",
+          "default": 6379
+        },
+        "cluster_node_timeout": {
+          "type": "integer",
+          "description": "The port that will be used for redis-cli",
+          "default": 5000
+        },
+        "requirepass": {
+          "type": "string",
+          "description": "Redis password",
+          "default": ""
+        },
+        "tcp_keepalive": {
+          "type": "integer",
+          "description": "Use SO_KEEPALIVE to send TCP ACKs to clients in absence of communication",
+          "default": 60
+        },
+        "redis_timeout": {
+          "type": "integer",
+          "description": "Timeout value of a redis server. Close the connection after a client is idle for N seconds (0 to disable)",
+          "default": 0
+        },
+        "save900": {
+          "type": "integer",
+          "description": "The number of write operations in 900s required to save a RDB snapshot to disks",
+          "default": 1
+        },
+        "save300": {
+          "type": "integer",
+          "description": "The number of write operations in 300s required to save a RDB snapshot to disks",
+          "default": 10
+        },
+        "save60": {
+          "type": "integer",
+          "description": "The number of write operations in 60s required to save a RDB snapshot to disks",
+          "default": 10000
+        },
+        "appendonly": {
+          "type": "string",
+          "enum": [
+            "yes",
+            "no"
+          ],
+          "description": "Enable the append-only persistent mode",
+          "default": "no"
+        },
+        "config_uri": {
+          "type": "string",
+          "description": "The uri for redis.conf. If uri specified, other configuration will be invalid.",
+          "default": ""
+        }
+      }
+    }
+  },
+  "type": "object"
+}

--- a/repo/packages/R/redis-cluster/0/marathon.json.mustache
+++ b/repo/packages/R/redis-cluster/0/marathon.json.mustache
@@ -1,0 +1,102 @@
+
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "user": "{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH; export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so); export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*); export JAVA_HOME=${JAVA_HOME%%/}; export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms256M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./operator-scheduler/bin/redis-cluster ./operator-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+    "PACKAGE_NAME": "redis-cluster",
+    "PACKAGE_VERSION": "stub-universe",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1593620728124",
+    "PACKAGE_BUILD_TIME_STR": "Wed Jul 01 2020 16:25:28 +0000",
+    "SERVICE_NAME": "{{service.name}}",
+    "SERVICE_USER": "{{service.user}}",
+    "SERVICE_PRINCIPAL": "{{service.principal}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+    "NODE_COUNT": "{{nodes.count}}",
+    "NODE_REPLICAS": "{{nodes.replicas}}",
+    "NODE_CPUS": "{{nodes.cpus}}",
+    "NODE_MEM": "{{nodes.mem}}",
+    "NODE_DISK": "{{nodes.disk}}",
+    "NODE_DISK_TYPE": "{{nodes.disk_type}}",
+    "NODE_DOCKER_IMAGE": "{{ nodes.docker_image }}",
+    "NODE_PLACEMENT": "{{nodes.placement_constraint}}",
+
+    "REDIS_PORT": "{{redis.port}}",
+    "REQUIREPASS": "{{redis.requirepass}}",
+    "REDIS_CONF_URI": "{{redis.config_uri}}",
+    "APPENDONLY": "{{redis.appendonly}}",
+    "RDB900": "{{redis.save900}}",
+    "RDB300": "{{redis.save300}}",
+    "RDB60": "{{redis.save60}}",
+    "TCP_KEEPALIVE":"{{redis.tcp_keepalive}}",
+    "REDIS_TIMEOUT":"{{redis.redis_timeout}}",
+    "CLUSTER_NODE_TIMEOUT": "{{redis.cluster_node_timeout}}",
+
+    "REDIS_CLI_IMAGE": "{{resource.assets.container.docker.redis-cli}}",
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.service_account_secret}}
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  },
+  "uris": [
+    "{{resource.assets.uris.bootstrap-zip}}",
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api"
+    }
+  ]
+}

--- a/repo/packages/R/redis-cluster/0/package.json
+++ b/repo/packages/R/redis-cluster/0/package.json
@@ -1,0 +1,22 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [
+    "*"
+  ],
+  "downgradesTo": [
+    "*"
+  ],
+  "minDcosReleaseVersion": "1.12",
+  "name": "redis-cluster",
+  "version": "0.1.0-5.0.5",
+  "maintainer": "hge@d2iq.com",
+  "description": "Redis cluster on DC/OS",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "redis"
+  ],
+  "postInstallNotes": "DC/OS redis-cluster is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/service-docs/redis-cluster/\n\tIssues: https://docs.mesosphere.com/support/",
+  "postUninstallNotes": "DC/OS redis-cluster is being uninstalled.",
+  "lastUpdated": 1593620755
+}

--- a/repo/packages/R/redis-cluster/0/resource.json
+++ b/repo/packages/R/redis-cluster/0/resource.json
@@ -1,0 +1,63 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/openjdk-jre-8u212b03-hotspot-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-1.14-beta.tar.gz",
+      "bootstrap-zip": "https://downloads.mesosphere.com/dcos-commons/artifacts/0.56.3/bootstrap.zip",
+      "scheduler-zip": "https://hge-dcos.s3.amazonaws.com/autodelete7d/redis-cluster/20200702-002517-7aIl3fsstWyoNKAH/operator-scheduler.zip"
+    },
+    "container": {
+      "docker": {
+        "redis-cli": "hyge/redis-cli"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/redis-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/redis-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/redis-icon-large.png",
+    "screenshots": [
+      "https://redis.io/images/redis-white.png"
+    ]
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "e8829cdacf4562988ba8cfb3ff14e0d2ba582dffd587ceb2fb967bfa2001a995"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://hge-dcos.s3.amazonaws.com/autodelete7d/redis-cluster/20200702-002517-7aIl3fsstWyoNKAH/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "180a9646ab16f672d056b8ac8bd3c68c2851165f155fb6c56f78759dab7265b5"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://hge-dcos.s3.amazonaws.com/autodelete7d/redis-cluster/20200702-002517-7aIl3fsstWyoNKAH/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "8e453d38d7e4e492680680080bf9725f31e8f3764d7faa7b0dcafe4db808ca6f"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://hge-dcos.s3.amazonaws.com/autodelete7d/redis-cluster/20200702-002517-7aIl3fsstWyoNKAH/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently, our community only has a single redis catalog service. I added a redis-cluster: https://redis.io/topics/cluster-tutorial

TODO:
1. Move `hge-dcos.s3.amazonaws.com/autodelete7d/redis-cluster/` to a official S3 address.
2. Here official redis image is used. But I think we can push to mesosphere's docker repo if necessary.