### PR TITLE
add a dcos-ui version to fix COPS-6139 on 1.13

### DIFF
--- a/repo/packages/D/dcos-ui/6/package.json
+++ b/repo/packages/D/dcos-ui/6/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "4.0",
+  "name": "dcos-ui",
+  "version": "2.100.0",
+  "tags": ["dcos-ui", "dcos", "ui"],
+  "maintainer": "frontend-dev@mesosphere.io",
+  "description": "DC/OS UI",
+  "scm": "https://github.com/dcos/dcos-ui",
+  "website": "https://dcos.io/",
+  "framework": false,
+  "minDcosReleaseVersion": "1.13",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/dcos/dcos-ui/master/LICENSE"
+    }
+  ],
+  "lastUpdated": 1592249438
+}

--- a/repo/packages/D/dcos-ui/6/resource.json
+++ b/repo/packages/D/dcos-ui/6/resource.json
@@ -1,0 +1,7 @@
+{
+  "assets": {
+    "uris": {
+      "dcos-ui-bundle": "https://github.com/dcos/dcos-ui/releases/download/v4.0.2/release.tar.gz"
+    }
+  }
+}


### PR DESCRIPTION
we want to provide a fix for COPS-6139 via the update service. 