### PR TITLE
Release portworx-nifi 1.3.1-0.3.0-1.7.1 (automated commit)

### DIFF
--- a/repo/packages/P/portworx-nifi/100/config.json
+++ b/repo/packages/P/portworx-nifi/100/config.json
@@ -1,0 +1,906 @@
+{
+  "type": "object",
+  "properties": {
+    "service": {
+      "type": "object",
+      "description": "DC/OS service configuration properties",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Apache NiFi",
+          "default": "portworx-nifi"
+        },
+        "user": {
+          "type": "string",
+          "description": "The user that the service will run as.",
+          "default": "root"
+        },
+        "service_account": {
+          "type": "string",
+          "description": "The service account for DC/OS service authentication. This is typically left empty to use the default unless service authentication is needed. The value given here is passed as the principal of Mesos framework.",
+          "default": ""
+        },
+        "service_account_secret": {
+          "type": "string",
+          "description": "Name of the Secret Store credentials to use for DC/OS service authentication. This should be left empty unless service authentication is needed.",
+          "default": ""
+        },
+        "virtual_network_enabled": {
+          "type": "boolean",
+          "description": "Enable virtual networking",
+          "default": false
+        },
+        "virtual_network_name": {
+          "type": "string",
+          "description": "The name of the virtual network to join",
+          "default": "dcos"
+        },
+        "virtual_network_plugin_labels": {
+          "type": "string",
+          "description": "Labels to pass to the virtual network plugin. Comma-separated key:value pairs. For example: k_0:v_0,k_1:v_1,...,k_n:v_n",
+          "default": ""
+        },
+        "mesos_api_version": {
+          "type": "string",
+          "title": "Apache Mesos Scheduler API version [V0, V1]",
+          "description": "Configures the Mesos API version to use. Possible values: V0 (non-HTTP), V1 (HTTP)",
+          "enum": [
+            "V0",
+            "V1"
+          ],
+          "default": "V1"
+        },
+        "log_level": {
+          "type": "string",
+          "title": "DC/OS Service Log Level",
+          "description": "The log level for the DC/OS service.",
+          "enum": [
+            "OFF",
+            "FATAL",
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG",
+            "TRACE",
+            "ALL"
+          ],
+          "default": "INFO"
+        },
+        "placement_constraint": {
+          "type": "string",
+          "description": "Placement constraint for Nifi nodes. Example: [[\"hostname\", \"UNIQUE\"]]",
+          "default": "[[\"hostname\", \"UNIQUE\"]]",
+          "media": {
+            "type": "application/x-zone-constraints+json"
+          }
+        },
+        "metrics_frequency": {
+          "type": "integer",
+          "description": "Frequency for pushing metrics diagnostics to StatsD(in seconds)",
+          "default": 20
+        },
+        "deploy_strategy": {
+          "enum": [
+            "serial",
+            "parallel"
+          ],
+          "description": "Deployment phase strategy. See documentation. [serial, parallel]",
+          "default": "serial"
+        },
+        "security": {
+          "description": "Nifi security settings",
+          "type": "object",
+          "properties": {
+            "kerberos_tls": {
+              "type": "object",
+              "description": "TLS, SSL and KERBEROS Authn/z configuration properties.",
+              "properties": {
+                "enable": {
+                  "description": "Enable TLS , SSL and KERBEROS authentication.",
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            },
+            "kerberos": {
+              "type": "object",
+              "description": "Kerberos configuration properties.",
+              "properties": {
+                "kdc": {
+                  "description": "KDC settings for Kerberos",
+                  "type": "object",
+                  "properties": {
+                    "hostname": {
+                      "type": "string",
+                      "description": "The name or address of a host running a KDC for the realm.",
+                      "default": "kdc.marathon.autoip.dcos.thisdcos.directory"
+                    },
+                    "port": {
+                      "type": "integer",
+                      "description": "The port of the host running a KDC for that realm.",
+                      "default": 2500
+                    }
+                  }
+                },
+                "realm": {
+                  "type": "string",
+                  "description": "The Kerberos realm used to render the principal of Nifi tasks.",
+                  "default": "LOCAL"
+                },
+                "primary": {
+                  "type": "string",
+                  "description": "The Kerberos primary used by Kafka tasks.  The full principal will be <service.kerberos.primary>/<mesos_dns_address>@<service.kerberos.realm>",
+                  "default": "nifi"
+                },
+                "keytab_secret": {
+                  "type": "string",
+                  "description": "The name of the DC/OS secret storing the keytab",
+                  "default": "__dcos_base64___keytab"
+                },
+                "authentication_expiration": {
+                  "type": "string",
+                  "title": "Authentication Expiration",
+                  "description": "The duration of how long the user authentication is valid for. If the user never logs out, they will be required to log back in following this duration",
+                  "default": "12 hours"
+                },
+                "debug": {
+                  "type": "boolean",
+                  "description": "Turn debug Kerberos logging on or off to assist in diagnosing issues with Kerberos authentication.",
+                  "default": false
+                },
+                "service_principal": {
+                  "type": "string",
+                  "title": "Kerberos Service Principal",
+                  "description": "The name of the NiFi Kerberos service principal",
+                  "default": "nifiprincipal@LOCAL"
+                },
+                "user_principal": {
+                  "type": "string",
+                  "title": "Kerberos User Principal",
+                  "description": "The name of the NiFi Kerberos User principal",
+                  "default": "nifiadmin@LOCAL"
+                },
+                "user_principal_keytab": {
+                  "type": "string",
+                  "title": "Kerberos User Principal Password Keytab",
+                  "description": "The Keytab for the NiFi Kerberos User principal",
+                  "default": "nifiadmin_kerberos_secret"
+                },
+                "cn_dn_node_identity": {
+                  "type": "string",
+                  "description": "Initial Node Identity for TLS",
+                  "default": "nifi"
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "name",
+        "user"
+      ]
+    },
+    "node": {
+      "type": "object",
+      "title": "NiFi Cluster Node Resources Configuration ",
+      "description": "NiFi Cluster Node Resources Configuration ",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "title": "NiFi Node Count",
+          "description": "Number of NiFi nodes to run",
+          "default": 2
+        },
+        "cpus": {
+          "type": "number",
+          "title": "CPU Shares",
+          "description": "NiFi Node CPU Requirements",
+          "default": 1
+        },
+        "mem": {
+          "type": "integer",
+          "title": "Memory size (MB)",
+          "description": "NiFi Node Memory Requirements (in MB)",
+          "default": 4096
+        },
+        "rlimit_nofile_soft": {
+          "type": "integer",
+          "title": "NiFi RLIMIT NOFILE Soft",
+          "description": "Maximum File Handles (Soft) Limit",
+          "default": 50000
+        },
+        "rlimit_nofile_hard": {
+          "type": "integer",
+          "title": "NiFi RLIMIT NOFILE Hard",
+          "description": "Maximum File Handles (Hard) Limit",
+          "default": 50000
+        },
+        "rlimit_nproc_soft": {
+          "type": "integer",
+          "title": "NiFi RLIMIT NPROC Soft",
+          "description": "Maximum Forked Processes (Soft) Limit",
+          "default": 10000
+        },
+        "rlimit_nproc_hard": {
+          "type": "integer",
+          "title": "NiFi RLIMIT NPROC Hard",
+          "description": "Maximum Forked Processes (Hard) Limit",
+          "default": 10000
+        },
+        "content_repository_portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "ContentRepoNifiVol"
+        },
+        "content_repository_portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "content_repository_disk_size": {
+          "type": "integer",
+          "description": "Persistent content repo volume size in MB",
+          "default": 1000
+        },
+        "database_repository_portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "DatabaseRepoNifiVol"
+        },
+        "database_repository_portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "database_repository_disk_size": {
+          "type": "integer",
+          "description": "Persistent database repo volume size in MB",
+          "default": 1000
+        },
+        "flowfile_repository_portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "FlowFileRepoNifiVol"
+        },
+        "flowfile_repository_portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "flowfile_repository_disk_size": {
+          "type": "integer",
+          "description": "Persistent flowfile repo volume size in MB",
+          "default": 1000
+        },
+        "provenance_repository_portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "ProvenanceRepoNifiVol"
+        },
+        "provenance_repository_portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "provenance_repository_disk_size": {
+          "type": "integer",
+          "description": "Persistent provenance repo volume size in MB",
+          "default": 1000
+        },
+        "misc_repository_portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "MiscRepoNifiVol"
+        },
+        "misc_repository_portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "misc_repository_disk_size": {
+          "type": "integer",
+          "description": "Persistent misc repo volume size in MB",
+          "default": 1000
+        },
+        "nifi_backup_portworx_volume_name": {
+          "description": "Portworx volume name",
+          "type": "string",
+          "default": "BackupNifiVol"
+        },
+        "nifi_backup_portworx_volume_options": {
+          "description": "Portworx volume options. Comma separated key=value pairs",
+          "type": "string",
+          "default": ""
+        },
+        "backup_disk_size": {
+          "type": "integer",
+          "description": "Persistent backup volume size in MB",
+          "default": 1000
+        },
+        "kill_grace_period": {
+          "description": "The number of seconds of grace to await a clean shutdown following SIGTERM before sending SIGKILL, default: `0`",
+          "type": "integer",
+          "default": 20
+        },
+        "nifi_bootstrap_jvm_min": {
+          "description": "Minimum Java Heap size in MB",
+          "type": "integer",
+          "default": 512
+        },
+        "nifi_bootstrap_jvm_max": {
+          "description": "Maximum Java Heap size in MB",
+          "type": "integer",
+          "default": 512
+        }
+      },
+      "required": [
+        "count",
+        "cpus",
+        "mem",
+        "backup_disk_size",
+        "misc_repository_disk_size",
+        "provenance_repository_disk_size",
+        "flowfile_repository_disk_size",
+        "content_repository_disk_size",
+        "database_repository_disk_size",
+        "nifi_backup_portworx_volume_name",
+        "content_repository_portworx_volume_name",
+        "database_repository_portworx_volume_name",
+        "flowfile_repository_portworx_volume_name",
+        "provenance_repository_portworx_volume_name",
+        "misc_repository_portworx_volume_name"
+      ]
+    },
+    "secrets": {
+      "type": "object",
+      "description": "These properties lets you to upolad files",
+      "properties": {
+        "enable": {
+          "description": "enable secrets",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "Advanced_Security": {
+      "type": "object",
+      "id": "https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#security-properties",
+      "description": "These properties pertain to various security features in NiFi",
+      "properties": {
+        "sensitive_props_key": {
+          "type": "string",
+          "title": "Sensitive Properties Encryption Key",
+          "description": "This is the password used to encrypt any sensitive property values that are configured in processors",
+          "default": ""
+        },
+        "sensitive_props_key_protected": {
+          "type": "string",
+          "title": "Sensitive Properties Encryption Key Protection",
+          "description": "This is the encryption key protection (aes/gcm/256)",
+          "default": ""
+        },
+        "sensitive_props_algorithm": {
+          "type": "string",
+          "title": "Sensitive Properties Encryption Algorithm",
+          "description": "The algorithm used to encrypt sensitive properties",
+          "default": "PBEWITHMD5AND256BITAES-CBC-OPENSSL"
+        },
+        "sensitive_props_provider": {
+          "type": "string",
+          "title": "Sensitive Properties Encryption Provider",
+          "description": "The sensitive property provider",
+          "default": "BC"
+        },
+        "sensitive_props_additional_keys": {
+          "type": "string",
+          "title": "Sensitive Properties Additional Keys",
+          "description": "The comma separated list of properties to encrypt in addition to the default sensitive properties (see Encrypt-Config Tool)",
+          "default": ""
+        },
+        "need_client_auth": {
+          "type": "string",
+          "title": "Need Client Auth",
+          "description": "This indicates whether client authentication in the cluster protocol",
+          "default": ""
+        },
+        "user_authorizer": {
+          "type": "string",
+          "title": "User Authorizer",
+          "description": "Specifies which of the configured Authorizers in the authorizers.xml file to use",
+          "default": "file-provider"
+        },
+        "user_login_identity_provider": {
+          "type": "string",
+          "title": "User Login Identity Provider",
+          "description": "This indicates what type of login identity provider to use",
+          "default": ""
+        },
+        "ocsp_responder_url": {
+          "type": "string",
+          "title": "OCSP Responder URL",
+          "description": "This is the URL for the Online Certificate Status Protocol (OCSP) responder if one is being used",
+          "default": ""
+        },
+        "ocsp_responder_certificate": {
+          "type": "string",
+          "title": "OCSP Responder Certificate",
+          "description": "This is the location of the OCSP responder certificate if one is being used",
+          "default": ""
+        }
+      }
+    },
+    "cluster": {
+      "type": "object",
+      "id": "https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#cluster-common-properties",
+      "title": "Cluster Configuration",
+      "description": "NiFi Cluster Configuration",
+      "properties": {
+        "protocol_heartbeat_interval": {
+          "type": "string",
+          "title": "Protocol Heartbeat Interval",
+          "description": "The interval at which nodes should emit heartbeats to the Cluster Coordinator",
+          "default": "5 secs"
+        },
+        "is_node": {
+          "type": "boolean",
+          "title": "Cluster Node?",
+          "description": "Set this to true if the instance is a node in a cluster",
+          "default": true
+        },
+        "node_protocol_port": {
+          "type": "integer",
+          "title": "Node Protocol Port",
+          "description": "The node's protocol port",
+          "default": 12000
+        },
+        "node_protocol_threads": {
+          "type": "integer",
+          "title": "Node Protocol Threads",
+          "description": "The number of threads that should be used to communicate with other nodes in the cluster",
+          "default": 10
+        },
+        "node_event_history_size": {
+          "type": "integer",
+          "title": "Node Event History Size",
+          "description": "When the state of a node in the cluster is changed, an event is generated and can be viewed in the Cluster page. This value indicates how many events to keep in memory for each node",
+          "default": 25
+        },
+        "node_connection_timeout": {
+          "type": "string",
+          "title": "Node Connection Timeout",
+          "description": "When connecting to another node in the cluster, specifies how long this node should wait before considering the connection a failure",
+          "default": "5 secs"
+        },
+        "node_read_timeout": {
+          "type": "string",
+          "title": "Node Read Timeout",
+          "description": "When communicating with another node in the cluster, specifies how long this node should wait to receive information from the remote node before considering the communication with the node a failure",
+          "default": "5 secs"
+        },
+        "firewall_file": {
+          "type": "string",
+          "title": "Firewall File (Relative) Path",
+          "description": "The location of the node firewall file. This is a file that may be used to list all the nodes that are allowed to connect to the cluster. It provides an additional layer of security",
+          "default": ""
+        },
+        "flow_election_max_wait_time": {
+          "type": "string",
+          "title": "Flow Election Max Wait Time",
+          "description": "Specifies the amount of time to wait before electing a Flow as the \"correct\" Flow. If the number of Nodes that have voted is equal to the number specified by the nifi.cluster.flow.election.max.candidates property, the cluster will not wait this long",
+          "default": "1 mins"
+        },
+        "flow_election_max_candidates": {
+          "type": "integer",
+          "title": "Flow Election Max Candidates",
+          "description": "Specifies the number of Nodes required in the cluster to cause early election of Flows. This allows the Nodes in the cluster to avoid having to wait a long time before starting processing if we reach at least this number of nodes in the cluster",
+          "default": 3
+        }
+      }
+    },
+    "zookeeper": {
+      "type": "object",
+      "id": "https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#zookeeper-properties",
+      "title": "Zookeeper Configuration",
+      "description": "NiFi depends on Apache ZooKeeper for determining which node in the cluster should play the role of Primary Node and which node should play the role of Cluster Coordinator. These properties must be configured in order for NiFi to join a cluster",
+      "properties": {
+        "connect_string": {
+          "type": "string",
+          "title": "Connection String",
+          "description": "The Connect String that is needed to connect to Apache ZooKeeper. This is a comma-separated list of hostname:port pairs",
+          "default": "master.mesos:2181"
+        },
+        "connect_timeout": {
+          "type": "string",
+          "title": "Connection Timeout",
+          "description": "How long to wait when connecting to ZooKeeper before considering the connection a failure",
+          "default": "3 secs"
+        },
+        "session_timeout": {
+          "type": "string",
+          "title": "Session Timeout",
+          "description": "How long to wait after losing a connection to ZooKeeper before the session is expired",
+          "default": "3 secs"
+        }
+      }
+    },
+    "core": {
+      "type": "object",
+      "id": "https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#core-properties-br",
+      "title": "Apache NiFi Core Configuration",
+      "description": "These properties apply to the core framework as a whole",
+      "properties": {
+        "flow_configuration_archive_enabled": {
+          "type": "boolean",
+          "title": "Enable Archival of Flow Configuration?",
+          "description": "Specifies whether NiFi creates a backup copy of the flow automatically when the flow is updated",
+          "default": true
+        },
+        "flow_configuration_archive_max_time": {
+          "type": "string",
+          "title": "Flow Configuration Archive Max Time",
+          "description": "The lifespan of archived flow.xml files",
+          "default": "30 days"
+        },
+        "flow_configuration_archive_max_storage": {
+          "type": "string",
+          "title": "Flow Configuration Archive Max Storage",
+          "description": "The total data size allowed for the archived flow.xml files",
+          "default": "500 MB"
+        },
+        "flow_configuration_archive_max_count": {
+          "type": "string",
+          "title": "Flow Configuration Archive Max Count",
+          "description": "The number of archive files allowed",
+          "default": ""
+        },
+        "flowcontroller_graceful_shutdown_period": {
+          "type": "string",
+          "title": "Flow Controller Graceful Shutdown Period",
+          "description": "Indicates the shutdown period",
+          "default": "10 secs"
+        },
+        "flowservice_writedelay_interval": {
+          "type": "string",
+          "title": "Flow Service Write Delay Interval",
+          "description": "When many changes are made to the flow.xml, this property specifies how long to wait before writing out the changes, so as to batch the changes into a single write",
+          "default": "500 ms"
+        },
+        "bored_yield_duration": {
+          "type": "string",
+          "title": "Bored Yield Duration",
+          "description": "When a component has no work to do (i.e., is \"bored\"), this is the amount of time it will wait before checking to see if it has new data to work on",
+          "default": "10 millis"
+        },
+        "queue_backpressure_count": {
+          "type": "string",
+          "title": "Queue Backpressure Count",
+          "description": "When drawing a new connection between two components, this is the default value for that connection's back pressure object threshold.",
+          "default": "10000"
+        },
+        "queue_backpressure_size": {
+          "type": "string",
+          "title": "Queue Backpressure Size",
+          "description": "When drawing a new connection between two components, this is the default value for that connection's back pressure data size threshold.",
+          "default": "1 GB"
+        },
+        "ui_banner_text": {
+          "type": "string",
+          "title": "UI Banner Text",
+          "description": "This is banner text that may be configured to display at the top of the User Interface",
+          "default": ""
+        },
+        "ui_autorefresh_interval": {
+          "type": "string",
+          "title": "UI Autorefresh Interval",
+          "description": "The interval at which the User Interface auto-refreshes",
+          "default": "30 secs"
+        },
+        "processor_scheduling_timeout": {
+          "type": "string",
+          "title": "Processor Scheduling Timeout",
+          "description": "Time to wait for a Processor's life-cycle operation (@OnScheduled and @OnUnscheduled) to finish before other life-cycle operation (e.g., stop) could be invoked",
+          "default": "1 mins"
+        }
+      }
+    },
+    "flowfile": {
+      "type": "object",
+      "id": "https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#flowfile-repository",
+      "title": "FlowFile Configuration",
+      "description": "The FlowFile repository keeps track of the attributes and current state of each FlowFile in the system",
+      "properties": {
+        "repository_partitions": {
+          "type": "integer",
+          "title": "FlowFile Repository Partitions",
+          "description": "The number of FlowFile partitions",
+          "default": 256
+        },
+        "repository_checkpoint_interval": {
+          "type": "string",
+          "title": "FlowFile Repository Checkpoint Interval",
+          "description": "The FlowFile Repository checkpoint interval",
+          "default": "2 mins"
+        },
+        "repository_always_sync": {
+          "type": "boolean",
+          "title": "Always Sync FlowFile Repository?",
+          "description": "If set to true, any change to the repository will be synchronized to the disk, meaning that NiFi will ask the operating system not to cache the information. This is very expensive and can significantly reduce NiFi performance. However, if it is false, there could be the potential for data loss if either there is a sudden power loss or the operating system crashes",
+          "default": false
+        }
+      }
+    },
+    "swap": {
+      "type": "object",
+      "id": "https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#swap-management",
+      "title": "Swap Configuration",
+      "description": "NiFi keeps FlowFile information in memory (the JVM) but during surges of incoming data, the FlowFile information can start to take up so much of the JVM that system performance suffers. To counteract this effect, NiFi \"swaps\" the FlowFile information to disk temporarily until more JVM space becomes available again",
+      "properties": {
+        "queue_swap_threshold": {
+          "type": "integer",
+          "title": "Swap Queue Threshold",
+          "description": "The queue threshold at which NiFi starts to swap FlowFile information to disk",
+          "default": 20000
+        },
+        "in_period": {
+          "type": "string",
+          "title": "Swap-In Period",
+          "description": "The swap in period",
+          "default": "5 secs"
+        },
+        "in_threads": {
+          "type": "integer",
+          "title": "Swap-In Threads",
+          "description": "The number of threads to use for swapping in",
+          "default": 1
+        },
+        "out_period": {
+          "type": "string",
+          "title": "Swap-Out Period",
+          "description": "The swap out period",
+          "default": "5 secs"
+        },
+        "out_threads": {
+          "type": "integer",
+          "title": "Swap-Out Threads",
+          "description": "The number of threads to use for swapping out",
+          "default": 4
+        }
+      }
+    },
+    "content": {
+      "type": "object",
+      "id": "https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#file-system-content-repository-properties",
+      "title": "Content Repository Configuration",
+      "description": "The Content Repository holds the content for all the FlowFiles in the system",
+      "properties": {
+        "claim_max_appendable_size": {
+          "type": "string",
+          "title": "Claim Max Appendable Size",
+          "description": "The maximum size for a content claim",
+          "default": "10 MB"
+        },
+        "claim_max_flow_files": {
+          "type": "integer",
+          "title": "Claim Max FlowFiles",
+          "description": "The maximum number of FlowFiles to assign to one content claim",
+          "default": 100
+        },
+        "repository_archive_max_retention_period": {
+          "type": "string",
+          "title": "Content Repository Archive Max Retention Period",
+          "description": "If archiving is enabled (see nifi.content.repository.archive.enabled below), then this property specifies the maximum amount of time to keep the archived data",
+          "default": "12 hours"
+        },
+        "repository_archive_max_usage_percentage": {
+          "type": "string",
+          "title": "Content Repository Archive Max Usage Percentage",
+          "description": "If archiving is enabled (see nifi.content.repository.archive.enabled below), then this property specifies the maximum amount of time to keep the archived data",
+          "default": "50%"
+        },
+        "repository_archive_enabled": {
+          "type": "boolean",
+          "title": "Enable Content Repository Archiving?",
+          "description": "To enable content archiving, set this to true and specify a value for the nifi.content.repository.archive.max.usage.percentage property above. Content archiving enables the provenance UI to view or replay content that is no longer in a dataflow queue",
+          "default": true
+        },
+        "repository_always_sync": {
+          "type": "boolean",
+          "title": "Always Sync Content Repository?",
+          "description": "If set to true, any change to the repository will be synchronized to the disk, meaning that NiFi will ask the operating system not to cache the information. This is very expensive and can significantly reduce NiFi performance. However, if it is false, there could be the potential for data loss if either there is a sudden power loss or the operating system crashes",
+          "default": false
+        },
+        "viewer_url": {
+          "type": "string",
+          "title": "Viewer URL",
+          "description": "The URL for a web-based content viewer if one is available",
+          "default": "/nifi-content-viewer/"
+        }
+      }
+    },
+    "volatile": {
+      "type": "object",
+      "id": "https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#volatile-content-repository-properties",
+      "title": "Volatile (In-Memory) FlowFile Repository Configuration",
+      "description": "Store flowfile content in memory instead of on disk (at the risk of data loss in the event of power/machine failure)",
+      "properties": {
+        "content_repository_max_size": {
+          "type": "string",
+          "title": "Volatile Content Repository Max Size",
+          "description": "The Content Repository maximum size in memory",
+          "default": "100 MB"
+        },
+        "content_repository_block_size": {
+          "type": "string",
+          "title": "Volatile Content Repository Block Size",
+          "description": "The Content Repository block size",
+          "default": "32 KB"
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "id": "https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#provenance-repository",
+      "title": "Provenance Repository Configuration",
+      "description": "The Provenance Repository contains the information related to Data Provenance",
+      "properties": {
+        "repository_max_storage_time": {
+          "type": "string",
+          "title": "Repository Max Storage Time",
+          "description": "The maximum amount of time to keep data provenance information",
+          "default": "24 hours"
+        },
+        "repository_max_storage_size": {
+          "type": "string",
+          "title": "Repository Max Storage Size",
+          "description": "The maximum amount of data provenance information to store at a time",
+          "default": "1 GB"
+        },
+        "repository_rollover_time": {
+          "type": "string",
+          "title": "Repository Rollover Time",
+          "description": "The amount of time to wait before rolling over the latest data provenance information so that it is available in the User Interface",
+          "default": "30 secs"
+        },
+        "repository_rollover_size": {
+          "type": "string",
+          "title": "Repository Rollover Size",
+          "description": "The amount of information to roll over at a time",
+          "default": "100 MB"
+        },
+        "repository_query_threads": {
+          "type": "integer",
+          "title": "Repository Query Threads",
+          "description": "The number of threads to use for Provenance Repository queries",
+          "default": 2
+        },
+        "repository_index_threads": {
+          "type": "integer",
+          "title": "Repository Index Threads",
+          "description": "The number of threads to use for indexing Provenance events so that they are searchable",
+          "default": 2
+        },
+        "repository_compress_on_rollover": {
+          "type": "boolean",
+          "title": "Compress Repository on Rollover?",
+          "description": "Indicates whether to compress the provenance information when an \"event file\" is rolled over",
+          "default": true
+        },
+        "repository_always_sync": {
+          "type": "boolean",
+          "title": "Always Sync Repository?",
+          "description": "If set to true, any change to the repository will be synchronized to the disk, meaning that NiFi will ask the operating system not to cache the information. This is very expensive and can significantly reduce NiFi performance. However, if it is false, there could be the potential for data loss if either there is a sudden power loss or the operating system crashes",
+          "default": false
+        },
+        "repository_journal_count": {
+          "type": "integer",
+          "title": "Repository Journal Count",
+          "description": "The number of journal files that should be used to serialize Provenance Event data. Increasing this value will allow more tasks to simultaneously update the repository but will result in more expensive merging of the journal files later. This value should ideally be equal to the number of threads that are expected to update the repository simultaneously, but 16 tends to work well in must environments",
+          "default": 16
+        },
+        "repository_indexed_fields": {
+          "type": "string",
+          "title": "Repository Indexed Fields",
+          "description": "This is a comma-separated list of the fields that should be indexed and made searchable. Fields that are not indexed will not be searchable. Valid fields are: EventType, FlowFileUUID, Filename, TransitURI, ProcessorID, AlternateIdentifierURI, Relationship, Details. The default value is: EventType, FlowFileUUID, Filename, ProcessorID",
+          "default": "EventType, FlowFileUUID, Filename, ProcessorID, Relationship"
+        },
+        "repository_indexed_attributes": {
+          "type": "string",
+          "title": "Repository Indexed Attributes",
+          "description": "This is a comma-separated list of FlowFile Attributes that should be indexed and made searchable. It is blank by default. But some good examples to consider are filename, uuid, and mime.type as well as any custom attritubes you might use which are valuable for your use case",
+          "default": ""
+        },
+        "repository_index_shard_size": {
+          "type": "string",
+          "title": "Repository Index Shard Size",
+          "description": "Large values for the shard size will result in more Java heap usage when searching the Provenance Repository but should provide better performance",
+          "default": "500 MB"
+        },
+        "repository_max_attribute_length": {
+          "type": "integer",
+          "title": "Repository Max Attribute Length",
+          "description": "Indicates the maximum length that a FlowFile attribute can be when retrieving a Provenance Event from the repository. If the length of any attribute exceeds this value, it will be truncated when the event is retrieved",
+          "default": 65536
+        },
+        "repository_buffer_size": {
+          "type": "integer",
+          "title": "Repository Buffer Size",
+          "description": "The (Volatile) Provenance Repository buffer size",
+          "default": 100000
+        },
+        "repository_concurrent_merge_threads": {
+          "type": "integer",
+          "title": "Repository Concurrent Merge Threads",
+          "description": "Apache Lucene creates several \"segments\" in an Index. These segments are periodically merged together in order to provide faster querying. This property specifies the maximum number of threads that are allowed to be used for each of the storage directories",
+          "default": 2
+        },
+        "repository_debug_frequency": {
+          "type": "string",
+          "title": "Repository Debug Frequency",
+          "description": "Controls the number of events processed between DEBUG statements documenting the performance metrics of the repository. This value is only used when DEBUG level statements are enabled in the log configuration",
+          "default": "1_000_000"
+        }
+      }
+    },
+    "components": {
+      "type": "object",
+      "id": "https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#component-status-repository",
+      "title": "Component Status Repository Configuration",
+      "description": "The Component Status Repository contains the information for the Component Status History tool in the User Interface",
+      "properties": {
+        "status_repository_buffer_size": {
+          "type": "integer",
+          "title": "Status Repository Buffer Size",
+          "description": "Specifies the buffer size for the Component Status Repository",
+          "default": 1440
+        },
+        "status_snapshot_frequency": {
+          "type": "string",
+          "title": "Status Repository Snapshot Frequency",
+          "description": "This value indicates how often to present a snapshot of the components' status history",
+          "default": "1 mins"
+        }
+      }
+    },
+    "remote": {
+      "type": "object",
+      "id": "https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#site_to_site_properties",
+      "title": "Site to Site Configuration",
+      "description": "These properties govern how this instance of NiFi communicates with remote instances of NiFi when Remote Process Groups are configured in the dataflow",
+      "properties": {
+        "input_socket_port": {
+          "type": "string",
+          "title": "Input Socket Port",
+          "description": "The remote input socket port for Site-to-Site communication. By default, it is blank, but it must have a value in order to use RAW socket as transport protocol for Site-to-Site",
+          "default": ""
+        },
+        "input_http_transaction_ttl": {
+          "type": "string",
+          "title": "Input HTTP Transaction TTL",
+          "description": "Specifies how long a transaction can stay alive on the server",
+          "default": "30 secs"
+        }
+      }
+    },
+    "web": {
+      "type": "object",
+      "id": "https://nifi.apache.org/docs/nifi-docs/html/administration-guide.html#web-properties",
+      "title": "Web UI Configuration",
+      "description": "These properties pertain to the web-based User Interface",
+      "properties": {
+        "proxy_host": {
+          "type": "string",
+          "title": "Proxy Host",
+          "description": "Allowed HTTP Host header values",
+          "default": ""
+        },
+        "proxy_context_path": {
+          "type": "string",
+          "title": "Proxy Context Path",
+          "description": "List of allowed HTTP X-ProxyContextPath or X-Forwarded-Context header values",
+          "default": ""
+        }
+      }
+    }
+  }
+}

--- a/repo/packages/P/portworx-nifi/100/marathon.json.mustache
+++ b/repo/packages/P/portworx-nifi/100/marathon.json.mustache
@@ -1,0 +1,313 @@
+{
+  "id": "{{service.name}}",
+  "cpus": 1.0,
+  "mem": 1024,
+  "instances": 1,
+  "user": "{{service.user}}",
+  "cmd": "export LD_LIBRARY_PATH=$MESOS_SANDBOX/libmesos-bundle/lib:$LD_LIBRARY_PATH && export MESOS_NATIVE_JAVA_LIBRARY=$(ls $MESOS_SANDBOX/libmesos-bundle/lib/libmesos-*.so) && export JAVA_HOME=$(ls -d $MESOS_SANDBOX/jdk*/jre*/) && export JAVA_HOME=${JAVA_HOME%/} && export PATH=$(ls -d $JAVA_HOME/bin):$PATH && export JAVA_OPTS=\"-Xms512M -Xmx512M -XX:-HeapDumpOnOutOfMemoryError\" && ./bootstrap -resolve=false -template=false && ./nifi-scheduler/bin/nifi ./nifi-scheduler/svc.yml",
+  "labels": {
+    "DCOS_COMMONS_API_VERSION": "v1",
+    "DCOS_COMMONS_UNINSTALL": "true",
+    "DCOS_PACKAGE_FRAMEWORK_NAME": "{{service.name}}",
+    "MARATHON_SINGLE_INSTANCE_APP": "true",
+    "DCOS_SERVICE_NAME": "{{service.name}}",
+    "DCOS_SERVICE_PORT_INDEX": "0",
+    "DCOS_SERVICE_SCHEME": "http"
+  },
+  {{#service.service_account_secret}}
+  "secrets": {
+    "serviceCredential": {
+      "source": "{{service.service_account_secret}}"
+    }
+  },
+  {{/service.service_account_secret}}
+  "env": {
+    "PACKAGE_NAME": "portworx-nifi",
+    "PACKAGE_VERSION": "1.3.1-0.3.0-1.7.1",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1596135532588",
+    "PACKAGE_BUILD_TIME_STR": "Thu Jul 30 2020 18:58:52 +0000",
+    "FRAMEWORK_NAME": "{{service.name}}",
+    "FRAMEWORK_USER": "{{service.user}}",
+    "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
+    "FRAMEWORK_LOG_LEVEL": "{{service.log_level}}",
+    "FRAMEWORK_ZOOKEEPER": "master.mesos:2181",
+
+    "MESOS_API_VERSION": "{{service.mesos_api_version}}",
+
+    "DEPLOY_STRATEGY": "{{service.deploy_strategy}}",
+    "BACKUP_NIFI_DOCKER_VOLUME_NAME": "{{{node.nifi_backup_portworx_volume_name}}}",
+    "BACKUP_NIFI_DOCKER_DRIVER_OPTIONS": "{{{node.nifi_backup_portworx_volume_options}}}",
+    "BACKUP_DISK_SIZE": "{{node.backup_disk_size}}",
+
+    "JAVA_URI": "{{resource.assets.uris.jre-tar-gz}}",
+    "LIBMESOS_URI": "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "BOOTSTRAP_URI": "{{resource.assets.uris.bootstrap-zip}}",
+    "EXECUTOR_URI": "{{resource.assets.uris.executor-zip}}",
+    "NIFI_URI": "{{resource.assets.uris.nifi-tar-gz}}",
+    "NIFI_TOOLKIT_URI": "{{resource.assets.uris.nifi-toolkit}}",
+    "NIFI_JANITOR_JAR_URI": "{{resource.assets.uris.nifi-janitor-jar}}",
+    "NIFI_STATSD_JAR_URI": "{{resource.assets.uris.nifi-statsd-jar}}",
+    "NIFI_API_ACCESS_JAR_URI": "{{resource.assets.uris.nifi-api-access-jar}}",
+    "NIFI_PYHTON_URI": "{{resource.assets.uris.nifi-python-tar-gz}}",
+
+    "NIFI_VERSION": "1.7.1",
+
+    "BASE_NIFI_IMAGE" : "{{resource.assets.container.docker.nifi}}",
+
+    "CONFIG_TEMPLATE_PATH": "nifi-scheduler",
+
+    {{#service.service_account_secret}}
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" },
+    "MESOS_MODULES": "{\"libraries\":[{\"file\":\"libmesos-bundle\/lib\/mesos\/libdcos_security.so\",\"modules\":[{\"name\": \"com_mesosphere_dcos_ClassicRPCAuthenticatee\"},{\"name\":\"com_mesosphere_dcos_http_Authenticatee\",\"parameters\":[{\"key\":\"jwt_exp_timeout\",\"value\":\"5mins\"},{\"key\":\"preemptive_refresh_duration\",\"value\":\"30mins\"}]}]}]}",
+    "MESOS_AUTHENTICATEE": "com_mesosphere_dcos_ClassicRPCAuthenticatee",
+    "MESOS_HTTP_AUTHENTICATEE": "com_mesosphere_dcos_http_Authenticatee",
+    {{/service.service_account_secret}}
+
+    "NODE_COUNT": "{{node.count}}",
+    "NODE_CPUS": "{{node.cpus}}",
+    "NODE_MEM": "{{node.mem}}",
+    "NODE_PORT": "0",
+
+    "TASKCFG_ALL_SECRETS_ENABLED": "false",
+    "TASKCFG_ALL_SECRETS_SECRET_ENABLED": "false",
+
+    {{#service.security.kerberos_tls.enable}}
+    "TASKCFG_ALL_SECRETS_ENABLED": "true",
+    {{#secrets.enable}}
+    "TASKCFG_ALL_SECRETS_SECRET_ENABLED": "true",
+    {{/secrets.enable}}
+    {{/service.security.kerberos_tls.enable}}
+
+    {{^service.security.kerberos_tls.enable}}
+    {{#secrets.enable}}
+    "TASKCFG_ALL_SECRETS_ENABLED": "true",
+    "TASKCFG_ALL_SECRETS_SECRET_ENABLED": "true",
+    {{/secrets.enable}}
+    {{/service.security.kerberos_tls.enable}}
+
+    "NODE_RLIMIT_NOFILE_SOFT": "{{node.rlimit_nofile_soft}}",
+    "NODE_RLIMIT_NOFILE_HARD": "{{node.rlimit_nofile_hard}}",
+    "NODE_RLIMIT_NPROC_SOFT": "{{node.rlimit_nproc_soft}}",
+    "NODE_RLIMIT_NPROC_HARD": "{{node.rlimit_nproc_hard}}",
+
+    "NODE_PLACEMENT_CONSTRAINTS": "{{{service.placement_constraint}}}",
+
+    {{#service.virtual_network_enabled}}
+    "ENABLE_VIRTUAL_NETWORK": "yes",
+    "VIRTUAL_NETWORK_NAME": "{{service.virtual_network_name}}",
+    "VIRTUAL_NETWORK_PLUGIN_LABELS": "{{service.virtual_network_plugin_labels}}",
+    {{/service.virtual_network_enabled}}
+
+    "NODE_CONTENT_REPOSITORY_DISK_PATH": "content-repository",
+    "NODE_CONTENT_REPOSITORY_NIFI_DOCKER_VOLUME_NAME": "{{{node.content_repository_portworx_volume_name}}}",
+    "NODE_CONTENT_REPOSITORY_NIFI_DOCKER_DRIVER_OPTIONS": "{{{node.content_repository_portworx_volume_options}}}",
+    "NODE_CONTENT_REPOSITORY_DISK_SIZE": "{{node.content_repository_disk_size}}",
+
+    "NODE_DATABASE_REPOSITORY_DISK_PATH": "database-repository",
+    "NODE_DATABASE_REPOSITORY_NIFI_DOCKER_VOLUME_NAME": "{{{node.database_repository_portworx_volume_name}}}",
+    "NODE_DATABASE_REPOSITORY_NIFI_DOCKER_DRIVER_OPTIONS": "{{{node.database_repository_portworx_volume_options}}}",
+    "NODE_DATABASE_REPOSITORY_DISK_SIZE": "{{node.database_repository_disk_size}}",
+
+    "NODE_FLOWFILE_REPOSITORY_DISK_PATH": "flowfile-repository",
+    "NODE_FLOWFILE_REPOSITORY_NIFI_DOCKER_VOLUME_NAME": "{{{node.flowfile_repository_portworx_volume_name}}}",
+    "NODE_FLOWFILE_REPOSITORY_NIFI_DOCKER_DRIVER_OPTIONS": "{{{node.flowfile_repository_portworx_volume_options}}}",
+    "NODE_FLOWFILE_REPOSITORY_DISK_SIZE": "{{node.flowfile_repository_disk_size}}",
+
+    "NODE_PROVENANCE_REPOSITORY_DISK_PATH": "provenance-repository",
+    "NODE_PROVENANCE_REPOSITORY_NIFI_DOCKER_VOLUME_NAME": "{{{node.provenance_repository_portworx_volume_name}}}",
+    "NODE_PROVENANCE_REPOSITORY_NIFI_DOCKER_DRIVER_OPTIONS": "{{{node.provenance_repository_portworx_volume_options}}}",
+    "NODE_PROVENANCE_REPOSITORY_DISK_SIZE": "{{node.provenance_repository_disk_size}}",
+
+    "NODE_MISC_REPOSITORY_DISK_PATH": "misc-repository",
+    "NODE_MISC_REPOSITORY_NIFI_DOCKER_VOLUME_NAME": "{{{node.misc_repository_portworx_volume_name}}}",
+    "NODE_MISC_REPOSITORY_NIFI_DOCKER_DRIVER_OPTIONS": "{{{node.misc_repository_portworx_volume_options}}}",
+    "NODE_MISC_REPOSITORY_DISK_SIZE": "{{node.misc_repository_disk_size}}",
+
+    "TASKCFG_ALL_NIFI_KILL_GRACE_PERIOD": "{{node.kill_grace_period}}",
+    "TASKCFG_ALL_NIFI_BOOTSTRAP_JVM_MIN": "{{node.nifi_bootstrap_jvm_min}}",
+    "TASKCFG_ALL_NIFI_BOOTSTRAP_JVM_MAX": "{{node.nifi_bootstrap_jvm_max}}",
+    "TASKCFG_ALL_NIFI_CN_DN_NODE_IDENTITY": "{{service.security.kerberos.cn_dn_node_identity}}",
+
+    "TASKCFG_ALL_NIFI_FRAMEWORK_USER": "{{service.user}}",
+    "TASKCFG_ALL_NIFI_METRICS_FREQUENCY": "{{service.metrics_frequency}}",
+
+    "NIFI_CLUSTER_NODE_PROTOCOL_PORT": "{{cluster.node_protocol_port}}",
+
+    "TASKCFG_ALL_NIFI_VERSION": "1.7.1",
+
+
+    "TASKCFG_ALL_NIFI_CORE_FLOW_CONFIGURATION_ARCHIVE_ENABLED": "{{core.flow_configuration_archive_enabled}}",
+    "TASKCFG_ALL_NIFI_CORE_FLOW_CONFIGURATION_ARCHIVE_MAX_TIME": "{{core.flow_configuration_archive_max_time}}",
+    "TASKCFG_ALL_NIFI_CORE_FLOW_CONFIGURATION_ARCHIVE_MAX_STORAGE": "{{core.flow_configuration_archive_max_storage}}",
+    "TASKCFG_ALL_NIFI_CORE_FLOW_CONFIGURATION_ARCHIVE_MAX_COUNT": "{{core.flow_configuration_archive_max_count}}",
+    "TASKCFG_ALL_NIFI_CORE_FLOWCONTROLLER_AUTORESUMESTATE": "true",
+    "TASKCFG_ALL_NIFI_CORE_FLOWCONTROLLER_GRACEFUL_SHUTDOWN_PERIOD": "{{core.flowcontroller_graceful_shutdown_period}}",
+    "TASKCFG_ALL_NIFI_CORE_FLOWSERVICE_WRITEDELAY_INTERVAL": "{{core.flowservice_writedelay_interval}}",
+    "TASKCFG_ALL_NIFI_CORE_BORED_YIELD_DURATION": "{{core.bored_yield_duration}}",
+    "TASKCFG_ALL_NIFI_CORE_QUEUE_BACKPRESSURE_COUNT": "{{core.queue_backpressure_count}}",
+    "TASKCFG_ALL_NIFI_CORE_QUEUE_BACKPRESSURE_SIZE": "{{core.queue_backpressure_size}}",
+    "TASKCFG_ALL_NIFI_CORE_UI_BANNER_TEXT": "{{core.ui_banner_text}}",
+    "TASKCFG_ALL_NIFI_CORE_UI_AUTOREFRESH_INTERVAL": "{{core.ui_autorefresh_interval}}",
+    "TASKCFG_ALL_NIFI_CORE_PROCESSOR_SCHEDULING_TIMEOUT": "{{core.processor_scheduling_timeout}}",
+
+    "TASKCFG_ALL_NIFI_DATABASE_REPOSITORY_DIRECTORY": "database-repository",
+
+    "TASKCFG_ALL_NIFI_FLOWFILE_REPOSITORY_DIRECTORY": "flowfile-repository",
+    "TASKCFG_ALL_NIFI_FLOWFILE_REPOSITORY_PARTITIONS": "{{flowfile.repository_partitions}}",
+    "TASKCFG_ALL_NIFI_FLOWFILE_REPOSITORY_CHECKPOINT_INTERVAL": "{{flowfile.repository_checkpoint_interval}}",
+    "TASKCFG_ALL_NIFI_FLOWFILE_REPOSITORY_ALWAYS_SYNC": "{{flowfile.repository_always_sync}}",
+
+    "TASKCFG_ALL_NIFI_QUEUE_SWAP_THRESHOLD": "{{swap.queue_swap_threshold}}",
+
+    "TASKCFG_ALL_NIFI_SWAP_IN_PERIOD": "{{swap.in_period}}",
+    "TASKCFG_ALL_NIFI_SWAP_IN_THREADS": "{{swap.in_threads}}",
+    "TASKCFG_ALL_NIFI_SWAP_OUT_PERIOD": "{{swap.out_period}}",
+    "TASKCFG_ALL_NIFI_SWAP_OUT_THREADS": "{{swap.out_threads}}",
+
+    "TASKCFG_ALL_NIFI_CONTENT_CLAIM_MAX_APPENDABLE_SIZE": "{{content.claim_max_appendable_size}}",
+    "TASKCFG_ALL_NIFI_CONTENT_CLAIM_MAX_FLOW_FILES": "{{content.claim_max_flow_files}}",
+    "TASKCFG_ALL_NIFI_CONTENT_REPOSITORY_DIRECTORY": "content-repository",
+    "TASKCFG_ALL_NIFI_CONTENT_REPOSITORY_ARCHIVE_MAX_RETENTION_PERIOD": "{{content.repository_archive_max_retention_period}}",
+    "TASKCFG_ALL_NIFI_CONTENT_REPOSITORY_ARCHIVE_MAX_USAGE_PERCENTAGE": "{{content.repository_archive_max_usage_percentage}}",
+    "TASKCFG_ALL_NIFI_CONTENT_REPOSITORY_ARCHIVE_ENABLED": "{{content.repository_archive_enabled}}",
+    "TASKCFG_ALL_NIFI_CONTENT_REPOSITORY_ALWAYS_SYNC": "{{content.repository_always_sync}}",
+    "TASKCFG_ALL_NIFI_CONTENT_VIEWER_URL": "{{content.viewer_url}}",
+
+    "TASKCFG_ALL_NIFI_VOLATILE_CONTENT_REPOSITORY_MAX_SIZE": "{{volatile.content_repository_max_size}}",
+    "TASKCFG_ALL_NIFI_VOLATILE_CONTENT_REPOSITORY_BLOCK_SIZE": "{{volatile.content_repository_block_size}}",
+
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_DIRECTORY": "provenance-repository",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_MAX_STORAGE_TIME": "{{provenance.repository_max_storage_time}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_MAX_STORAGE_SIZE": "{{provenance.repository_max_storage_size}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_ROLLOVER_TIME": "{{provenance.repository_rollover_time}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_ROLLOVER_SIZE": "{{provenance.repository_rollover_size}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_QUERY_THREADS": "{{provenance.repository_query_threads}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_INDEX_THREADS": "{{provenance.repository_index_threads}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_COMPRESS_ON_ROLLOVER": "{{provenance.repository_compress_on_rollover}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_ALWAYS_SYNC": "{{provenance.repository_always_sync}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_JOURNAL_COUNT": "{{provenance.repository_journal_count}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_INDEXED_FIELDS": "{{provenance.repository_indexed_fields}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_INDEXED_ATTRIBUTES": "{{provenance.repository_indexed_attributes}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_INDEX_SHARD_SIZE": "{{provenance.repository_index_shard_size}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_MAX_ATTRIBUTE_LENGTH": "{{provenance.repository_max_attribute_length}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_BUFFER_SIZE": "{{provenance.repository_buffer_size}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_CONCURRENT_MERGE_THREADS": "{{provenance.repository_concurrent_merge_threads}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_WARM_CACHE_FREQUENCY": "",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_DEBUG_FREQUENCY": "{{provenance.repository_debug_frequency}}",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_ENCRYPTION_KEY_PROVIDER_IMPLEMENTATION": "",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_ENCRYPTION_KEY_PROVIDER_LOCATION": "",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_ENCRYPTION_KEY_ID": "",
+    "TASKCFG_ALL_NIFI_PROVENANCE_REPOSITORY_ENCRYPTION_KEY": "",
+
+    "TASKCFG_ALL_NIFI_COMPONENTS_STATUS_REPOSITORY_BUFFER_SIZE": "{{components.status_repository_buffer_size}}",
+    "TASKCFG_ALL_NIFI_COMPONENTS_STATUS_SNAPSHOT_FREQUENCY": "{{components.status_snapshot_frequency}}",
+
+    "TASKCFG_ALL_NIFI_REMOTE_INPUT_SOCKET_PORT": "{{remote.input_socket_port}}",
+    "TASKCFG_ALL_NIFI_REMOTE_INPUT_HTTP_TRANSACTION_TTL": "{{remote.input_http_transaction_ttl}}",
+
+    "TASKCFG_ALL_NIFI_WEB_WAR_DIRECTORY": "./lib",
+    "TASKCFG_ALL_NIFI_WEB_HTTP_HOST": "",
+    "TASKCFG_ALL_NIFI_WEB_HTTP_NETWORK_INTERFACE_DEFAULT": "",
+    "TASKCFG_ALL_NIFI_WEB_HTTPS_HOST": "",
+    "TASKCFG_ALL_NIFI_WEB_HTTPS_NETWORK_INTERFACE_DEFAULT": "",
+    "TASKCFG_ALL_NIFI_WEB_JETTY_WORKING_DIRECTORY": "./work/jetty",
+    "TASKCFG_ALL_NIFI_WEB_JETTY_THREADS": "200",
+    "TASKCFG_ALL_NIFI_WEB_PROXY_HOST": "{{web.proxy_host}}",
+    "TASKCFG_ALL_NIFI_WEB_PROXY_CONTEXT_PATH": "{{web.proxy_context_path}}",
+
+    "TASKCFG_ALL_NIFI_SENSITIVE_PROPS_KEY": "{{Advanced_Security.sensitive_props_key}}",
+    "TASKCFG_ALL_NIFI_SENSITIVE_PROPS_KEY_PROTECTED": "{{Advanced_Security.sensitive_props_key_protected}}",
+    "TASKCFG_ALL_NIFI_SENSITIVE_PROPS_ALGORITHM": "{{Advanced_Security.sensitive_props_algorithm}}",
+    "TASKCFG_ALL_NIFI_SENSITIVE_PROPS_PROVIDER": "{{Advanced_Security.sensitive_props_provider}}",
+    "TASKCFG_ALL_NIFI_SENSITIVE_PROPS_ADDITIONAL_KEYS": "{{Advanced_Security.sensitive_props_additional_keys}}",
+
+
+    "TASKCFG_ALL_NIFI_SECURITY_NEEDCLIENTAUTH": "{{Advanced_Security.need_client_auth}}",
+    "TASKCFG_ALL_NIFI_SECURITY_USER_AUTHORIZER": "{{Advanced_Security.user_authorizer}}",
+    "TASKCFG_ALL_NIFI_SECURITY_USER_LOGIN_IDENTITY_PROVIDER": "{{Advanced_Security.user_login_identity_provider}}",
+    "TASKCFG_ALL_NIFI_SECURITY_OCSP_RESPONDER_URL": "{{Advanced_Security.ocsp_responder_url}}",
+    "TASKCFG_ALL_NIFI_SECURITY_OCSP_RESPONDER_CERTIFICATE": "{{Advanced_Security.ocsp_responder_certificate}}",
+
+    "TASKCFG_ALL_NIFI_CLUSTER_PROTOCOL_HEARTBEAT_INTERVAL": "{{cluster.protocol_heartbeat_interval}}",
+
+    {{#service.security.kerberos_tls.enable}}
+    "TASKCFG_ALL_NIFI_CLUSTER_PROTOCOL_IS_SECURE": "{{service.security.kerberos_tls.enable}}",
+    "TASKCFG_ALL_NIFI_REMOTE_INPUT_SECURE": "{{service.security.kerberos_tls.enable}}",
+    "TASKCFG_ALL_NIFI_REMOTE_INPUT_HTTP_ENABLED": "false",
+    {{/service.security.kerberos_tls.enable}}
+
+    {{^service.security.kerberos_tls.enable}}
+    "TASKCFG_ALL_NIFI_CLUSTER_PROTOCOL_IS_SECURE": "{{service.security.kerberos_tls.enable}}",
+    "TASKCFG_ALL_NIFI_REMOTE_INPUT_SECURE": "{{service.security.kerberos_tls.enable}}",
+    "TASKCFG_ALL_NIFI_REMOTE_INPUT_HTTP_ENABLED": "true",
+    {{/service.security.kerberos_tls.enable}}
+
+    "TASKCFG_ALL_NIFI_CLUSTER_IS_NODE": "{{cluster.is_node}}",
+    "TASKCFG_ALL_NIFI_CLUSTER_NODE_PROTOCOL_PORT": "{{cluster.node_protocol_port}}",
+    "TASKCFG_ALL_NIFI_CLUSTER_NODE_PROTOCOL_THREADS": "{{cluster.node_protocol_threads}}",
+    "TASKCFG_ALL_NIFI_CLUSTER_NODE_EVENT_HISTORY_SIZE": "{{cluster.node_event_history_size}}",
+    "TASKCFG_ALL_NIFI_CLUSTER_NODE_CONNECTION_TIMEOUT": "{{cluster.node_connection_timeout}}",
+    "TASKCFG_ALL_NIFI_CLUSTER_NODE_READ_TIMEOUT": "{{cluster.node_read_timeout}}",
+    "TASKCFG_ALL_NIFI_CLUSTER_FIREWALL_FILE": "{{cluster.firewall_file}}",
+    "TASKCFG_ALL_NIFI_CLUSTER_FLOW_ELECTION_MAX_WAIT_TIME": "{{cluster.flow_election_max_wait_time}}",
+    "TASKCFG_ALL_NIFI_CLUSTER_FLOW_ELECTION_MAX_CANDIDATES": "{{cluster.flow_election_max_candidates}}",
+
+    "TASKCFG_ALL_NIFI_ZOOKEEPER_CONNECT_STRING": "{{zookeeper.connect_string}}",
+    "TASKCFG_ALL_NIFI_ZOOKEEPER_CONNECT_TIMEOUT": "{{zookeeper.connect_timeout}}",
+    "TASKCFG_ALL_NIFI_ZOOKEEPER_SESSION_TIMEOUT": "{{zookeeper.session_timeout}}",
+
+    "SECURITY_KERBEROS_KEYTAB_SECRET": "{{service.security.kerberos.keytab_secret}}",
+    {{#service.security.kerberos_tls.enable}}
+    "TASKCFG_ALL_SECURITY_KERBEROS_ENABLED": "true",
+    {{/service.security.kerberos_tls.enable}}
+
+    {{^service.security.kerberos_tls.enable}}
+    "TASKCFG_ALL_SECURITY_KERBEROS_ENABLED": "false",
+    {{/service.security.kerberos_tls.enable}}
+
+
+    "TASKCFG_ALL_SECURITY_KERBEROS_PRIMARY": "{{service.security.kerberos.primary}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_REALM": "{{service.security.kerberos.realm}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_DEBUG": "{{service.security.kerberos.debug}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_KDC_HOSTNAME": "{{service.security.kerberos.kdc.hostname}}",
+    "TASKCFG_ALL_SECURITY_KERBEROS_KDC_PORT": "{{service.security.kerberos.kdc.port}}",
+
+    "TASKCFG_ALL_NIFI_KERBEROS_DEFAULT_REALM": "{{service.security.kerberos.realm}}",
+    "TASKCFG_ALL_NIFI_KERBEROS_AUTHENTICATION_EXPIRATION": "{{service.security.kerberos.authentication_expiration}}",
+    "TASKCFG_ALL_NIFI_KERBEROS_SERVICE_PRINCIPAL": "{{service.security.kerberos.service_principal}}",
+    "TASKCFG_ALL_NIFI_KERBEROS_USER_PRINCIPAL": "{{service.security.kerberos.user_principal}}",
+    "SECURITY_NIFI_KERBEROS_USER_PRINCIPAL_KEYTAB": "{{service.security.kerberos.user_principal_keytab}}",
+
+    "TASKCFG_ALL_NIFI_VARIABLE_REGISTRY_PROPERTIES": ""
+
+  },
+  "uris": [
+    "{{resource.assets.uris.jre-tar-gz}}",
+    "{{resource.assets.uris.scheduler-zip}}",
+    "{{resource.assets.uris.libmesos-bundle-tar-gz}}",
+    "{{resource.assets.uris.bootstrap-zip}}"
+  ],
+  "upgradeStrategy":{
+    "minimumHealthCapacity": 0,
+    "maximumOverCapacity": 0
+  },
+  "healthChecks": [
+    {
+      "protocol": "MESOS_HTTP",
+      "path": "/v1/health",
+      "gracePeriodSeconds": 900,
+      "intervalSeconds": 30,
+      "portIndex": 0,
+      "timeoutSeconds": 30,
+      "maxConsecutiveFailures": 0
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 0,
+      "protocol": "tcp",
+      "name": "api",
+      "labels": { "VIP_0": "/api.{{service.name}}:80" }
+    }
+  ]
+}

--- a/repo/packages/P/portworx-nifi/100/package.json
+++ b/repo/packages/P/portworx-nifi/100/package.json
@@ -1,0 +1,24 @@
+{
+  "packagingVersion": "4.0",
+  "upgradesFrom": [],
+  "downgradesTo": [],
+  "minDcosReleaseVersion": "1.9",
+  "name": "portworx-nifi",
+  "version": "1.3.1-0.3.0-1.7.1",
+  "maintainer": "support@portworx.com",
+  "description": "Apache NiFi backed by Portworx volumes",
+  "selected": false,
+  "framework": true,
+  "tags": [
+    "nifi"
+  ],
+  "preInstallNotes": "Default configuration requires 2 agent nodes each with: 1.1 CPU | 2048 MB MEM | 6 1000 MB Disk\nPortworx should be installed on the Private Agents to be able to provision volumes.",
+  "postInstallNotes": "DC/OS Apache NiFi is being installed!\n\n\tDocumentation: https://docs.mesosphere.com/services/nifi\n\tIssues: Issues: support@portworx.com",
+  "postUninstallNotes": "DC/OS Apache NiFi is being uninstalled.\nPlease follow the instructions at https://docs.portworx.com/scheduler/mesosphere-dcos/framework_cleanup.html to remove any persistent state if required.",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://github.com/apache/nifi/blob/master/LICENSE"
+    }
+  ]
+}

--- a/repo/packages/P/portworx-nifi/100/resource.json
+++ b/repo/packages/P/portworx-nifi/100/resource.json
@@ -1,0 +1,67 @@
+{
+  "assets": {
+    "uris": {
+      "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
+      "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
+      "bootstrap-zip": "https://s3-us-west-1.amazonaws.com/px-dcos/dcos-commons/artifacts/0.40.5-1.3.3/bootstrap.zip",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/nifi-scheduler.zip",
+      "executor-zip": "https://s3-us-west-1.amazonaws.com/px-dcos/dcos-commons/artifacts/0.40.5-1.3.3/executor.zip",
+      "nifi-tar-gz": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/nifi-1.7.1-bin.tar.gz",
+      "nifi-toolkit": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/nifi-toolkit-1.7.1-bin.tar.gz",
+      "nifi-janitor-jar": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/nifi-janitor.jar",
+      "nifi-statsd-jar": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/nifi-statsd.jar",
+      "nifi-api-access-jar": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/nifi-api-access.jar",
+      "nifi-python-tar-gz": "https://downloads.mesosphere.com/nifi/assets/python-2.7.14.tar.gz"
+    },
+    "container": {
+      "docker": {
+        "nifi": "mesostcs/nifi-base"
+      }
+    }
+  },
+  "images": {
+    "icon-small": "https://downloads.mesosphere.com/nifi/assets/nifi-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/nifi/assets/nifi-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/nifi/assets/nifi-icon-large.png"
+  },
+  "cli": {
+    "binaries": {
+      "darwin": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "9d479b913b4338d63e3937c069c5d87ce5d3e8698143f88d40d3b15867a1ae76"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/dcos-service-cli-darwin"
+        }
+      },
+      "linux": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "3bd270544af02d6248a757502de0875ce59090996c77cf664da5b0776cf747af"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/dcos-service-cli-linux"
+        }
+      },
+      "windows": {
+        "x86-64": {
+          "contentHash": [
+            {
+              "algo": "sha256",
+              "value": "e889ccce039eae521bf798a42b81540055b620eb13417f7ad0717f42740cd847"
+            }
+          ],
+          "kind": "executable",
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/dcos-service-cli.exe"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Description:
Source URL: https://px-dcos-dev.s3.amazonaws.com/autodelete7d/portworx-nifi/20200730-115851-AKnrtGgTkQLqipjO/stub-universe-portworx-nifi.json

Changes between revisions 0 => 100:
0 files added: []
0 files removed: []
3 files changed:

```
--- 0/marathon.json.mustache
+++ 100/marathon.json.mustache
@@ -23,9 +23,9 @@
   {{/service.service_account_secret}}
   "env": {
     "PACKAGE_NAME": "portworx-nifi",
-    "PACKAGE_VERSION": "1.3-0.3.0-1.7.1",
-    "PACKAGE_BUILD_TIME_EPOCH_MS": "1553292139715",
-    "PACKAGE_BUILD_TIME_STR": "Fri Mar 22 2019 22:02:19 +0000",
+    "PACKAGE_VERSION": "1.3.1-0.3.0-1.7.1",
+    "PACKAGE_BUILD_TIME_EPOCH_MS": "1596135532588",
+    "PACKAGE_BUILD_TIME_STR": "Thu Jul 30 2020 18:58:52 +0000",
     "FRAMEWORK_NAME": "{{service.name}}",
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
--- 0/package.json
+++ 100/package.json
@@ -4,7 +4,7 @@
   "downgradesTo": [],
   "minDcosReleaseVersion": "1.9",
   "name": "portworx-nifi",
-  "version": "1.3-0.3.0-1.7.1",
+  "version": "1.3.1-0.3.0-1.7.1",
   "maintainer": "support@portworx.com",
   "description": "Apache NiFi backed by Portworx volumes",
   "selected": false,
@@ -20,7 +20,5 @@
       "name": "Apache License Version 2.0",
       "url": "https://github.com/apache/nifi/blob/master/LICENSE"
     }
-  ],
-  "hasKnownIssues": true,
-  "lastUpdated": 1571120354
-}
+  ]
+}--- 0/resource.json
+++ 100/resource.json
@@ -4,14 +4,14 @@
       "jre-tar-gz": "https://downloads.mesosphere.com/java/server-jre-8u162-linux-x64.tar.gz",
       "libmesos-bundle-tar-gz": "https://downloads.mesosphere.com/libmesos-bundle/libmesos-bundle-master-28f8827.tar.gz",
       "bootstrap-zip": "https://s3-us-west-1.amazonaws.com/px-dcos/dcos-commons/artifacts/0.40.5-1.3.3/bootstrap.zip",
-      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3-0.3.0-1.7.1/nifi-scheduler.zip",
+      "scheduler-zip": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/nifi-scheduler.zip",
       "executor-zip": "https://s3-us-west-1.amazonaws.com/px-dcos/dcos-commons/artifacts/0.40.5-1.3.3/executor.zip",
-      "nifi-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-binary/nifi-1.7.1-bin.tar.gz",
-      "nifi-toolkit": "https://s3-ap-southeast-2.amazonaws.com/nifi-toolkit/nifi-toolkit-1.7.1-bin.tar.gz",
-      "nifi-janitor-jar": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3-0.3.0-1.7.1/nifi-janitor.jar",
-      "nifi-statsd-jar": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3-0.3.0-1.7.1/nifi-statsd.jar",
-      "nifi-api-access-jar": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3-0.3.0-1.7.1/nifi-api-access.jar",
-      "nifi-python-tar-gz": "https://s3-us-west-1.amazonaws.com/nifi-python/python-2.7.14.tar.gz"
+      "nifi-tar-gz": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/nifi-1.7.1-bin.tar.gz",
+      "nifi-toolkit": "https://downloads.mesosphere.com/nifi/assets/0.3.0-1.7.1/nifi-toolkit-1.7.1-bin.tar.gz",
+      "nifi-janitor-jar": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/nifi-janitor.jar",
+      "nifi-statsd-jar": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/nifi-statsd.jar",
+      "nifi-api-access-jar": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/nifi-api-access.jar",
+      "nifi-python-tar-gz": "https://downloads.mesosphere.com/nifi/assets/python-2.7.14.tar.gz"
     },
     "container": {
       "docker": {
@@ -20,9 +20,9 @@
     }
   },
   "images": {
-    "icon-small": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-small.png",
-    "icon-medium": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-medium.png",
-    "icon-large": "https://downloads.mesosphere.com/assets/universe/000/nifi-icon-large.png"
+    "icon-small": "https://downloads.mesosphere.com/nifi/assets/nifi-icon-small.png",
+    "icon-medium": "https://downloads.mesosphere.com/nifi/assets/nifi-icon-medium.png",
+    "icon-large": "https://downloads.mesosphere.com/nifi/assets/nifi-icon-large.png"
   },
   "cli": {
     "binaries": {
@@ -31,11 +31,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "0611d2142457ab2fbc2bba7ee9300efd0e97ed84e8acfb96926c7c89b24b130b"
+              "value": "9d479b913b4338d63e3937c069c5d87ce5d3e8698143f88d40d3b15867a1ae76"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3-0.3.0-1.7.1/dcos-service-cli-darwin"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/dcos-service-cli-darwin"
         }
       },
       "linux": {
@@ -43,11 +43,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "2e84cbeb4e10b33a685d5946516568d6e5fece406498ead1c62f15da987ff2b7"
+              "value": "3bd270544af02d6248a757502de0875ce59090996c77cf664da5b0776cf747af"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3-0.3.0-1.7.1/dcos-service-cli-linux"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/dcos-service-cli-linux"
         }
       },
       "windows": {
@@ -55,11 +55,11 @@
           "contentHash": [
             {
               "algo": "sha256",
-              "value": "75b78d8f6b543a0fc11a7e12df2121833e3731c669631b533423b8113ec88fa7"
+              "value": "e889ccce039eae521bf798a42b81540055b620eb13417f7ad0717f42740cd847"
             }
           ],
           "kind": "executable",
-          "url": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3-0.3.0-1.7.1/dcos-service-cli.exe"
+          "url": "https://px-dcos.s3.amazonaws.com/portworx-nifi/assets/1.3.1-0.3.0-1.7.1/dcos-service-cli.exe"
         }
       }
     }
```