### PR TITLE
Allowe dcos-monitoring to be upgradedfrom 1.3.1 to 1.4.0

### DIFF
--- a/repo/packages/D/dcos-monitoring/10400/package.json
+++ b/repo/packages/D/dcos-monitoring/10400/package.json
@@ -1,7 +1,8 @@
 {
   "packagingVersion": "4.0",
   "upgradesFrom": [
-    "v1.4.0"
+    "v1.4.0",
+    "v1.3.1"
   ],
   "downgradesTo": [
     "v1.4.0"


### PR DESCRIPTION
```json
{"type":"BadVersionUpdate","message":"The service of version v1.3.1 cannot update to the requested version v1.4.0","data":{"currentVersion":"v1.3.1","updateVersion":"v1.4.0","validVersions":["v1.3.1","v1.3.0"]}}
```

```
$ dcos monitoring update start  --package-version=v1.4.0 
dcos-service-cli: error: Unable to update monitoring to requested version: v1.4.0
Valid package versions are:
- v1.3.1
- v1.3.0, try --help
```