### PR TITLE
Set Certified to true for NiFi

### DIFF
--- a/repo/packages/N/nifi/100/package.json
+++ b/repo/packages/N/nifi/100/package.json
@@ -11,7 +11,7 @@
   "version": "0.1.0-1.5.0",
   "maintainer": "support@mesosphere.io",
   "description": "Apache NiFi",
-  "selected": false,
+  "selected": true,
   "framework": true,
   "tags": [
     "nifi"

--- a/repo/packages/N/nifi/200/package.json
+++ b/repo/packages/N/nifi/200/package.json
@@ -11,7 +11,7 @@
   "version": "0.2.0-1.5.0",
   "maintainer": "support@mesosphere.io",
   "description": "Apache NiFi",
-  "selected": false,
+  "selected": true,
   "framework": true,
   "tags": [
     "nifi"

--- a/repo/packages/N/nifi/300/package.json
+++ b/repo/packages/N/nifi/300/package.json
@@ -11,7 +11,7 @@
   "version": "0.3.0-1.7.1",
   "maintainer": "support@mesosphere.io",
   "description": "Apache NiFi",
-  "selected": false,
+  "selected": true,
   "framework": true,
   "tags": [
     "nifi"

--- a/repo/packages/N/nifi/400/package.json
+++ b/repo/packages/N/nifi/400/package.json
@@ -11,7 +11,7 @@
   "version": "0.4.0-1.8.0",
   "maintainer": "support@mesosphere.io",
   "description": "Apache NiFi",
-  "selected": false,
+  "selected": true,
   "framework": true,
   "tags": [
     "nifi"

--- a/repo/packages/N/nifi/500/package.json
+++ b/repo/packages/N/nifi/500/package.json
@@ -7,7 +7,7 @@
   "version": "0.4.1-1.8.0",
   "maintainer": "support@mesosphere.io",
   "description": "Apache NiFi",
-  "selected": false,
+  "selected": true,
   "framework": true,
   "tags": [
     "nifi"

--- a/repo/packages/N/nifi/600/package.json
+++ b/repo/packages/N/nifi/600/package.json
@@ -7,7 +7,7 @@
   "version": "0.5.0-1.9.2",
   "maintainer": "support@mesosphere.io",
   "description": "Apache NiFi",
-  "selected": false,
+  "selected": true,
   "framework": true,
   "tags": [
     "nifi"

--- a/repo/packages/N/nifi/800/package.json
+++ b/repo/packages/N/nifi/800/package.json
@@ -11,7 +11,7 @@
   "version": "1.0.1-1.9.2",
   "maintainer": "support@mesosphere.io",
   "description": "Apache NiFi",
-  "selected": false,
+  "selected": true,
   "framework": true,
   "tags": [
     "nifi"


### PR DESCRIPTION
NiFi hadn't set the `selected` setting to `true` and didn't show up under the Certified List of Packages by default.

This PR corrects previously released packages, and [this PR](https://github.com/mesosphere/dcos-nifi/pull/139) prevents this from happening for future releases.