### PR TITLE
certification: set confluent packages as certified

### DIFF
--- a/repo/packages/C/confluent-connect/300/package.json
+++ b/repo/packages/C/confluent-connect/300/package.json
@@ -10,6 +10,7 @@
   ],
   "scm": "https://github.com/confluentinc/cp-docker-images",
   "description": "Confluent Connect worker. Includes Replicator Connector.\n\n\tDocumentation: https://docs.confluent.io/5.3.0/connect/managing.html",
+  "selected": true,
   "maintainer": "partner-support@confluent.io",
   "tags": [
     "kafka",

--- a/repo/packages/C/confluent-control-center/200/package.json
+++ b/repo/packages/C/confluent-control-center/200/package.json
@@ -10,6 +10,7 @@
   ],
   "scm": "https://github.com/confluentinc/cp-docker-images",
   "description": "Confluent Control Center service\n\n\tDocumentation: https://docs.confluent.io/5.3.0/control-center/docs/userguide.html\n\tDC/OS Specifics: https://www.confluent.io/whitepaper/deploying-confluent-platform-with-mesosphere",
+  "selected": true,
   "maintainer": "partner-support@confluent.io",
   "tags": [
     "kafka",

--- a/repo/packages/C/confluent-control-center/200/package.json
+++ b/repo/packages/C/confluent-control-center/200/package.json
@@ -24,8 +24,8 @@
   "minDcosReleaseVersion": "1.11",
   "licenses": [
     {
-      "name": "Apache License v2",
-      "url": "https://raw.githubusercontent.com/confluentinc/control-center/master/LICENSE"
+      "name": "Confluent Enterprise License",
+      "url": "https://docs.confluent.io/current/installation/license.html#c3"
     }
   ],
   "lastUpdated": 1571120354

--- a/repo/packages/C/confluent-replicator/200/package.json
+++ b/repo/packages/C/confluent-replicator/200/package.json
@@ -10,6 +10,7 @@
   ],
   "scm": "https://github.com/confluentinc/cp-docker-images",
   "description": "Confluent Enterprise Replicator for multi-data center synchronization of topic data\n\n\tDocumentation: https://docs.confluent.io/5.3.0/connect/connect-replicator/docs/index.html",
+  "selected": true,
   "maintainer": "partner-support@confluent.io",
   "tags": [
     "kafka",

--- a/repo/packages/C/confluent-rest-proxy/300/package.json
+++ b/repo/packages/C/confluent-rest-proxy/300/package.json
@@ -10,6 +10,7 @@
   ],
   "scm": "https://github.com/confluentinc/kafka-rest",
   "description": "Confluent REST Proxy service\n\n\tDocumentation: https://docs.confluent.io/5.3.0/kafka-rest/docs/api.html",
+  "selected": true,
   "maintainer": "partner-support@confluent.io",
   "tags": [
     "kafka",

--- a/repo/packages/C/confluent-schema-registry/200/package.json
+++ b/repo/packages/C/confluent-schema-registry/200/package.json
@@ -10,6 +10,7 @@
   ],
   "scm": "https://github.com/confluentinc/schema-registry",
   "description": "Confluent Schema Registry service\n\n\tDocumentation: https://docs.confluent.io/5.3.0/schema-registry/docs/intro.html",
+  "selected": true,
   "maintainer": "partner-support@confluent.io",
   "tags": [
     "kafka",


### PR DESCRIPTION
Setting all the current confluent packages to `certified`. Future releases will have this permanently changed.