### PR TITLE
Deprecate Chronos

### DIFF
--- a/repo/packages/C/chronos/7/package.json
+++ b/repo/packages/C/chronos/7/package.json
@@ -27,8 +27,8 @@
     }
   ],
   "preInstallNotes": "The use of chronos has been DEPRECATED! If you still choose to use it, we recommend a minimum of one node with at least 1 CPU and 2GB of RAM available for the Chronos Service.",
-  "postInstallNotes": "Chronos DCOS Service has been successfully installed!\n\n\tDocumentation: http://mesos.github.io/chronos\n\tIssues: https://github.com/mesos/chronos/issues",
-  "postUninstallNotes": "The Chronos DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at https://docs.mesosphere.com/latest/deploying-services/uninstall/ to clean up any persisted state.",
+  "postInstallNotes": "[DEPRECATED] Chronos DCOS Service has been successfully installed!\n\n\tDocumentation: http://mesos.github.io/chronos\n\tIssues: https://github.com/mesos/chronos/issues",
+  "postUninstallNotes": "[DEPRECATED] The Chronos DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at https://docs.mesosphere.com/latest/deploying-services/uninstall/ to clean up any persisted state.",
   "selected": false,
   "lastUpdated": 1513356170
 }

--- a/repo/packages/C/chronos/7/package.json
+++ b/repo/packages/C/chronos/7/package.json
@@ -4,7 +4,7 @@
   "version": "2.5.1",
   "scm": "https://github.com/mesos/chronos.git",
   "maintainer": "support@mesosphere.io",
-  "description": "A fault tolerant job scheduler for Mesos which handles dependencies and ISO8601 based schedules. [DEPRECATED]",
+  "description": "[DEPRECATED] A fault tolerant job scheduler for Mesos which handles dependencies and ISO8601 based schedules.",
   "framework": true,
   "minDcosReleaseVersion": "1.9",
   "upgradesFrom": [
@@ -26,7 +26,7 @@
       "url": "https://github.com/mesos/chronos/blob/master/LICENSE"
     }
   ],
-  "preInstallNotes": "We recommend a minimum of one node with at least 1 CPU and 2GB of RAM available for the Chronos Service.",
+  "preInstallNotes": "The use of chronos has been DEPRECATED! If you still choose to use it, we recommend a minimum of one node with at least 1 CPU and 2GB of RAM available for the Chronos Service.",
   "postInstallNotes": "Chronos DCOS Service has been successfully installed!\n\n\tDocumentation: http://mesos.github.io/chronos\n\tIssues: https://github.com/mesos/chronos/issues",
   "postUninstallNotes": "The Chronos DCOS Service has been uninstalled and will no longer run.\nPlease follow the instructions at https://docs.mesosphere.com/latest/deploying-services/uninstall/ to clean up any persisted state.",
   "selected": false,

--- a/repo/packages/C/chronos/7/package.json
+++ b/repo/packages/C/chronos/7/package.json
@@ -4,7 +4,7 @@
   "version": "2.5.1",
   "scm": "https://github.com/mesos/chronos.git",
   "maintainer": "support@mesosphere.io",
-  "description": "A fault tolerant job scheduler for Mesos which handles dependencies and ISO8601 based schedules.",
+  "description": "A fault tolerant job scheduler for Mesos which handles dependencies and ISO8601 based schedules. [DEPRECATED]",
   "framework": true,
   "minDcosReleaseVersion": "1.9",
   "upgradesFrom": [

--- a/repo/packages/C/chronos/7/package.json
+++ b/repo/packages/C/chronos/7/package.json
@@ -4,7 +4,7 @@
   "version": "2.5.1",
   "scm": "https://github.com/mesos/chronos.git",
   "maintainer": "support@mesosphere.io",
-  "description": "[DEPRECATED] A fault tolerant job scheduler for Mesos which handles dependencies and ISO8601 based schedules.",
+  "description": "[DEPRECATED] A fault tolerant job scheduler for Mesos. With DC/OS 2.2.0 a new Jobs & Dependencies feature will be shipped.",
   "framework": true,
   "minDcosReleaseVersion": "1.9",
   "upgradesFrom": [


### PR DESCRIPTION
Starting to deprecated Chronos. Jobs with dependencies has been recently added to Marathon and DC/OS 2.2.

@kaiwalyajoshi @timcharper @pierrebeitz please review.

/cc @vinodkone 