### PR TITLE
add DCOS-UI 6.2.0

### DIFF
--- a/repo/packages/D/dcos-ui/8/package.json
+++ b/repo/packages/D/dcos-ui/8/package.json
@@ -1,0 +1,19 @@
+{
+  "packagingVersion": "4.0",
+  "name": "dcos-ui",
+  "version": "6.2.0",
+  "tags": ["dcos-ui", "dcos", "ui"],
+  "maintainer": "frontend-dev@mesosphere.io",
+  "description": "DC/OS UI",
+  "scm": "https://github.com/dcos/dcos-ui",
+  "website": "https://dcos.io/",
+  "framework": false,
+  "minDcosReleaseVersion": "1.13",
+  "licenses": [
+    {
+      "name": "Apache License Version 2.0",
+      "url": "https://raw.githubusercontent.com/dcos/dcos-ui/master/LICENSE"
+    }
+  ],
+  "lastUpdated": 1610643574
+}

--- a/repo/packages/D/dcos-ui/8/resource.json
+++ b/repo/packages/D/dcos-ui/8/resource.json
@@ -1,0 +1,7 @@
+{
+  "assets": {
+    "uris": {
+      "dcos-ui-bundle": "https://github.com/dcos/dcos-ui/releases/download/v6.2.0/release.tar.gz"
+    }
+  }
+}


### PR DESCRIPTION
ship a new version for customers that suffer of https://jira.d2iq.com/browse/COPS-6744.